### PR TITLE
release: v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## v0.9.0 - 2026-08-04
+#### Features
+- (**cli** / **diff**) global `--color auto|always|never` for top-level `--diff`, `sdiff`, and `git-diff`; shared ANSI styling for headers, hunks, additions, and removals (closes #6)
+- (**reflow**) `--clause-breaks` / `clause_breaks` config: prefer soft breaks after independent-clause punctuation (comma, semicolon, colon, em dash) under `max_width` (closes #7)
+#### Notes
+- Subcommand `--no-color` remains as an alias for `--color never`
+
+- - -
+
 ## v0.8.1 - 2026-07-20
 #### Bug Fixes
 - (**pre-commit**) ship a real `id: snapper` hook (`snapper --in-place`) with extension-based `files` matching; drop leftover SemBr `id`/`entry` and invalid identify type `org`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,9 +10,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -102,7 +102,7 @@ checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -205,9 +205,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.3"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fb99565819980999fb7b4a1796046a5c949e6d4ff132cf5fadf5a641e20d776"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -281,9 +281,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.6.2"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09628afdcc538b57f3c6341e9c8e9970f18e4a481690a64974d7023bd33548b"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -293,14 +293,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.3"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f2392eae7f16557a3d727ef3a12e57b2b2ca6f98566a5f4fb41ffe305df077"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -512,13 +512,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
+checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -559,9 +559,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
 
 [[package]]
 name = "enum-ordinalize"
@@ -794,9 +794,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "half"
@@ -1098,9 +1098,9 @@ dependencies = [
 
 [[package]]
 name = "kqueue"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+checksum = "8d763e5b24120b4ddf50de6c92308156765aabfbbccebf401da7cff2d70a41ea"
 dependencies = [
  "kqueue-sys",
  "libc",
@@ -1133,9 +1133,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.186"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libloading"
@@ -1149,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c943259e342f1e06ff2da7a83eabdfe7f92ce10262688dbf1895ff0b3e6e4652"
+checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
 dependencies = [
  "libc",
 ]
@@ -1505,9 +1505,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pest"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47627dd7305c6a2d6c8c6bcd24c5a4c17dbbf425f4f9c5313e724b38fc9782e9"
+checksum = "7df728be843c7070fab6ab7c328c4e9e9d78e23bf749c0669c86ee7ebfa050a2"
 dependencies = [
  "memchr",
  "ucd-trie",
@@ -1515,9 +1515,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b4254325ecad416ab689e27ba51da03ba01a9632bc6e108f5fe7c3c4ad29d58"
+checksum = "9e2dd6fc3b26b3462ee188aac870f5a41d398f1cd5e2408d16531bd71c9591fd"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1525,9 +1525,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c4c0e91ead7a8f7acecbca6f003fc2e8282b1dbe2dd9c9d2f16aba42995e0a7"
+checksum = "6a7a9205cfb6f596a9e8b689c0a15f9ceb7a1aafae7aaf788150ac65b29975b6"
 dependencies = [
  "pest",
  "pest_meta",
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.8.7"
+version = "2.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9744bc48116fee06334924bb5f2bad41eed5e89bd26e29b0b799f9a3f82c210"
+checksum = "85abd351c0de1e8384fc791a0737111a350394937e92b956b743dac12429f57c"
 dependencies = [
  "pest",
 ]
@@ -1876,7 +1876,7 @@ checksum = "2c9283685feec7d69af75fb0e858d5e7378f33fe4fc699383b2916ab9273e03c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1893,9 +1893,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2034,9 +2034,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+checksum = "687274d293b6cdc6e73e0fee520bf2049650090d7164f87672d212a3c530cf4a"
 dependencies = [
  "chrono",
  "dyn-clone",
@@ -2048,14 +2048,14 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+checksum = "d98c67716b46af2f0b8cf752abc930f6f9aecfbf671ecfb531db8a31dbe4e2ba"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2112,18 +2112,18 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "serde_derive_internals"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+checksum = "f852137cce035d6a4df67ccce505ff6b3e9fd3a10e3e52b24dc71e650bb1a9bd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2147,7 +2147,7 @@ checksum = "8d3b1629de253c70a0508c3899572da79ca359fdab27c7920ff00406df418906"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2202,7 +2202,7 @@ checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "snapper-fmt"
-version = "0.8.1"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2272,9 +2272,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.2"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a207d6d6a2b7fc470b80443726053f18a2481b7e1eee970597051596567987a3"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2364,7 +2364,7 @@ checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.2",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2415,24 +2415,25 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.7.1"
+version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6328af13490e73a9b4694030fafd93f8c8c6a9dede33e821c3fc63eddf8042ba"
+checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "494815d09bf52b5548659851081238f0ca39ff638363907596da739561c62c52"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "libc",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapper-fmt"
-version = "0.8.1"
+version = "0.9.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Semantic line break formatter for Org, LaTeX, Markdown, and plaintext"

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Configuration guide (org source in-tree): `docs/orgmode/howto/mcp-integration.or
 ## Pre-commit hook
 
     - repo: https://github.com/TurtleTech-ehf/snapper
-      rev: v0.8.1
+      rev: v0.9.0
       hooks:
         - id: snapper
 

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -3,7 +3,7 @@
 schema_version: 1
 
 context:
-  version: "0.8.1"
+  version: "0.9.0"
 
 package:
   name: snapper-fmt

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/TurtleTech-ehf/snapper/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: c2b4c8bb49445d449d75967f64c6e001718d1797b6a5357b2d839449961a7442
+  sha256: eadda94560e3877cb31c8a0e849591904efc98758cb1c0b4828b035d02335ed8
 
 build:
   number: 0

--- a/docs/orgmode/howto/ci-enforcement.org
+++ b/docs/orgmode/howto/ci-enforcement.org
@@ -10,7 +10,7 @@ The easiest way to enforce semantic line breaks in CI.
 Add to your workflow:
 
 #+begin_src yaml
-- uses: TurtleTech-ehf/snapper@v0.8.1
+- uses: TurtleTech-ehf/snapper@v0.9.0
   with:
     files: '**/*.org **/*.tex **/*.md'
 #+end_src
@@ -20,7 +20,7 @@ This installs snapper and runs =--check= on the specified files.
 For GitHub Code Scanning integration (SARIF annotations on PRs):
 
 #+begin_src yaml
-- uses: TurtleTech-ehf/snapper@v0.8.1
+- uses: TurtleTech-ehf/snapper@v0.9.0
   with:
     files: '**/*.org **/*.tex **/*.md'
     sarif: 'true'
@@ -35,7 +35,7 @@ Add to =.pre-commit-config.yaml=:
 
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.8.1
+  rev: v0.9.0
   hooks:
     - id: snapper
 #+end_src

--- a/docs/orgmode/tutorials/quickstart.org
+++ b/docs/orgmode/tutorials/quickstart.org
@@ -210,7 +210,7 @@ Add to your =.pre-commit-config.yaml=:
 
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.8.1
+  rev: v0.9.0
   hooks:
     - id: snapper
 #+end_src

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,7 @@ import os
 project = "snapper"
 copyright = '2026--present, <a href="https://rgoswami.me">Rohit Goswami</a>'
 author = "Rohit Goswami"
-release = "0.8.1"
+release = "0.9.0"
 html_logo = "../../branding/logo/snapper_logo.png"
 
 extensions = [

--- a/editors/obsidian/manifest.json
+++ b/editors/obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "snapper",
   "name": "Snapper - Semantic Line Breaks",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "minAppVersion": "1.0.0",
   "description": "Format prose with semantic line breaks for clean git diffs. Supports Org-mode, LaTeX, Markdown, and plaintext.",
   "author": "TurtleTech",

--- a/editors/obsidian/package-lock.json
+++ b/editors/obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-snapper",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-snapper",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@snapper/wasm": "file:../../packages/snapper-wasm",
@@ -17,7 +17,7 @@
     },
     "../../packages/snapper-wasm": {
       "name": "@snapper/wasm",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dev": true,
       "license": "MIT",
       "devDependencies": {

--- a/editors/obsidian/package.json
+++ b/editors/obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-snapper",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "description": "Obsidian plugin for snapper semantic line break formatter",
   "scripts": {

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,6 @@
 # snapper - Semantic Line Breaks
 
-Requires **snapper** CLI **0.8.1+** on your PATH (or set `snapper.path`). Install: `cargo install snapper-fmt` or the [release installer](https://github.com/TurtleTech-ehf/snapper/releases/tag/v0.8.0).
+Requires **snapper** CLI **0.9.0+** on your PATH (or set `snapper.path`). Install: `cargo install snapper-fmt` or the [release installer](https://github.com/TurtleTech-ehf/snapper/releases/tag/v0.8.0).
 
 
 Format prose so each sentence occupies its own line, producing clean git diffs for collaborative writing.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "snapper",
   "displayName": "snapper - Semantic Line Breaks",
   "description": "Format prose with semantic line breaks for clean git diffs",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "publisher": "TurtleTech",
   "license": "MIT",
   "repository": {

--- a/editors/word/README.md
+++ b/editors/word/README.md
@@ -2,7 +2,7 @@
 
 Office add-in that formats document prose with **semantic line breaks** (one sentence per line) using the **snapper WASM** build (`@snapper/wasm`). Useful when drafting in Word and exporting to Org, Markdown, or LaTeX for git-friendly diffs.
 
-**Version:** 0.8.1 (tracks snapper-fmt)
+**Version:** 0.9.0 (tracks snapper-fmt)
 
 Development preview; not published in AppSource.
 

--- a/editors/word/manifest.xml
+++ b/editors/word/manifest.xml
@@ -5,7 +5,7 @@
   xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
   xsi:type="TaskPaneApp">
   <Id>a8f3c2e1-9b4d-4e7a-8c5f-1d2e3f4a5b6c</Id>
-  <Version>0.8.1</Version>
+  <Version>0.9.0</Version>
   <ProviderName>TurtleTech ehf</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Snapper — Semantic Line Breaks"/>

--- a/editors/word/package-lock.json
+++ b/editors/word/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "word-snapper",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "word-snapper",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "@snapper/wasm": "file:../../packages/snapper-wasm",
@@ -21,7 +21,7 @@
     },
     "../../packages/snapper-wasm": {
       "name": "@snapper/wasm",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "dev": true,
       "license": "MIT",
       "devDependencies": {

--- a/editors/word/package.json
+++ b/editors/word/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-snapper",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "description": "Microsoft Word add-in for snapper semantic line break formatter",
   "scripts": {

--- a/editors/word/src/taskpane/taskpane.html
+++ b/editors/word/src/taskpane/taskpane.html
@@ -10,7 +10,7 @@
 <body>
   <div class="snapper-taskpane">
     <h2>Snapper</h2>
-    <p class="tagline">Semantic line breaks for Word (v0.8.1)</p>
+    <p class="tagline">Semantic line breaks for Word (v0.9.0)</p>
     <p class="hint">Formats paragraphs as plaintext. Use the CLI or VS Code for Org/LaTeX structure awareness.</p>
     <div class="actions">
       <button type="button" id="format-doc">Format Document</button>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turtletech/snapper-mcp",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "description": "MCP server for snapper semantic line break formatter",
   "main": "bin/run.js",

--- a/packages/snapper-wasm/package-lock.json
+++ b/packages/snapper-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snapper/wasm",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@snapper/wasm",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.4"

--- a/packages/snapper-wasm/package.json
+++ b/packages/snapper-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapper/wasm",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "WebAssembly build of snapper semantic line break formatter",
   "type": "module",
   "main": "dist/index.js",

--- a/readme_src.org
+++ b/readme_src.org
@@ -133,7 +133,7 @@ Configuration guide (org source in-tree): =docs/orgmode/howto/mcp-integration.or
 :END:
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.8.1
+  rev: v0.9.0
   hooks:
     - id: snapper
 #+end_src

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2,6 +2,8 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
 
+use crate::diff::ColorMode;
+
 #[derive(Debug, Clone, Copy, ValueEnum)]
 pub enum FormatArg {
     Org,
@@ -16,6 +18,28 @@ pub enum OutputFormat {
     Text,
     Json,
     Sarif,
+}
+
+/// Control when colored output is used (ruff-style).
+#[derive(Debug, Clone, Copy, ValueEnum, Default, PartialEq, Eq)]
+pub enum ColorWhen {
+    /// Display colors if the output goes to an interactive terminal.
+    #[default]
+    Auto,
+    /// Always display colors.
+    Always,
+    /// Never display colors.
+    Never,
+}
+
+impl From<ColorWhen> for ColorMode {
+    fn from(value: ColorWhen) -> Self {
+        match value {
+            ColorWhen::Auto => ColorMode::Auto,
+            ColorWhen::Always => ColorMode::Always,
+            ColorWhen::Never => ColorMode::Never,
+        }
+    }
 }
 
 #[derive(Debug, Parser)]
@@ -80,6 +104,15 @@ pub struct Cli {
     #[arg(long)]
     pub diff: bool,
 
+    /// Control when colored output is used.
+    ///
+    /// Possible values:
+    /// - auto:   Display colors if the output goes to an interactive terminal
+    /// - always: Always display colors
+    /// - never:  Never display colors
+    #[arg(long, value_enum, default_value_t = ColorWhen::Auto, global = true, value_name = "WHEN")]
+    pub color: ColorWhen,
+
     /// Path to config file (default: .snapperrc.toml in current or parent dirs).
     #[arg(long)]
     pub config: Option<PathBuf>,
@@ -118,7 +151,7 @@ pub enum Commands {
         /// Input format (auto-detected from extension if omitted).
         #[arg(short, long)]
         format: Option<FormatArg>,
-        /// Disable colored output.
+        /// Disable colored output (alias for `--color never`).
         #[arg(long)]
         no_color: bool,
     },
@@ -133,7 +166,7 @@ pub enum Commands {
         /// Input format (auto-detected from extension if omitted).
         #[arg(short, long)]
         format: Option<FormatArg>,
-        /// Disable colored output.
+        /// Disable colored output (alias for `--color never`).
         #[arg(long)]
         no_color: bool,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,11 @@ pub struct Cli {
     #[arg(short = 'w', long, default_value_t = 0)]
     pub max_width: usize,
 
+    /// Prefer soft breaks after independent-clause punctuation (comma,
+    /// semicolon, colon, em dash) when wrapping under `--max-width`.
+    #[arg(long, default_value_t = false)]
+    pub clause_breaks: bool,
+
     /// Use neural sentence detection (nnsplit LSTM model).
     #[arg(long)]
     pub neural: bool,

--- a/src/config.rs
+++ b/src/config.rs
@@ -45,6 +45,8 @@ pub struct ProjectConfig {
     pub default_format: Option<String>,
     /// Default max width.
     pub max_width: Option<usize>,
+    /// Prefer soft breaks after independent-clause punctuation when wrapping.
+    pub clause_breaks: Option<bool>,
     /// Default language for abbreviation sets.
     pub lang: Option<String>,
 
@@ -169,6 +171,7 @@ extra_abbreviations = ["Dept", "Univ", "Corp"]
 ignore = ["*.bib", "*.cls"]
 format = "org"
 max_width = 80
+clause_breaks = true
 lang = "de"
 "#;
         let config = ProjectConfig::parse(toml).unwrap();
@@ -176,6 +179,7 @@ lang = "de"
         assert_eq!(config.ignore_patterns, vec!["*.bib", "*.cls"]);
         assert_eq!(config.default_format, Some("org".to_string()));
         assert_eq!(config.max_width, Some(80));
+        assert_eq!(config.clause_breaks, Some(true));
         assert_eq!(config.lang, Some("de".to_string()));
     }
 

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -1,5 +1,70 @@
 use imara_diff::{Algorithm, BasicLineDiffPrinter, Diff, InternedInput, UnifiedDiffConfig};
 
+/// When colored unified-diff output should be emitted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ColorMode {
+    /// Color when stdout is an interactive terminal.
+    #[default]
+    Auto,
+    /// Always emit ANSI color codes.
+    Always,
+    /// Never emit ANSI color codes.
+    Never,
+}
+
+impl ColorMode {
+    /// Resolve whether to colorize given a TTY probe (or forced override).
+    pub fn should_colorize(self, is_tty: bool) -> bool {
+        match self {
+            ColorMode::Always => true,
+            ColorMode::Never => false,
+            ColorMode::Auto => is_tty,
+        }
+    }
+}
+
+/// Apply ANSI styling to a unified-diff body (headers, hunks, adds, removals).
+///
+/// Lines that already lack a leading `+`/`-`/`@`/`---`/`+++` marker are left
+/// unchanged. Empty input stays empty.
+pub fn colorize_unified_diff(diff: &str) -> String {
+    if diff.is_empty() {
+        return String::new();
+    }
+    let mut output = String::with_capacity(diff.len() + 32);
+    for line in diff.lines() {
+        if line.starts_with("--- ") || line.starts_with("+++ ") {
+            output.push_str("\x1b[1m");
+            output.push_str(line);
+            output.push_str("\x1b[0m\n");
+        } else if line.starts_with("@@") {
+            output.push_str("\x1b[36m");
+            output.push_str(line);
+            output.push_str("\x1b[0m\n");
+        } else if line.starts_with('+') {
+            output.push_str("\x1b[32m");
+            output.push_str(line);
+            output.push_str("\x1b[0m\n");
+        } else if line.starts_with('-') {
+            output.push_str("\x1b[31m");
+            output.push_str(line);
+            output.push_str("\x1b[0m\n");
+        } else {
+            output.push_str(line);
+            output.push('\n');
+        }
+    }
+    if diff.ends_with('\n') && !output.ends_with('\n') {
+        output.push('\n');
+    }
+    // Preserve trailing newline when present; unified diffs always end with \n
+    // after the loop above. If the input had no trailing newline, trim once.
+    if !diff.ends_with('\n') && output.ends_with('\n') {
+        output.pop();
+    }
+    output
+}
+
 /// Produce a unified diff between original and formatted text using
 /// imara-diff's histogram algorithm (same as git's default).
 ///
@@ -23,10 +88,17 @@ pub fn unified_diff(path: &str, original: &str, formatted: &str) -> String {
 }
 
 /// Print a unified diff to stdout. No-op if texts are identical.
-pub fn print_diff(path: &str, original: &str, formatted: &str) {
+///
+/// When `color` is true, headers / hunks / additions / removals are ANSI-styled.
+pub fn print_diff(path: &str, original: &str, formatted: &str, color: bool) {
     let diff = unified_diff(path, original, formatted);
-    if !diff.is_empty() {
-        print!("{}", diff);
+    if diff.is_empty() {
+        return;
+    }
+    if color {
+        print!("{}", colorize_unified_diff(&diff));
+    } else {
+        print!("{diff}");
     }
 }
 
@@ -66,5 +138,64 @@ mod tests {
     fn file_headers_present() {
         let diff = unified_diff("foo.org", "a\n", "b\n");
         assert!(diff.starts_with("--- a/foo.org\n+++ b/foo.org\n"));
+    }
+
+    #[test]
+    fn color_mode_resolution() {
+        assert!(ColorMode::Always.should_colorize(false));
+        assert!(ColorMode::Always.should_colorize(true));
+        assert!(!ColorMode::Never.should_colorize(false));
+        assert!(!ColorMode::Never.should_colorize(true));
+        assert!(!ColorMode::Auto.should_colorize(false));
+        assert!(ColorMode::Auto.should_colorize(true));
+    }
+
+    #[test]
+    fn colorize_adds_ansi_for_headers_hunks_and_changes() {
+        let plain = "--- a/t.md\n+++ b/t.md\n@@ -1 +1 @@\n-old line\n+new line\n context\n";
+        let colored = colorize_unified_diff(plain);
+        assert!(
+            colored.contains("\x1b[1m--- a/t.md\x1b[0m"),
+            "headers should be bold: {colored:?}"
+        );
+        assert!(
+            colored.contains("\x1b[1m+++ b/t.md\x1b[0m"),
+            "headers should be bold: {colored:?}"
+        );
+        assert!(
+            colored.contains("\x1b[36m@@ -1 +1 @@\x1b[0m"),
+            "hunk headers should be cyan: {colored:?}"
+        );
+        assert!(
+            colored.contains("\x1b[31m-old line\x1b[0m"),
+            "removals should be red: {colored:?}"
+        );
+        assert!(
+            colored.contains("\x1b[32m+new line\x1b[0m"),
+            "additions should be green: {colored:?}"
+        );
+        assert!(
+            colored.contains(" context\n"),
+            "context lines stay plain: {colored:?}"
+        );
+        assert!(
+            colored.contains("\x1b["),
+            "colored output must contain ANSI escapes"
+        );
+    }
+
+    #[test]
+    fn colorize_empty_is_empty() {
+        assert!(colorize_unified_diff("").is_empty());
+    }
+
+    #[test]
+    fn plain_unified_diff_has_no_ansi() {
+        let diff = unified_diff("foo.md", "a\n", "b\n");
+        assert!(
+            !diff.contains('\x1b'),
+            "raw unified_diff must not emit ANSI: {diff:?}"
+        );
+        assert!(!colorize_unified_diff(&diff).is_empty());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,10 @@ pub struct FormatConfig {
     /// after comment reflow. Default `false` preserves v0.7.7 behaviour
     /// (no subprocess is spawned).
     pub format_code: bool,
+    /// Prefer soft breaks after independent-clause punctuation when wrapping
+    /// under `max_width` (sembr rule 5). Default `false` keeps plain
+    /// `textwrap::fill` behaviour.
+    pub clause_breaks: bool,
 }
 
 impl Default for FormatConfig {
@@ -110,6 +114,7 @@ impl Default for FormatConfig {
             pandoc_backend: parser::pandoc::PandocBackend::default(),
             code: HashMap::new(),
             format_code: false,
+            clause_breaks: false,
         }
     }
 }
@@ -208,6 +213,7 @@ pub fn format_text_with_splitter(
         max_width: config.max_width,
         code: Some(&config.code),
         format_code: config.format_code,
+        clause_breaks: config.clause_breaks,
     };
 
     let mut output = reflow(&regions, splitter, &reflow_config);

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -50,6 +50,7 @@ impl SnapperLsp {
             format,
             max_width: project.max_width_for_format(format_str).unwrap_or(0),
             extra_abbreviations: project.abbreviations_for_format(format_str),
+            clause_breaks: project.clause_breaks.unwrap_or(false),
             ..Default::default()
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fs;
-use std::io::{self, Read};
+use std::io::{self, IsTerminal, Read};
 use std::path::Path;
 use std::process;
 use std::sync::Arc;
@@ -9,14 +9,26 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rayon::prelude::*;
 
-use snapper_fmt::cli::{Cli, Commands, OutputFormat, parse_range};
+use snapper_fmt::cli::{Cli, ColorWhen, Commands, OutputFormat, parse_range};
 use snapper_fmt::config::ProjectConfig;
+use snapper_fmt::diff::ColorMode;
 use snapper_fmt::format::Format;
 use snapper_fmt::output::{CheckResult, output_json, output_sarif};
 use snapper_fmt::sentence::SentenceSplitter;
 use snapper_fmt::{
     FormatConfig, build_splitter, format_range, format_text, format_text_with_splitter,
 };
+
+/// Resolve whether colored diff output should be used.
+///
+/// `no_color` (legacy subcommand flag) forces off; otherwise `--color` decides
+/// with auto = stdout is a TTY.
+fn resolve_color(when: ColorWhen, no_color: bool) -> bool {
+    if no_color {
+        return false;
+    }
+    ColorMode::from(when).should_colorize(io::stdout().is_terminal())
+}
 
 fn main() {
     if let Err(e) = run() {
@@ -39,7 +51,8 @@ fn run() -> Result<()> {
                 no_color,
             } => {
                 let fmt = format.map(Format::from_arg);
-                let result = snapper_fmt::sdiff::sentence_diff(old, new, fmt, !no_color)?;
+                let color = resolve_color(cli.color, *no_color);
+                let result = snapper_fmt::sdiff::sentence_diff(old, new, fmt, color)?;
                 if result.is_empty() {
                     eprintln!("No sentence-level differences.");
                 } else {
@@ -55,7 +68,8 @@ fn run() -> Result<()> {
                 no_color,
             } => {
                 let fmt = format.map(Format::from_arg);
-                let has_diff = snapper_fmt::git_diff::run_git_diff(git_ref, files, fmt, !no_color)?;
+                let color = resolve_color(cli.color, *no_color);
+                let has_diff = snapper_fmt::git_diff::run_git_diff(git_ref, files, fmt, color)?;
                 if has_diff {
                     process::exit(1);
                 }
@@ -115,7 +129,8 @@ fn run() -> Result<()> {
         };
 
         if cli.diff {
-            snapper_fmt::diff::print_diff("<stdin>", &input, &output);
+            let color = resolve_color(cli.color, false);
+            snapper_fmt::diff::print_diff("<stdin>", &input, &output, color);
         } else if let Some(ref path) = cli.output {
             fs::write(path, &output)
                 .with_context(|| format!("failed to write {}", path.display()))?;
@@ -167,10 +182,11 @@ fn run() -> Result<()> {
         let mut any_changed = false;
         let mut check_results: Vec<CheckResult> = Vec::new();
 
+        let color = resolve_color(cli.color, false);
         for (path_str, input, output) in &results {
             if cli.diff {
                 if output != input {
-                    snapper_fmt::diff::print_diff(path_str, input, output);
+                    snapper_fmt::diff::print_diff(path_str, input, output, color);
                     any_changed = true;
                 }
             } else if cli.check {
@@ -382,5 +398,15 @@ mod tests {
     fn both_zero_returns_zero() {
         assert_eq!(resolve_max_width(0, None, None), 0);
         assert_eq!(resolve_max_width(0, Some(0), None), 0);
+    }
+
+    #[test]
+    fn resolve_color_respects_never_and_no_color_flag() {
+        // no_color forces off regardless of ColorWhen
+        assert!(!resolve_color(ColorWhen::Always, true));
+        assert!(!resolve_color(ColorWhen::Auto, true));
+        assert!(!resolve_color(ColorWhen::Never, false));
+        // Always without no_color is always on (independent of TTY)
+        assert!(resolve_color(ColorWhen::Always, false));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -302,6 +302,9 @@ fn build_format_config(
         .or_else(|| project_config.lang.clone())
         .unwrap_or_else(|| "en".to_string());
 
+    // CLI --clause-breaks wins when set; otherwise project config (default false).
+    let clause_breaks = cli.clause_breaks || project_config.clause_breaks.unwrap_or(false);
+
     FormatConfig {
         format,
         max_width,
@@ -317,6 +320,7 @@ fn build_format_config(
             .unwrap_or(snapper_fmt::parser::pandoc::PandocBackend::Cli),
         code: project_config.code.clone(),
         format_code: cli.format_code,
+        clause_breaks,
         ..Default::default()
     }
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -13,6 +13,9 @@ pub struct ReflowConfig<'a> {
     pub code: Option<&'a HashMap<String, CodeLang>>,
     /// When `true`, the per-language `formatter` runs after comment reflow.
     pub format_code: bool,
+    /// Prefer soft breaks after independent-clause punctuation (`,`, `;`,
+    /// `:`, em dash, `--`) when wrapping under `max_width`.
+    pub clause_breaks: bool,
 }
 
 /// Minimum region count before parallelizing reflow (large multi-MB org/md files).
@@ -103,7 +106,11 @@ fn reflow_one(
             let sentences = splitter.split(text);
             for (i, sentence) in sentences.iter().enumerate() {
                 if config.max_width > 0 {
-                    let wrapped = textwrap::fill(sentence, config.max_width);
+                    let wrapped = if config.clause_breaks {
+                        wrap_with_clause_breaks(sentence, config.max_width)
+                    } else {
+                        textwrap::fill(sentence, config.max_width)
+                    };
                     output.push_str(&wrapped);
                 } else {
                     output.push_str(sentence);
@@ -126,6 +133,138 @@ fn reflow_one(
         }
     }
     output
+}
+
+/// True when `word` ends with independent-clause punctuation (sembr rule 5).
+fn ends_with_clause_punct(word: &str) -> bool {
+    word.ends_with(',')
+        || word.ends_with(';')
+        || word.ends_with(':')
+        || word.ends_with('\u{2014}') // em dash —
+        || word.ends_with("--")
+}
+
+/// Split a sentence into clause segments ending at `,` / `;` / `:` / em dash /
+/// `--`, keeping the punctuation with the preceding segment. Whitespace after
+/// the punctuation starts the next segment.
+fn split_clauses(sentence: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let chars: Vec<char> = sentence.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        let c = chars[i];
+        // ASCII double-hyphen em-dash surrogate
+        if c == '-' && i + 1 < chars.len() && chars[i + 1] == '-' {
+            current.push('-');
+            current.push('-');
+            i += 2;
+            // absorb trailing spaces into break (not into next segment)
+            while i < chars.len() && chars[i] == ' ' {
+                i += 1;
+            }
+            if !current.is_empty() {
+                segments.push(std::mem::take(&mut current));
+            }
+            continue;
+        }
+        current.push(c);
+        if matches!(c, ',' | ';' | ':' | '\u{2014}') {
+            i += 1;
+            while i < chars.len() && chars[i] == ' ' {
+                i += 1;
+            }
+            if !current.is_empty() {
+                segments.push(std::mem::take(&mut current));
+            }
+            continue;
+        }
+        i += 1;
+    }
+    if !current.is_empty() {
+        segments.push(current);
+    }
+    if segments.is_empty() && !sentence.is_empty() {
+        segments.push(sentence.to_string());
+    }
+    segments
+}
+
+/// Wrap `sentence` under `max_width`, preferring breaks after clause
+/// punctuation. Each clause is placed on its own line when it fits; clauses
+/// longer than `max_width` fall back to ordinary word wrapping.
+pub fn wrap_with_clause_breaks(sentence: &str, max_width: usize) -> String {
+    if max_width == 0 {
+        return sentence.to_string();
+    }
+    let clauses = split_clauses(sentence);
+    if clauses.is_empty() {
+        return String::new();
+    }
+    let mut lines: Vec<String> = Vec::new();
+    for clause in clauses {
+        let trimmed = clause.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        if trimmed.chars().count() <= max_width {
+            lines.push(trimmed.to_string());
+        } else {
+            // Long clause: pack words greedily, still preferring clause ends
+            // if any remain (usually none inside a single clause).
+            let wrapped = wrap_words_preferring_clause(trimmed, max_width);
+            for line in wrapped {
+                lines.push(line);
+            }
+        }
+    }
+    lines.join("\n")
+}
+
+/// Greedy word wrap that, when forced to break, prefers the last word that
+/// ends with clause punctuation; otherwise breaks at the last word boundary.
+fn wrap_words_preferring_clause(text: &str, max_width: usize) -> Vec<String> {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    if words.is_empty() {
+        return Vec::new();
+    }
+    let mut lines = Vec::new();
+    let mut start = 0;
+    while start < words.len() {
+        let mut end = start;
+        let mut line_len = 0usize;
+        while end < words.len() {
+            let wlen = words[end].chars().count();
+            let next_len = if end == start {
+                wlen
+            } else {
+                line_len + 1 + wlen
+            };
+            if next_len > max_width && end > start {
+                break;
+            }
+            line_len = next_len;
+            end += 1;
+            // Single overlong word: take it alone
+            if end == start + 1 && line_len > max_width {
+                break;
+            }
+        }
+        // Prefer last clause-punct word in [start, end)
+        let mut break_at = end;
+        for j in (start..end).rev() {
+            if ends_with_clause_punct(words[j]) && j + 1 > start {
+                break_at = j + 1;
+                break;
+            }
+        }
+        if break_at == start {
+            break_at = end;
+        }
+        lines.push(words[start..break_at].join(" "));
+        start = break_at;
+    }
+    lines
 }
 
 /// When the next region is an inline structure island (pandoc `Math`/`Code` as
@@ -207,5 +346,90 @@ mod tests {
                 line
             );
         }
+    }
+
+    #[test]
+    fn clause_breaks_prefer_commas_under_max_width() {
+        // Issue #7 sample: max_width=80 with clause breaks should land soft
+        // breaks after the independent-clause commas rather than packing
+        // mid-phrase as plain textwrap::fill does.
+        let sentence = "It contains rules which govern how the Objectives are orchestrated, along with rules which can automatically activate the Objectives in the plan, without additional human intervention.";
+        let wrapped = wrap_with_clause_breaks(sentence, 80);
+        let expected = "\
+It contains rules which govern how the Objectives are orchestrated,
+along with rules which can automatically activate the Objectives in the plan,
+without additional human intervention.";
+        assert_eq!(
+            wrapped, expected,
+            "clause-first wrap:\n--- got ---\n{wrapped}\n--- expected ---\n{expected}"
+        );
+        for line in wrapped.lines() {
+            assert!(
+                line.chars().count() <= 80,
+                "line exceeds max_width: {line:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn clause_breaks_off_matches_textwrap_fill() {
+        let sentence = "It contains rules which govern how the Objectives are orchestrated, along with rules which can automatically activate the Objectives in the plan, without additional human intervention.";
+        let regions = vec![Region::Prose(sentence.to_string())];
+        let config = ReflowConfig {
+            max_width: 80,
+            clause_breaks: false,
+            ..Default::default()
+        };
+        let result = reflow(&regions, &UnicodeSentenceSplitter::new(), &config);
+        let plain = format!("{}\n", textwrap::fill(sentence, 80));
+        assert_eq!(result, plain);
+        // And that plain fill is *not* the clause-first shape
+        assert!(
+            result.contains("orchestrated, along with\n"),
+            "control path still packs past the first comma: {result:?}"
+        );
+    }
+
+    #[test]
+    fn clause_breaks_via_reflow_config() {
+        let sentence = "It contains rules which govern how the Objectives are orchestrated, along with rules which can automatically activate the Objectives in the plan, without additional human intervention.";
+        let regions = vec![Region::Prose(sentence.to_string())];
+        let config = ReflowConfig {
+            max_width: 80,
+            clause_breaks: true,
+            ..Default::default()
+        };
+        let result = reflow(&regions, &UnicodeSentenceSplitter::new(), &config);
+        assert!(
+            result.contains("orchestrated,\nalong with"),
+            "reflow with clause_breaks must break after first comma: {result:?}"
+        );
+        assert!(
+            result.contains("plan,\nwithout"),
+            "reflow with clause_breaks must break after second comma: {result:?}"
+        );
+    }
+
+    #[test]
+    fn clause_breaks_handles_semicolon_colon_emdash() {
+        let s = "First clause; second clause: third clause — fourth clause.";
+        let wrapped = wrap_with_clause_breaks(s, 80);
+        assert_eq!(
+            wrapped,
+            "First clause;\nsecond clause:\nthird clause —\nfourth clause."
+        );
+    }
+
+    #[test]
+    fn long_clause_still_word_wraps() {
+        let long = "This is a deliberately long independent clause without internal punctuation that must still wrap under a tight max width constraint for the test.";
+        let wrapped = wrap_with_clause_breaks(long, 40);
+        for line in wrapped.lines() {
+            assert!(
+                line.chars().count() <= 40,
+                "overlong clause must still wrap: {line:?}"
+            );
+        }
+        assert!(wrapped.contains('\n'));
     }
 }

--- a/src/sdiff.rs
+++ b/src/sdiff.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 use anyhow::{Context, Result};
 use imara_diff::{Algorithm, BasicLineDiffPrinter, Diff, InternedInput, UnifiedDiffConfig};
 
+use crate::diff::colorize_unified_diff;
 use crate::format::Format;
 use crate::parser::Region;
 use crate::sentence::SentenceSplitter;
@@ -88,35 +89,21 @@ pub fn sentence_diff(
         return Ok(String::new());
     }
 
-    let mut output = String::new();
     let old_name = old_path.display();
     let new_name = new_path.display();
-
-    if color {
-        output.push_str(&format!("\x1b[1m--- a/{old_name}\x1b[0m\n"));
-        output.push_str(&format!("\x1b[1m+++ b/{new_name}\x1b[0m\n"));
-        for line in diff_text.lines() {
-            if line.starts_with("@@") {
-                output.push_str(&format!("\x1b[36m{line}\x1b[0m\n"));
-            } else if line.starts_with('+') {
-                output.push_str(&format!("\x1b[32m{line}\x1b[0m\n"));
-            } else if line.starts_with('-') {
-                output.push_str(&format!("\x1b[31m{line}\x1b[0m\n"));
-            } else {
-                output.push_str(line);
-                output.push('\n');
-            }
-        }
-    } else {
-        output.push_str(&format!("--- a/{old_name}\n"));
-        output.push_str(&format!("+++ b/{new_name}\n"));
-        output.push_str(&diff_text);
-        if !diff_text.ends_with('\n') {
-            output.push('\n');
-        }
+    let mut plain = String::new();
+    plain.push_str(&format!("--- a/{old_name}\n"));
+    plain.push_str(&format!("+++ b/{new_name}\n"));
+    plain.push_str(&diff_text);
+    if !diff_text.ends_with('\n') {
+        plain.push('\n');
     }
 
-    Ok(output)
+    if color {
+        Ok(colorize_unified_diff(&plain))
+    } else {
+        Ok(plain)
+    }
 }
 
 #[cfg(test)]
@@ -156,6 +143,28 @@ mod tests {
         std::fs::write(&tmp2, "Hello world.\nThis is a test.\nAnother sentence.\n").unwrap();
         let result = sentence_diff(&tmp1, &tmp2, Some(Format::Plaintext), false).unwrap();
         assert!(result.is_empty(), "reflow should not produce a diff");
+        std::fs::remove_file(&tmp1).ok();
+        std::fs::remove_file(&tmp2).ok();
+    }
+
+    #[test]
+    fn colored_sentence_diff_contains_ansi() {
+        let tmp1 = std::env::temp_dir().join("sdiff_color_a.txt");
+        let tmp2 = std::env::temp_dir().join("sdiff_color_b.txt");
+        std::fs::write(&tmp1, "Hello world. This is old. Goodbye.\n").unwrap();
+        std::fs::write(&tmp2, "Hello world. This is new. Goodbye.\n").unwrap();
+        let colored = sentence_diff(&tmp1, &tmp2, Some(Format::Plaintext), true).unwrap();
+        let plain = sentence_diff(&tmp1, &tmp2, Some(Format::Plaintext), false).unwrap();
+        assert!(
+            colored.contains("\x1b["),
+            "color=true must emit ANSI: {colored:?}"
+        );
+        assert!(
+            !plain.contains("\x1b["),
+            "color=false must not emit ANSI: {plain:?}"
+        );
+        assert!(colored.contains("\x1b[31m-This is old.\x1b[0m"));
+        assert!(colored.contains("\x1b[32m+This is new.\x1b[0m"));
         std::fs::remove_file(&tmp1).ok();
         std::fs::remove_file(&tmp2).ok();
     }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -473,6 +473,10 @@ impl DelimState {
 /// (unbalanced input like a lone `{`). Any earlier `\n` while `is_inside()`
 /// is rejected.
 ///
+/// Inline code / links / emphasis are stripped via [`protect_inline_tokens`]
+/// first so brackets inside `` `[` `` do not count as real spans (same as the
+/// production splitter path).
+///
 /// Implementation feeds whole lines (not per-char) so apostrophe heuristics
 /// see real `prev`/`next` neighbors; fails when a prior line left a span open.
 pub fn newlines_respect_delimiter_spans(formatted: &str) -> bool {
@@ -480,8 +484,9 @@ pub fn newlines_respect_delimiter_spans(formatted: &str) -> bool {
     if trimmed_end.is_empty() {
         return true;
     }
+    let (protected, _) = protect_inline_tokens(trimmed_end);
     let mut state = DelimState::default();
-    for line in trimmed_end.split('\n') {
+    for line in protected.split('\n') {
         if state.is_inside() {
             return false;
         }
@@ -795,6 +800,10 @@ mod tests {
             "See [note. One] more. Trailing.\n",
             "He said ``Hello world. How?'' Then.\n",
             "Don't stop. It's ok. Done.\n",
+            // Brackets inside inline code are opaque (protect_inline_tokens);
+            // outer `[…].` closes before the period, so a following sentence
+            // break is allowed.
+            "[`[`].A\"\"]\"}\"''\n",
         ];
         let cfg = FormatConfig {
             format: Format::Plaintext,

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -136,6 +136,7 @@ fn format_file_in_place(
             .clone()
             .unwrap_or_else(|| "en".to_string()),
         extra_abbreviations: project_config.abbreviations_for_format(format_key),
+        clause_breaks: project_config.clause_breaks.unwrap_or(false),
         ..Default::default()
     };
 

--- a/tests/sentence_delim_props.rs
+++ b/tests/sentence_delim_props.rs
@@ -173,10 +173,14 @@ fn code_block_comment_respects_quotes() {
 }
 
 /// True when `DelimState` ends outside all spans (balanced delimiters).
+///
+/// Matches production: protect inline code/links first so brackets inside
+/// `` `[` `` do not count as real nesting.
 fn delimiters_balanced(text: &str) -> bool {
-    use snapper_fmt::sentence::unicode::DelimState;
+    use snapper_fmt::sentence::unicode::{DelimState, protect_inline_tokens};
+    let (protected, _) = protect_inline_tokens(text);
     let mut state = DelimState::default();
-    state.feed(text);
+    state.feed(&protected);
     !state.is_inside()
 }
 


### PR DESCRIPTION
## Summary

Release **v0.9.0**: colored unified diffs and preferential clause breaks under `max_width`.

### Features
- **#6** — global `--color auto|always|never` for top-level `--diff`, `sdiff`, and `git-diff` (`f04336e`)
- **#7** — `--clause-breaks` / `clause_breaks` config for independent-clause soft breaks (`6c3c5c2`)

### Release prep
- Version pins: Cargo, Cargo.lock, editors, npm/wasm, docs, README pre-commit rev, conda mirror
- CHANGELOG entry for v0.9.0

### After merge
1. Tag `v0.9.0` on main (triggers cargo-dist Release workflow)
2. Confirm GitHub Release assets
3. Refresh conda-forge staged-recipes / feedstock sha if needed
4. Close #6 and #7 (done in parallel with this PR)

## Test plan
- [x] Unit tests for color resolution / ANSI and clause-break wrap (rg.terra)
- [x] CLI smoke: `--help` shows both flags; `--color always|never`; `-w 80 --clause-breaks` sample
- [ ] CI green on this PR