### PR TITLE
fix(reflow): lossless clause breaks under max_width, plus
  release guardrails

### DIFF
--- a/.github/workflows/ci_prek.yml
+++ b/.github/workflows/ci_prek.yml
@@ -22,6 +22,16 @@ jobs:
       - uses: actions/checkout@v4
       - run: bash scripts/check_public_contract.sh
 
+  release-ready:
+    name: Release readiness gate
+    if: github.event_name == 'pull_request' && startsWith(github.head_ref, 'release/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - run: bash scripts/check_release_ready.sh
+
   lychee:
     name: Link check
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file. See [conven
 - (**reflow**) `--clause-breaks` / `clause_breaks` config: prefer soft breaks after independent-clause punctuation (comma, semicolon, colon, em dash) under `max_width` (closes #7)
 #### Notes
 - Subcommand `--no-color` remains as an alias for `--color never`
+- `--color auto` honors the `NO_COLOR` environment variable
+- Clause breaks only apply to sentences that exceed `max_width`, and only at whitespace after the punctuation; tokens such as `1,000`, `10:30`, URLs, and `--flags` never split
 
 - - -
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,110 @@
+# Releasing snapper
+
+A release fans out across several channels. Some fire automatically from the
+tag, some are manual. Every release must either complete **all** channels or
+**none**; the recovery rules below exist so a half-published version never
+lingers.
+
+## Channel inventory
+
+| Channel | Trigger | Workflow / step |
+|---|---|---|
+| GitHub Release (binaries, shell/powershell installers) | tag `v*` push | `Release` (cargo-dist) |
+| Homebrew tap `TurtleTech-ehf/homebrew-tap` | tag `v*` push | `Release` publish-homebrew-formula job |
+| PyPI `snapper-fmt` (sdist + wheels) | tag `v*` push | `Python wheels` publish job (trusted publishing) |
+| Docs site (Cloudflare Pages) | push to `main` or tag | `Build and Deploy` |
+| conda recipe mirror (`conda/recipe.yaml`) | manual, **after** the tag exists | see "After the tag" |
+| VS Code extension (`TurtleTech.snapper`) | manual marketplace publish | `editors/vscode` |
+| Obsidian plugin / Word add-in | not published (development preview) | built by `WASM` workflow only |
+| npm wrapper (`npm/`) | not published (`"private": true`) | none |
+
+crates.io is **not** a channel; nothing publishes there.
+
+## Before the tag
+
+1. Branch `release/vX.Y.Z` off `main`. Bump the version everywhere it is
+   pinned; `scripts/check_release_ready.sh` enumerates every file and fails on
+   any mismatch:
+
+   ```sh
+   scripts/check_release_ready.sh
+   ```
+
+   Leave `conda/recipe.yaml`'s `sha256` untouched — it can only be computed
+   after the tag exists (see below). Never write a sha by hand.
+2. Add the `## vX.Y.Z` CHANGELOG section.
+3. Run the full CI matrix locally-equivalent suite:
+
+   ```sh
+   cargo test --features "cli,neural,lsp,watch,pandoc,mcp,wasm"
+   cargo test --no-default-features --lib
+   ```
+
+4. Open the release PR, wait for **all** checks (CI, Pre-checks, WASM,
+   Python wheels, Build and Deploy) to pass, then merge.
+
+## The tag
+
+Tag only the merge commit on `main`, only after every merge-triggered
+workflow on `main` is green:
+
+```sh
+git switch main && git pull
+scripts/check_release_ready.sh   # must pass on the exact commit being tagged
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+Never tag a release branch head, and never push the tag while `main` CI is
+still running: the tag is consumed immediately by three workflows and cannot
+be rebuilt in place.
+
+## After the tag
+
+Watch **all three** tag-triggered workflows to completion; a release is not
+done while any of them is running or red:
+
+```sh
+gh run list --branch vX.Y.Z
+```
+
+Then verify each channel:
+
+```sh
+gh release view vX.Y.Z                                  # assets + installers
+curl -s https://pypi.org/pypi/snapper-fmt/json | jq -r .info.version
+gh api repos/TurtleTech-ehf/homebrew-tap/commits --jq '.[0].commit.message'
+```
+
+Refresh the conda recipe from the real tarball and verify:
+
+```sh
+curl -fsSL -o /tmp/snapper.tar.gz \
+  https://github.com/TurtleTech-ehf/snapper/archive/refs/tags/vX.Y.Z.tar.gz
+sha256sum /tmp/snapper.tar.gz     # paste into conda/recipe.yaml
+scripts/check_release_ready.sh --post-tag
+```
+
+Commit that as `chore(conda): refresh source sha256 for vX.Y.Z archive` on
+`main`, then update the conda-forge feedstock with the same sha. Finally
+publish the VS Code extension from `editors/vscode` at the same version.
+
+## When something fails mid-release
+
+The decision rule is: **has any channel published?**
+
+- **No channel published yet** (workflows failed or were cancelled before
+  their publish steps): cancel the remaining tag runs, delete the tag
+  (`git push origin :refs/tags/vX.Y.Z`), fix on a branch, merge, and re-tag
+  the same version. A tag no consumer has seen may be recreated; a consumed
+  one may not.
+- **Any channel published** (a GitHub Release exists, PyPI has the version,
+  or the tap formula moved): the version number is burned. Do not delete or
+  move the tag. Fix forward, bump to `vX.Y.(Z+1)`, and run the full release
+  again so every channel converges on the new version. PyPI in particular
+  can never re-accept a version, which is how a partial release becomes
+  permanent skew.
+
+Never re-run a publish job against a moved tag, and never leave a release
+with some channels on the new version and others on the old one overnight —
+either finish it or roll forward.

--- a/scripts/check_release_ready.sh
+++ b/scripts/check_release_ready.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# Gate a release before tagging: every channel-pinned version must match
+# Cargo.toml, the CHANGELOG must carry the version, and the tag must not
+# exist yet. With --post-tag, additionally verify that conda/recipe.yaml
+# carries the sha256 of the real published tag tarball.
+#
+# Usage:
+#   scripts/check_release_ready.sh             # pre-tag gate
+#   scripts/check_release_ready.sh --post-tag  # after the tag is pushed
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+mode="pre"
+if [[ "${1:-}" == "--post-tag" ]]; then
+  mode="post"
+fi
+
+version="$(sed -n '/^\[package\]$/,/^\[/s/^version = "\([^"]*\)"/\1/p' "$repo_root/Cargo.toml" | head -n 1)"
+if [[ -z "$version" ]]; then
+  printf 'could not read version from Cargo.toml\n' >&2
+  exit 1
+fi
+printf 'checking release readiness for v%s\n' "$version"
+
+failed=0
+fail() {
+  printf 'NOT READY: %s\n' "$1" >&2
+  failed=1
+}
+
+expect() {
+  local pattern="$1" file="$2"
+  if ! grep -Fq "$pattern" "$repo_root/$file"; then
+    fail "$file is missing '$pattern'"
+  fi
+}
+
+# Cargo.lock carries the workspace crate at the release version.
+if ! grep -A1 '^name = "snapper-fmt"$' "$repo_root/Cargo.lock" \
+    | grep -Fq "version = \"$version\""; then
+  fail "Cargo.lock snapper-fmt entry is not $version"
+fi
+
+# JSON manifests across the wasm package and editor integrations.
+json_versioned=(
+  npm/package.json
+  packages/snapper-wasm/package.json
+  packages/snapper-wasm/package-lock.json
+  editors/obsidian/package.json
+  editors/obsidian/package-lock.json
+  editors/obsidian/manifest.json
+  editors/word/package.json
+  editors/word/package-lock.json
+  editors/vscode/package.json
+)
+for file in "${json_versioned[@]}"; do
+  expect "\"version\": \"$version\"" "$file"
+done
+
+# Word add-in ships the version in three more places.
+expect "$version" editors/word/manifest.xml
+expect "$version" editors/word/src/taskpane/taskpane.html
+expect "$version" editors/word/README.md
+expect "$version" editors/vscode/README.md
+
+# Conda recipe mirror and docs.
+expect "version: \"$version\"" conda/recipe.yaml
+expect "release = \"$version\"" docs/source/conf.py
+
+# pre-commit / GitHub Action rev pins in user-facing docs.
+rev_pinned=(
+  README.md
+  readme_src.org
+  docs/orgmode/tutorials/quickstart.org
+  docs/orgmode/howto/ci-enforcement.org
+)
+for file in "${rev_pinned[@]}"; do
+  expect "rev: v$version" "$file"
+done
+expect "TurtleTech-ehf/snapper@v$version" docs/orgmode/howto/ci-enforcement.org
+
+# CHANGELOG must document this release.
+expect "## v$version" CHANGELOG.md
+
+# The public availability contract must hold too.
+bash "$repo_root/scripts/check_public_contract.sh" || fail "check_public_contract.sh failed"
+
+if [[ "$mode" == "pre" ]]; then
+  if [[ -n "$(git -C "$repo_root" tag -l "v$version")" ]]; then
+    fail "local tag v$version already exists; a consumed tag must never move"
+  fi
+  if git -C "$repo_root" ls-remote --tags origin "refs/tags/v$version" | grep -q .; then
+    fail "remote tag v$version already exists; bump the version instead"
+  fi
+  if [[ -n "$(git -C "$repo_root" status --porcelain)" ]]; then
+    fail "working tree is dirty"
+  fi
+else
+  # Post-tag: the conda recipe sha256 must be computed from the real
+  # tarball, never written by hand.
+  url="https://github.com/TurtleTech-ehf/snapper/archive/refs/tags/v$version.tar.gz"
+  tarball="$(mktemp)"
+  trap 'rm -f "$tarball"' EXIT
+  if ! curl -fsSL --retry 3 -o "$tarball" "$url"; then
+    fail "could not download $url (tag not pushed yet?)"
+  else
+    actual="$(sha256sum "$tarball" | cut -d' ' -f1)"
+    if ! grep -Fq "sha256: $actual" "$repo_root/conda/recipe.yaml"; then
+      fail "conda/recipe.yaml sha256 does not match the v$version tarball ($actual)"
+    fi
+  fi
+fi
+
+if [[ "$failed" -eq 0 ]]; then
+  printf 'release checks passed for v%s (%s-tag)\n' "$version" "$mode"
+fi
+exit "$failed"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,7 +113,7 @@ pub struct Cli {
     ///
     /// Possible values:
     /// - auto:   Display colors if the output goes to an interactive terminal
-    ///           and the `NO_COLOR` environment variable is unset
+    ///   and the `NO_COLOR` environment variable is unset
     /// - always: Always display colors
     /// - never:  Never display colors
     #[arg(long, value_enum, default_value_t = ColorWhen::Auto, global = true, value_name = "WHEN")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,6 +113,7 @@ pub struct Cli {
     ///
     /// Possible values:
     /// - auto:   Display colors if the output goes to an interactive terminal
+    ///           and the `NO_COLOR` environment variable is unset
     /// - always: Always display colors
     /// - never:  Never display colors
     #[arg(long, value_enum, default_value_t = ColorWhen::Auto, global = true, value_name = "WHEN")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,12 +22,18 @@ use snapper_fmt::{
 /// Resolve whether colored diff output should be used.
 ///
 /// `no_color` (legacy subcommand flag) forces off; otherwise `--color` decides
-/// with auto = stdout is a TTY.
+/// with auto = stdout is a TTY and `NO_COLOR` unset.
 fn resolve_color(when: ColorWhen, no_color: bool) -> bool {
     if no_color {
         return false;
     }
-    ColorMode::from(when).should_colorize(io::stdout().is_terminal())
+    let mode = ColorMode::from(when);
+    // `auto` honors the NO_COLOR convention (https://no-color.org): any
+    // non-empty value disables color; explicit `always` still wins.
+    if mode == ColorMode::Auto && std::env::var_os("NO_COLOR").is_some_and(|v| !v.is_empty()) {
+        return false;
+    }
+    mode.should_colorize(io::stdout().is_terminal())
 }
 
 fn main() {

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -135,94 +135,33 @@ fn reflow_one(
     output
 }
 
-/// True when `word` ends with independent-clause punctuation (sembr rule 5).
+/// True when `word` ends with independent-clause punctuation (sembr rule 5),
+/// ignoring trailing closing quotes and brackets. Words come from whitespace
+/// splitting, so a match always marks a lossless break site: the punctuation
+/// is followed by real whitespace in the source.
 fn ends_with_clause_punct(word: &str) -> bool {
-    word.ends_with(',')
-        || word.ends_with(';')
-        || word.ends_with(':')
-        || word.ends_with('\u{2014}') // em dash —
-        || word.ends_with("--")
-}
-
-/// Split a sentence into clause segments ending at `,` / `;` / `:` / em dash /
-/// `--`, keeping the punctuation with the preceding segment. Whitespace after
-/// the punctuation starts the next segment.
-fn split_clauses(sentence: &str) -> Vec<String> {
-    let mut segments = Vec::new();
-    let mut current = String::new();
-    let chars: Vec<char> = sentence.chars().collect();
-    let mut i = 0;
-    while i < chars.len() {
-        let c = chars[i];
-        // ASCII double-hyphen em-dash surrogate
-        if c == '-' && i + 1 < chars.len() && chars[i + 1] == '-' {
-            current.push('-');
-            current.push('-');
-            i += 2;
-            // absorb trailing spaces into break (not into next segment)
-            while i < chars.len() && chars[i] == ' ' {
-                i += 1;
-            }
-            if !current.is_empty() {
-                segments.push(std::mem::take(&mut current));
-            }
-            continue;
-        }
-        current.push(c);
-        if matches!(c, ',' | ';' | ':' | '\u{2014}') {
-            i += 1;
-            while i < chars.len() && chars[i] == ' ' {
-                i += 1;
-            }
-            if !current.is_empty() {
-                segments.push(std::mem::take(&mut current));
-            }
-            continue;
-        }
-        i += 1;
-    }
-    if !current.is_empty() {
-        segments.push(current);
-    }
-    if segments.is_empty() && !sentence.is_empty() {
-        segments.push(sentence.to_string());
-    }
-    segments
+    let core = word.trim_end_matches(['"', '\'', ')', ']', '}']);
+    core.ends_with(',')
+        || core.ends_with(';')
+        || core.ends_with(':')
+        || core.ends_with('\u{2014}') // em dash —
+        || core.ends_with("--")
 }
 
 /// Wrap `sentence` under `max_width`, preferring breaks after clause
-/// punctuation. Each clause is placed on its own line when it fits; clauses
-/// longer than `max_width` fall back to ordinary word wrapping.
+/// punctuation (sembr rule 5). A sentence that already fits stays on one
+/// line. Breaks only ever land at whitespace, so tokens like `1,000`,
+/// `10:30`, URLs, and `--flags` are never split apart.
 pub fn wrap_with_clause_breaks(sentence: &str, max_width: usize) -> String {
     if max_width == 0 {
         return sentence.to_string();
     }
-    let clauses = split_clauses(sentence);
-    if clauses.is_empty() {
-        return String::new();
-    }
-    let mut lines: Vec<String> = Vec::new();
-    for clause in clauses {
-        let trimmed = clause.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if trimmed.chars().count() <= max_width {
-            lines.push(trimmed.to_string());
-        } else {
-            // Long clause: pack words greedily, still preferring clause ends
-            // if any remain (usually none inside a single clause).
-            let wrapped = wrap_words_preferring_clause(trimmed, max_width);
-            for line in wrapped {
-                lines.push(line);
-            }
-        }
-    }
-    lines.join("\n")
+    wrap_words_preferring_clause(sentence, max_width).join("\n")
 }
 
-/// Greedy word wrap that, when forced to break, prefers the last word that
-/// ends with clause punctuation; otherwise breaks at the last word boundary.
+/// Greedy word wrap that, when forced to break, prefers the last word on the
+/// line that ends with clause punctuation; otherwise breaks at the last word
+/// boundary that fits.
 fn wrap_words_preferring_clause(text: &str, max_width: usize) -> Vec<String> {
     let words: Vec<&str> = text.split_whitespace().collect();
     if words.is_empty() {
@@ -250,16 +189,16 @@ fn wrap_words_preferring_clause(text: &str, max_width: usize) -> Vec<String> {
                 break;
             }
         }
-        // Prefer last clause-punct word in [start, end)
+        // Only a forced break gets pulled back to a clause boundary; the
+        // final line of a sentence keeps its remaining words together.
         let mut break_at = end;
-        for j in (start..end).rev() {
-            if ends_with_clause_punct(words[j]) && j + 1 > start {
-                break_at = j + 1;
-                break;
+        if end < words.len() {
+            for j in (start..end).rev() {
+                if ends_with_clause_punct(words[j]) {
+                    break_at = j + 1;
+                    break;
+                }
             }
-        }
-        if break_at == start {
-            break_at = end;
         }
         lines.push(words[start..break_at].join(" "));
         start = break_at;
@@ -413,11 +352,72 @@ without additional human intervention.";
     #[test]
     fn clause_breaks_handles_semicolon_colon_emdash() {
         let s = "First clause; second clause: third clause — fourth clause.";
-        let wrapped = wrap_with_clause_breaks(s, 80);
+        // Fits under the limit: no break is forced, the sentence stays whole.
+        assert_eq!(wrap_with_clause_breaks(s, 80), s);
+        // Forced under a tight limit: every break lands after clause punctuation.
         assert_eq!(
-            wrapped,
+            wrap_with_clause_breaks(s, 20),
             "First clause;\nsecond clause:\nthird clause —\nfourth clause."
         );
+    }
+
+    #[test]
+    fn clause_breaks_leave_fitting_sentences_alone() {
+        let regions = vec![Region::Prose(
+            "Hello, world. Short, sweet, and done.".to_string(),
+        )];
+        let config = ReflowConfig {
+            max_width: 80,
+            clause_breaks: true,
+            ..Default::default()
+        };
+        let result = reflow(&regions, &UnicodeSentenceSplitter::new(), &config);
+        assert_eq!(result, "Hello, world.\nShort, sweet, and done.\n");
+    }
+
+    #[test]
+    fn clause_breaks_never_split_inside_tokens() {
+        // Clause punctuation not followed by whitespace stays inside its
+        // token; a break there would render as an inserted space.
+        let s = "Totals reached 1,000,000 by 10:30 via https://example.com/a,b using --clause-breaks and rock—paper logic in a sentence long enough to need wrapping.";
+        let wrapped = wrap_with_clause_breaks(s, 30);
+        let rejoined: Vec<&str> = wrapped.split_whitespace().collect();
+        let original: Vec<&str> = s.split_whitespace().collect();
+        assert_eq!(rejoined, original, "wrapping must be lossless: {wrapped:?}");
+        for token in [
+            "1,000,000",
+            "10:30",
+            "https://example.com/a,b",
+            "--clause-breaks",
+            "rock—paper",
+        ] {
+            assert!(
+                wrapped.lines().any(|l| l.contains(token)),
+                "{token:?} must stay on a single line: {wrapped:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn clause_breaks_idempotent() {
+        let sentence = "It contains rules which govern how the Objectives are orchestrated, along with rules which can automatically activate the Objectives in the plan, without additional human intervention.";
+        let config = ReflowConfig {
+            max_width: 80,
+            clause_breaks: true,
+            ..Default::default()
+        };
+        let splitter = UnicodeSentenceSplitter::new();
+        let first = reflow(
+            &[Region::Prose(sentence.to_string())],
+            &splitter,
+            &config,
+        );
+        let second = reflow(
+            &[Region::Prose(first.trim_end().to_string())],
+            &splitter,
+            &config,
+        );
+        assert_eq!(first, second, "clause-break reflow must be idempotent");
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -407,11 +407,7 @@ without additional human intervention.";
             ..Default::default()
         };
         let splitter = UnicodeSentenceSplitter::new();
-        let first = reflow(
-            &[Region::Prose(sentence.to_string())],
-            &splitter,
-            &config,
-        );
+        let first = reflow(&[Region::Prose(sentence.to_string())], &splitter, &config);
         let second = reflow(
             &[Region::Prose(first.trim_end().to_string())],
             &splitter,

--- a/src/sentence/neural.rs
+++ b/src/sentence/neural.rs
@@ -1,7 +1,14 @@
+use std::sync::Mutex;
+
 use nnsplit::NNSplit;
 
 use super::SentenceSplitter;
 use super::unicode::{UnicodeSentenceSplitter, protect_inline_tokens, restore_inline_tokens};
+
+/// nnsplit downloads models to `~/.cache/nnsplit/` on first use; concurrent
+/// loads race the download and can observe a partially written model
+/// ("model proto does not contain a graph"). Serialize loads process-wide.
+static MODEL_LOAD_LOCK: Mutex<()> = Mutex::new(());
 
 /// Sentence splitter using nnsplit's neural network (byte-level LSTM via tract).
 /// Models download and cache to ~/.cache/nnsplit/ on first use.
@@ -26,7 +33,10 @@ impl NeuralSentenceSplitter {
         extras: &[String],
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let options = nnsplit::NNSplitOptions::default();
-        let inner = NNSplit::load(language, options)?;
+        let inner = {
+            let _guard = MODEL_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            NNSplit::load(language, options)?
+        };
         Ok(Self {
             inner,
             post: UnicodeSentenceSplitter::for_lang(language, extras),
@@ -45,7 +55,10 @@ impl NeuralSentenceSplitter {
         extras: &[String],
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let options = nnsplit::NNSplitOptions::default();
-        let inner = NNSplit::new(path, options)?;
+        let inner = {
+            let _guard = MODEL_LOAD_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+            NNSplit::new(path, options)?
+        };
         Ok(Self {
             inner,
             post: UnicodeSentenceSplitter::for_lang(language, extras),


### PR DESCRIPTION
`--clause-breaks` (#7) split at every clause mark regardless of width or following whitespace.
Two consequences:

- Sentences already under `max_width` were shattered onto one line per clause: "Hello, world." became two lines.
- Punctuation inside tokens triggered breaks: `1,000`, `10:30`, `https://example.com`, `--flags`, `word—word` all split mid-token.
A newline renders as a space, so this rewrote content, not just line geometry.

Wrapping is now word-based: clause punctuation is a preferred break site only when a sentence overflows `max_width`, and only after whitespace-delimited words, so every break replaces real whitespace and rejoining the lines reproduces the original token stream.
The #7 sample still produces the exact expected shape.
New tests cover fitting sentences, token integrity (lossless round-trip), semicolon/colon/em-dash preference, and idempotency.

`--color auto` (#6) now honors `NO_COLOR`, matching the ruff behavior the issue referenced; explicit `--color always` still forces color.

Release process, after the first v0.9.0 tag had to be cancelled and deleted (hand-written conda sha256, tag cut before the release PR merged):

- `RELEASING.md`: channel inventory (GitHub Release + Homebrew tap + PyPI + docs deploy fire on the tag; conda mirror and VS Code marketplace are manual; Obsidian/Word/npm are unpublished previews), the tag protocol, per-channel verification commands, and the partial-failure rule: nothing published means delete the tag, fix, re-cut; anything published means the version is burned, roll forward.
- `scripts/check_release_ready.sh`: pre-tag gate for version parity across every pinned file (Cargo, lockfiles, editors, conda recipe, docs, pre-commit revs), the CHANGELOG entry, and tag absence; `--post-tag` verifies the conda sha256 against the real tag tarball.
Pre-checks runs it on `release/*` PRs.

v0.9.0 gets re-tagged from main once this lands.
