### PR TITLE
release: v0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 
+## v0.9.1 - 2026-08-04
+#### Bug Fixes
+- (**reflow**) clause breaks only engage when a sentence exceeds `max_width` and only at whitespace after the punctuation; v0.9.0 split at every clause mark, including inside tokens (`1,000`, `10:30`, URLs, `--flags`, unspaced em dashes), which inserted spaces into rendered output
+- (**cli**) `--color auto` honors the `NO_COLOR` environment variable
+- (**neural**) nnsplit model loads are serialized process-wide; concurrent first-use construction could read a partially downloaded model
+#### Notes
+- v0.9.1 supersedes v0.9.0 on every channel; do not use v0.9.0 with `--clause-breaks`
+- `RELEASING.md` documents the release channels and recovery rules; `scripts/check_release_ready.sh` gates version parity, tag hygiene, and the conda sha256
+
+- - -
+
 ## v0.9.0 - 2026-08-04
 #### Features
 - (**cli** / **diff**) global `--color auto|always|never` for top-level `--diff`, `sdiff`, and `git-diff`; shared ANSI styling for headers, hunks, additions, and removals (closes #6)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,7 +2202,7 @@ checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "snapper-fmt"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapper-fmt"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2024"
 rust-version = "1.85"
 description = "Semantic line break formatter for Org, LaTeX, Markdown, and plaintext"

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Configuration guide (org source in-tree): `docs/orgmode/howto/mcp-integration.or
 ## Pre-commit hook
 
     - repo: https://github.com/TurtleTech-ehf/snapper
-      rev: v0.9.0
+      rev: v0.9.1
       hooks:
         - id: snapper
 

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -3,7 +3,7 @@
 schema_version: 1
 
 context:
-  version: "0.9.0"
+  version: "0.9.1"
 
 package:
   name: snapper-fmt

--- a/docs/orgmode/howto/ci-enforcement.org
+++ b/docs/orgmode/howto/ci-enforcement.org
@@ -10,7 +10,7 @@ The easiest way to enforce semantic line breaks in CI.
 Add to your workflow:
 
 #+begin_src yaml
-- uses: TurtleTech-ehf/snapper@v0.9.0
+- uses: TurtleTech-ehf/snapper@v0.9.1
   with:
     files: '**/*.org **/*.tex **/*.md'
 #+end_src
@@ -20,7 +20,7 @@ This installs snapper and runs =--check= on the specified files.
 For GitHub Code Scanning integration (SARIF annotations on PRs):
 
 #+begin_src yaml
-- uses: TurtleTech-ehf/snapper@v0.9.0
+- uses: TurtleTech-ehf/snapper@v0.9.1
   with:
     files: '**/*.org **/*.tex **/*.md'
     sarif: 'true'
@@ -35,7 +35,7 @@ Add to =.pre-commit-config.yaml=:
 
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.9.0
+  rev: v0.9.1
   hooks:
     - id: snapper
 #+end_src

--- a/docs/orgmode/tutorials/quickstart.org
+++ b/docs/orgmode/tutorials/quickstart.org
@@ -210,7 +210,7 @@ Add to your =.pre-commit-config.yaml=:
 
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.9.0
+  rev: v0.9.1
   hooks:
     - id: snapper
 #+end_src

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,7 @@ import os
 project = "snapper"
 copyright = '2026--present, <a href="https://rgoswami.me">Rohit Goswami</a>'
 author = "Rohit Goswami"
-release = "0.9.0"
+release = "0.9.1"
 html_logo = "../../branding/logo/snapper_logo.png"
 
 extensions = [

--- a/editors/obsidian/manifest.json
+++ b/editors/obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "snapper",
   "name": "Snapper - Semantic Line Breaks",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "minAppVersion": "1.0.0",
   "description": "Format prose with semantic line breaks for clean git diffs. Supports Org-mode, LaTeX, Markdown, and plaintext.",
   "author": "TurtleTech",

--- a/editors/obsidian/package-lock.json
+++ b/editors/obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-snapper",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-snapper",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@snapper/wasm": "file:../../packages/snapper-wasm",
@@ -17,7 +17,7 @@
     },
     "../../packages/snapper-wasm": {
       "name": "@snapper/wasm",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dev": true,
       "license": "MIT",
       "devDependencies": {

--- a/editors/obsidian/package.json
+++ b/editors/obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-snapper",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Obsidian plugin for snapper semantic line break formatter",
   "scripts": {

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,6 @@
 # snapper - Semantic Line Breaks
 
-Requires **snapper** CLI **0.9.0+** on your PATH (or set `snapper.path`). Install: `cargo install snapper-fmt` or the [release installer](https://github.com/TurtleTech-ehf/snapper/releases/tag/v0.8.0).
+Requires **snapper** CLI **0.9.1+** on your PATH (or set `snapper.path`). Install: `cargo install snapper-fmt` or the [release installer](https://github.com/TurtleTech-ehf/snapper/releases/tag/v0.8.0).
 
 
 Format prose so each sentence occupies its own line, producing clean git diffs for collaborative writing.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "snapper",
   "displayName": "snapper - Semantic Line Breaks",
   "description": "Format prose with semantic line breaks for clean git diffs",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "publisher": "TurtleTech",
   "license": "MIT",
   "repository": {

--- a/editors/word/README.md
+++ b/editors/word/README.md
@@ -2,7 +2,7 @@
 
 Office add-in that formats document prose with **semantic line breaks** (one sentence per line) using the **snapper WASM** build (`@snapper/wasm`). Useful when drafting in Word and exporting to Org, Markdown, or LaTeX for git-friendly diffs.
 
-**Version:** 0.9.0 (tracks snapper-fmt)
+**Version:** 0.9.1 (tracks snapper-fmt)
 
 Development preview; not published in AppSource.
 

--- a/editors/word/manifest.xml
+++ b/editors/word/manifest.xml
@@ -5,7 +5,7 @@
   xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
   xsi:type="TaskPaneApp">
   <Id>a8f3c2e1-9b4d-4e7a-8c5f-1d2e3f4a5b6c</Id>
-  <Version>0.9.0</Version>
+  <Version>0.9.1</Version>
   <ProviderName>TurtleTech ehf</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Snapper — Semantic Line Breaks"/>

--- a/editors/word/package-lock.json
+++ b/editors/word/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "word-snapper",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "word-snapper",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "@snapper/wasm": "file:../../packages/snapper-wasm",
@@ -21,7 +21,7 @@
     },
     "../../packages/snapper-wasm": {
       "name": "@snapper/wasm",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "dev": true,
       "license": "MIT",
       "devDependencies": {
@@ -638,7 +638,7 @@
         "tinyglobby": "^0.2.12"
       },
       "engines": {
-        "node": ">= 20.9.0"
+        "node": ">= 20.9.1"
       },
       "funding": {
         "type": "opencollective",

--- a/editors/word/package.json
+++ b/editors/word/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-snapper",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "Microsoft Word add-in for snapper semantic line break formatter",
   "scripts": {

--- a/editors/word/src/taskpane/taskpane.html
+++ b/editors/word/src/taskpane/taskpane.html
@@ -10,7 +10,7 @@
 <body>
   <div class="snapper-taskpane">
     <h2>Snapper</h2>
-    <p class="tagline">Semantic line breaks for Word (v0.9.0)</p>
+    <p class="tagline">Semantic line breaks for Word (v0.9.1)</p>
     <p class="hint">Formats paragraphs as plaintext. Use the CLI or VS Code for Org/LaTeX structure awareness.</p>
     <div class="actions">
       <button type="button" id="format-doc">Format Document</button>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turtletech/snapper-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": true,
   "description": "MCP server for snapper semantic line break formatter",
   "main": "bin/run.js",

--- a/packages/snapper-wasm/package-lock.json
+++ b/packages/snapper-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snapper/wasm",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@snapper/wasm",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.4"

--- a/packages/snapper-wasm/package.json
+++ b/packages/snapper-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapper/wasm",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "WebAssembly build of snapper semantic line break formatter",
   "type": "module",
   "main": "dist/index.js",

--- a/readme_src.org
+++ b/readme_src.org
@@ -133,7 +133,7 @@ Configuration guide (org source in-tree): =docs/orgmode/howto/mcp-integration.or
 :END:
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.9.0
+  rev: v0.9.1
   hooks:
     - id: snapper
 #+end_src


### PR DESCRIPTION
Roll-forward release. v0.9.0 published to GitHub Releases, PyPI, and the Homebrew tap
with the broken clause-break splitter (#9 has the analysis: mid-token splits render as
inserted spaces), and PyPI versions are immutable, so the version is burned per
RELEASING.md: fix forward, converge every channel on v0.9.1.

Carries only version pins and the CHANGELOG section; the code fixes landed in #9.
The `release/*` readiness gate runs on this PR.

After merge: tag `v0.9.1` on the merge commit, then the post-tag steps from RELEASING.md
(conda sha256 from the real tarball, channel verification, VS Code publish).
