### PR TITLE
fix: org verbatim pairing and block-comment closer inside a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. See [conven
 - - -
 ## Unreleased (main)
 
+#### Bug Fixes
+- (**org** / **sentence**) verbatim and inline-code spans pair to the first closer that satisfies Org's border and post rules, so an `=` or `~` inside the span no longer orphans the real closer onto the next line
+- (**markdown** / **sentence**) inline code delimited by two or more backticks can contain a shorter backtick run
+- (**code-block**) a block-comment closer inside a string no longer ends the comment; quote-sequence closers (`"""`) still match naively so Python docstrings reflow
+
 - - -
 
 ## v0.9.1 - 2026-08-04

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ pip:
 
     pip install snapper-fmt
 
+conda-forge:
+
+    conda install -c conda-forge snapper-fmt
+
 Compile from source:
 
     cargo install snapper-fmt
@@ -96,7 +100,8 @@ Nix:
 The crate is `snapper-fmt` on all registries.
 Each install ships two CLI names for the same program: `snapper` and `snapper-fmt`.
 
-**Name collision:** [openSUSE snapper](https://github.com/openSUSE/snapper) is a different project (Btrfs/LVM snapshots) that also installs a `snapper` binary. On systems where that tool already owns `/usr/bin/snapper`, call this formatter as `snapper-fmt`, or put the TurtleTech install path ahead of the system path.
+**Name collision:** [openSUSE snapper](https://github.com/openSUSE/snapper) is a different project (Btrfs/LVM snapshots) that also installs a `snapper` binary.
+On systems where that tool already owns `/usr/bin/snapper`, call this formatter as `snapper-fmt`, or put the TurtleTech install path ahead of the system path.
 
 
 <a id="usage"></a>

--- a/docs/orgmode/faq/index.org
+++ b/docs/orgmode/faq/index.org
@@ -36,7 +36,8 @@ For fully transparent integration, use a git smudge/clean filter (see the how-to
 
 Snapper maintains curated abbreviation lists for English (80+), German, French, Icelandic, and Polish.
 After Unicode sentence boundary detection, it merges any splits that occurred at known abbreviation periods.
-Select a language with =--lang de= (or set =lang = "de"= in =.snapperrc.toml=). You can also add project-specific abbreviations via =extra_abbreviations= in the config file.
+Select a language with =--lang de= (or set =lang = "de"= in =.snapperrc.toml=).
+You can also add project-specific abbreviations via =extra_abbreviations= in the config file.
 
 * What about non-English text?
 :PROPERTIES:
@@ -61,7 +62,9 @@ Use neural for languages where abbreviation rules fall short (Chinese, Turkish, 
 :CUSTOM_ID: name-collision
 :END:
 
-[[https://github.com/openSUSE/snapper][openSUSE snapper]] is a different project (Btrfs/LVM volume snapshots) that also installs a =snapper= binary. This formatter's crate name is =snapper-fmt=; installers ship both =snapper= and =snapper-fmt= as names for the same program. On systems where openSUSE already owns =/usr/bin/snapper=, invoke =snapper-fmt= (or put the TurtleTech install directory first on =PATH=).
+[[https://github.com/openSUSE/snapper][openSUSE snapper]] is a different project (Btrfs/LVM volume snapshots) that also installs a =snapper= binary.
+This formatter's crate name is =snapper-fmt=; installers ship both =snapper= and =snapper-fmt= as names for the same program.
+On systems where openSUSE already owns =/usr/bin/snapper=, invoke =snapper-fmt= (or put the TurtleTech install directory first on =PATH=).
 
 * Can I use snapper as a library?
 :PROPERTIES:

--- a/docs/orgmode/howto/neural-detection.org
+++ b/docs/orgmode/howto/neural-detection.org
@@ -31,7 +31,8 @@ For English academic papers, the rule-based detector produces better results (fa
 snapper --neural paper.org
 #+end_src
 
-On first run, the English model (~4MB) downloads and caches to =~/.cache/nnsplit/en/=. Subsequent runs load from cache.
+On first run, the English model (~4MB) downloads and caches to =~/.cache/nnsplit/en/=.
+Subsequent runs load from cache.
 
 * Non-English languages
 :PROPERTIES:

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -128,7 +128,9 @@ Default: =text= (prints filenames to stderr).
 :END:
 
 Use neural sentence detection via nnsplit (byte-level LSTM, tract backend).
-Downloads and caches the model (~4MB) to =~/.cache/nnsplit/= on first use. Rule-based detection remains the default (faster, better abbreviation handling). Neural excels for non-English text.
+Downloads and caches the model (~4MB) to =~/.cache/nnsplit/= on first use.
+Rule-based detection remains the default (faster, better abbreviation handling).
+Neural excels for non-English text.
 
 *** =--lang <CODE>=
 :PROPERTIES:

--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -208,7 +208,9 @@ The VS Code extension runs the CLI rather than the wasm build, so it has grammar
 The scanner reads [[#field-string-delims][string_delims]] to find trailing comments on its own, so both engines agree on ordinary code.
 A grammar still wins on raw strings, heredocs, triple-quoted strings and nested comments, where quote counting alone gives the wrong answer.
 
-Block comments always go through the marker scanner, so a close marker inside a string ends the comment early regardless of the grammar.
+Block comments stay on the scanner.
+A close marker inside a string does not end the comment, so =let s = "*/";= in a =/* ... */= block stays in the comment.
+When the closer is itself a quote sequence (="""=, ='''=), the first match is the closer, which is how Python docstrings reflow.
 
 * Precedence
 :PROPERTIES:

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -55,8 +55,8 @@ These tokens within prose are not split across lines:
 - Links: =[[url][description]]=
 - Emphasis: =*bold*=, =/italic/=, =_underline_=, =+strike+=
 - Inline code: =~code~=, ===verbatim===
-- A =~code~= or ===verbatim=== span may contain the marker character; pairing uses Org's border and post rules, so =x = 1= stays one span
-- Markdown inline code: a run of =n= backticks closes on the next run of the same length, so a double span can hold a single backtick
+- A =~code~= or ===verbatim=== span may contain the marker character; pairing matches pandoc's org reader, so =x = 1= stays one span
+- Markdown inline code: a run of =n= backticks closes on the next run of the same length (CommonMark / pandoc), so a double span can hold a single backtick
 - Inline export snippets: =@@backend:value@@=
 - URLs: =https://...= (trailing sentence punctuation not swallowed)
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -55,6 +55,8 @@ These tokens within prose are not split across lines:
 - Links: =[[url][description]]=
 - Emphasis: =*bold*=, =/italic/=, =_underline_=, =+strike+=
 - Inline code: =~code~=, ===verbatim===
+- A =~code~= or ===verbatim=== span may contain the marker character; pairing uses Org's border and post rules, so =x = 1= stays one span
+- Markdown inline code: a run of =n= backticks closes on the next run of the same length, so a double span can hold a single backtick
 - Inline export snippets: =@@backend:value@@=
 - URLs: =https://...= (trailing sentence punctuation not swallowed)
 

--- a/docs/orgmode/tutorials/quickstart.org
+++ b/docs/orgmode/tutorials/quickstart.org
@@ -40,6 +40,12 @@ pip:
 pip install snapper-fmt
 #+end_src
 
+conda-forge:
+
+#+begin_src bash
+conda install -c conda-forge snapper-fmt
+#+end_src
+
 Nix:
 
 #+begin_src bash

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -73,6 +73,9 @@ curl -LsSf https://github.com/TurtleTech-ehf/snapper/releases/latest/download/sn
 # pip
 pip install snapper-fmt
 
+# conda-forge
+conda install -c conda-forge snapper-fmt
+
 # Homebrew
 brew install TurtleTech-ehf/tap/snapper-fmt
 

--- a/readme_src.org
+++ b/readme_src.org
@@ -52,6 +52,10 @@ pip:
 #+begin_src bash
 pip install snapper-fmt
 #+end_src
+conda-forge:
+#+begin_src bash
+conda install -c conda-forge snapper-fmt
+#+end_src
 Compile from source:
 #+begin_src bash
 cargo install snapper-fmt
@@ -63,7 +67,8 @@ nix build github:TurtleTech-ehf/snapper
 The crate is =snapper-fmt= on all registries.
 Each install ships two CLI names for the same program: =snapper= and =snapper-fmt=.
 
-*Name collision:* [[https://github.com/openSUSE/snapper][openSUSE snapper]] is a different project (Btrfs/LVM snapshots) that also installs a =snapper= binary. On systems where that tool already owns =/usr/bin/snapper=, call this formatter as =snapper-fmt=, or put the TurtleTech install path ahead of the system path.
+*Name collision:* [[https://github.com/openSUSE/snapper][openSUSE snapper]] is a different project (Btrfs/LVM snapshots) that also installs a =snapper= binary.
+On systems where that tool already owns =/usr/bin/snapper=, call this formatter as =snapper-fmt=, or put the TurtleTech install path ahead of the system path.
 * Usage
 :PROPERTIES:
 :CUSTOM_ID: usage

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -56,7 +56,7 @@ pub fn reflow_code_body(
     #[cfg(feature = "treesitter")]
     let body: &str = &{
         let frozen = frozen_lines(body, cfg);
-        crate::ts_comments::reflow_line_comments(lang, body, cfg, splitter, &frozen)
+        crate::ts_comments::reflow_grammar_comments(lang, body, cfg, splitter, &frozen)
             .unwrap_or_else(|| body.to_string())
     };
     #[cfg(not(feature = "treesitter"))]
@@ -109,7 +109,7 @@ fn reflow_comments(body: &str, cfg: &CodeLang, splitter: &dyn SentenceSplitter) 
                     // Same-line open + close (e.g. `/* one sentence. */`)?
                     let trimmed_after = after_open.trim_start();
                     if !close.is_empty() {
-                        if let Some(idx) = trimmed_after.find(close) {
+                        if let Some(idx) = find_close(trimmed_after, close, cfg) {
                             let interior = &trimmed_after[..idx];
                             // Emit: indent + open\n + reflowed interior\n + indent + close\n
                             emit_block_comment(&mut out, indent, open, close, interior, splitter);
@@ -121,7 +121,7 @@ fn reflow_comments(body: &str, cfg: &CodeLang, splitter: &dyn SentenceSplitter) 
                     let mut close_indent: Option<String> = None;
                     let mut closed = false;
                     for next in iter.by_ref() {
-                        if let Some(idx) = next.find(close) {
+                        if let Some(idx) = find_close(next, close, cfg) {
                             // Found close. Anything before it (on this line)
                             // joins the interior; the close marker stays on
                             // its own emitted line at its original indent.
@@ -369,6 +369,51 @@ fn rewrite_trailing(
         out.push_str(sentence);
     }
     Some(out)
+}
+
+/// Byte offset of `close` on `line`, skipping matches that sit inside a
+/// string. When `close` is itself a quote sequence (`"""`, `'''`), the first
+/// match is the closer and quoting does not apply.
+fn find_close(line: &str, close: &str, cfg: &CodeLang) -> Option<usize> {
+    if close.is_empty() {
+        return None;
+    }
+    let quotes = cfg.quote_chars();
+    if close.chars().all(|c| quotes.contains(&c)) {
+        return line.find(close);
+    }
+    let escape = cfg.escape_char();
+    let bytes = line.as_bytes();
+    let mut in_string: Option<char> = None;
+    let mut i = 0;
+    while i < bytes.len() {
+        let rest = &line[i..];
+        let ch = rest.chars().next()?;
+        match in_string {
+            Some(delim) => {
+                if ch == escape {
+                    i += ch.len_utf8();
+                    if let Some(next) = line[i..].chars().next() {
+                        i += next.len_utf8();
+                    }
+                    continue;
+                }
+                if ch == delim {
+                    in_string = None;
+                }
+            }
+            None => {
+                if rest.starts_with(close) {
+                    return Some(i);
+                }
+                if quotes.contains(&ch) {
+                    in_string = Some(ch);
+                }
+            }
+        }
+        i += ch.len_utf8();
+    }
+    None
 }
 
 /// Split a line at the first occurrence of `marker`. Returns

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -477,6 +477,31 @@ mod tests {
     }
 
     #[test]
+    fn verbatim_inner_equals_does_not_orphan_closer() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        // The period after `note.` is inside the first span. Closing on the
+        // inner `=` would emit a line that starts with `=` and leave the
+        // document's markup unterminated.
+        let input = "so =x = 1 -- note.= reflows while =s = \"x\"= does not.\n";
+        let cfg = FormatConfig {
+            format: Format::Org,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, input,
+            "verbatim spans with inner `=` must stay one sentence, got:\n{out}"
+        );
+        assert!(
+            !out.lines().any(|l| l.starts_with('=')),
+            "must not orphan a closer onto its own line, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
     fn bold_emphasis_with_period_does_not_become_headline() {
         use crate::format::Format;
         use crate::{FormatConfig, format_text};

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -29,12 +29,13 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             r"/[^/\s\n](?:[^/\n]*[^/\s\n])?/",   // Org italic: /text/
             r"_[^_\s\n](?:[^_\n]*[^_\s\n])?_",   // Org underline: _text_
             r"\+[^\+\s\n](?:[^\+\n]*[^\+\s\n])?\+", // Org strike-through: +text+
-            r"~[^~\n]+~",                        // Org inline code: ~code~
-            r"=[^=\n]+=",                        // Org verbatim: =text=
-            r"`[^`\n]+`",                        // Markdown inline code: `code`
-            r#"https?://\S+[^.\s!?,;:)\]'""]"#,  // URLs (don't swallow trailing punctuation)
-            r"file:\S+",                         // Org file: links
-            r"@@[a-zA-Z]+:[^@]*@@",              // Org inline export snippets: @@backend:value@@
+            // Org `=verbatim=` / `~code~` and Markdown backtick spans are
+            // paired below: a regex that forbids the delimiter inside the
+            // span closes on the first inner copy and leaves the real closer
+            // (and any period before it) unprotected.
+            r#"https?://\S+[^.\s!?,;:)\]'""]"#, // URLs (don't swallow trailing punctuation)
+            r"file:\S+",                        // Org file: links
+            r"@@[a-zA-Z]+:[^@]*@@",             // Org inline export snippets: @@backend:value@@
         ]
         .join("|"),
     )
@@ -104,12 +105,128 @@ impl Default for UnicodeSentenceSplitter {
 /// (UAX or neural) cannot cut inside them. Shared by rules and neural paths.
 pub fn protect_inline_tokens(text: &str) -> (String, Vec<String>) {
     let mut placeholders: Vec<String> = Vec::new();
-    let protected = INLINE_TOKEN_RE.replace_all(text, |caps: &regex::Captures| {
+    let after_spans = protect_paired_spans(text, &mut placeholders);
+    let protected = INLINE_TOKEN_RE.replace_all(&after_spans, |caps: &regex::Captures| {
         let idx = placeholders.len();
         placeholders.push(caps[0].to_string());
         format!("\x00PH{idx}\x00")
     });
     (protected.into_owned(), placeholders)
+}
+
+/// Org `=`/`~` and Markdown backtick spans, paired to the real closer.
+///
+/// Org markers follow the emphasis border/post rules: the opener sits after
+/// a pre character (start of text, whitespace, or `('"{`), the first and last
+/// interior characters are not whitespace, and the closer is the first
+/// matching marker whose next character is a post character (end of text,
+/// whitespace, or `-.,:!?;'")}[`). Inner copies of the marker are content.
+///
+/// Markdown inline code uses CommonMark fence-length matching: a run of `n`
+/// backticks closes on the next run of exactly `n` backticks, so a double
+/// span can hold a single backtick.
+fn protect_paired_spans(text: &str, placeholders: &mut Vec<String>) -> String {
+    let mut out = String::with_capacity(text.len());
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < text.len() {
+        if bytes[i] == b'`' {
+            if let Some(end) = find_md_code_span(text, i) {
+                push_placeholder(&mut out, placeholders, &text[i..end]);
+                i = end;
+                continue;
+            }
+        } else if bytes[i] == b'=' || bytes[i] == b'~' {
+            let marker = bytes[i] as char;
+            if let Some(end) = find_org_paired_span(text, i, marker) {
+                push_placeholder(&mut out, placeholders, &text[i..end]);
+                i = end;
+                continue;
+            }
+        }
+        let ch = text[i..].chars().next().expect("i is in range");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+fn push_placeholder(out: &mut String, placeholders: &mut Vec<String>, span: &str) {
+    let idx = placeholders.len();
+    placeholders.push(span.to_string());
+    out.push_str(&format!("\x00PH{idx}\x00"));
+}
+
+fn find_org_paired_span(text: &str, open_at: usize, marker: char) -> Option<usize> {
+    // org-emphasis-regexp-components: pre / post. Border is whitespace.
+    const PRE: &str = " \t\n('\"{";
+    const POST: &str = " \t\n-.,:!?;'\")}[";
+
+    if open_at > 0 {
+        let prev = text[..open_at].chars().next_back()?;
+        if !PRE.contains(prev) {
+            return None;
+        }
+    }
+    let after_open = open_at + marker.len_utf8();
+    if after_open >= text.len() {
+        return None;
+    }
+    let first = text[after_open..].chars().next()?;
+    if first.is_whitespace() {
+        return None;
+    }
+
+    let mut j = after_open;
+    while j < text.len() {
+        let ch = text[j..].chars().next()?;
+        if ch == '\n' {
+            return None;
+        }
+        if ch == marker && j > after_open {
+            let prev = text[..j].chars().next_back()?;
+            if !prev.is_whitespace() {
+                let after_close = j + marker.len_utf8();
+                let post_ok =
+                    after_close == text.len() || POST.contains(text[after_close..].chars().next()?);
+                if post_ok {
+                    return Some(after_close);
+                }
+            }
+        }
+        j += ch.len_utf8();
+    }
+    None
+}
+
+fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if bytes.get(open_at) != Some(&b'`') {
+        return None;
+    }
+    let mut n = 0usize;
+    while open_at + n < bytes.len() && bytes[open_at + n] == b'`' {
+        n += 1;
+    }
+    let mut j = open_at + n;
+    while j < bytes.len() {
+        if bytes[j] == b'\n' {
+            return None;
+        }
+        if bytes[j] == b'`' {
+            let mut m = 0usize;
+            while j + m < bytes.len() && bytes[j + m] == b'`' {
+                m += 1;
+            }
+            if m == n && j > open_at + n {
+                return Some(j + m);
+            }
+            j += m;
+        } else {
+            j += 1;
+        }
+    }
+    None
 }
 
 /// Restore placeholders produced by [`protect_inline_tokens`] into each segment.
@@ -654,6 +771,70 @@ mod tests {
             split("End of first. *Bold spans period. Continues* after."),
             vec!["End of first.", "*Bold spans period. Continues* after."]
         );
+    }
+
+    #[test]
+    fn org_verbatim_inner_equals_pairs_to_the_real_closer() {
+        // `=[^=]+ =` reads the inner `=` as a closer and leaves the period
+        // after `note.` unprotected. Both spans must be captured whole.
+        let text = r#"so =x = 1 -- note.= reflows while =s = "x"= does not."#;
+        let (protected, placeholders) = protect_inline_tokens(text);
+        assert_eq!(
+            placeholders,
+            vec![
+                r#"=x = 1 -- note.="#.to_string(),
+                r#"=s = "x"="#.to_string(),
+            ],
+            "pairing must not close on the inner `=`; got {placeholders:?} from {protected:?}"
+        );
+        assert_eq!(split(text), vec![text.to_string()]);
+    }
+
+    #[test]
+    fn org_verbatim_inner_equals_alone_stays_one_sentence() {
+        let text = "so =x = 1 -- note.= reflows here.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert_eq!(placeholders, vec!["=x = 1 -- note.=".to_string()]);
+        assert_eq!(split(text), vec![text.to_string()]);
+    }
+
+    #[test]
+    fn org_verbatim_second_span_alone_does_not_need_inner_equals() {
+        let text = r#"so =x -- note.= reflows while =s = "x"= does not."#;
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert_eq!(
+            placeholders,
+            vec!["=x -- note.=".to_string(), r#"=s = "x"="#.to_string(),]
+        );
+        assert_eq!(split(text), vec![text.to_string()]);
+    }
+
+    #[test]
+    fn org_code_inner_tilde_pairs_to_the_real_closer() {
+        let text = r#"so ~x ~ 1 -- note.~ reflows while ~s ~ "x"~ does not."#;
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert_eq!(
+            placeholders,
+            vec![
+                r#"~x ~ 1 -- note.~"#.to_string(),
+                r#"~s ~ "x"~"#.to_string(),
+            ]
+        );
+        assert_eq!(split(text), vec![text.to_string()]);
+    }
+
+    #[test]
+    fn markdown_double_backticks_can_hold_a_backtick() {
+        let text = r#"see ``x ` 1 -- note.`` and ``s ` "x"`` too."#;
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert_eq!(
+            placeholders,
+            vec![
+                r#"``x ` 1 -- note.``"#.to_string(),
+                r#"``s ` "x"``"#.to_string(),
+            ]
+        );
+        assert_eq!(split(text), vec![text.to_string()]);
     }
 
     #[test]

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -116,15 +116,19 @@ pub fn protect_inline_tokens(text: &str) -> (String, Vec<String>) {
 
 /// Org `=`/`~` and Markdown backtick spans, paired to the real closer.
 ///
-/// Org markers follow the emphasis border/post rules: the opener sits after
-/// a pre character (start of text, whitespace, or `('"{`), the first and last
+/// Org markers follow the same walk as pandoc's org reader
+/// (`verbatimBetween` / `emphasisStart` / `emphasisEnd`, the Emacs
+/// `org-emphasis-regexp-components` defaults). The opener sits after a pre
+/// character (start of text, whitespace, or `('"{`), the first and last
 /// interior characters are not whitespace, and the closer is the first
 /// matching marker whose next character is a post character (end of text,
 /// whitespace, or `-.,:!?;'")}[`). Inner copies of the marker are content.
+/// `pandoc -f org` reports those spans as `Code` inlines with class
+/// `verbatim` or bare `Code`.
 ///
-/// Markdown inline code uses CommonMark fence-length matching: a run of `n`
-/// backticks closes on the next run of exactly `n` backticks, so a double
-/// span can hold a single backtick.
+/// Markdown inline code uses CommonMark / pandoc fence-length matching: a
+/// run of `n` backticks closes on the next run of exactly `n` backticks, so
+/// a double span can hold a single backtick.
 fn protect_paired_spans(text: &str, placeholders: &mut Vec<String>) -> String {
     let mut out = String::with_capacity(text.len());
     let bytes = text.as_bytes();
@@ -158,7 +162,8 @@ fn push_placeholder(out: &mut String, placeholders: &mut Vec<String>, span: &str
 }
 
 fn find_org_paired_span(text: &str, open_at: usize, marker: char) -> Option<usize> {
-    // org-emphasis-regexp-components: pre / post. Border is whitespace.
+    // pandoc org reader / org-emphasis-regexp-components defaults.
+    // Border (forbidden at the inner edges) is whitespace.
     const PRE: &str = " \t\n('\"{";
     const POST: &str = " \t\n-.,:!?;'\")}[";
 
@@ -775,8 +780,9 @@ mod tests {
 
     #[test]
     fn org_verbatim_inner_equals_pairs_to_the_real_closer() {
-        // `=[^=]+ =` reads the inner `=` as a closer and leaves the period
-        // after `note.` unprotected. Both spans must be captured whole.
+        // `pandoc -f org` makes two Code inlines, class verbatim, contents
+        // `x = 1 -- note.` and `s = "x"`. A `=[^=]+=` regex instead closes
+        // on the inner `=` and leaves the period after `note.` unprotected.
         let text = r#"so =x = 1 -- note.= reflows while =s = "x"= does not."#;
         let (protected, placeholders) = protect_inline_tokens(text);
         assert_eq!(

--- a/src/ts_comments.rs
+++ b/src/ts_comments.rs
@@ -7,10 +7,11 @@
 //! which bytes are a comment and which are a string, so this pass rewrites
 //! the comments it finds and leaves every other byte alone.
 //!
-//! Only line comments are handled here. Block comments keep their existing
-//! open/close-on-own-line shape from the scanner, which runs after this pass
-//! and is a no-op on the output produced here (one sentence re-split is that
-//! same sentence).
+//! Line comments keep the per-line marker shape. Block comments stay on the
+//! scanner: languages that use `*/` end a comment at the first closer, even
+//! when that closer sits inside a string, so a grammar span cannot reach the
+//! real end. Python docstrings are string nodes, not comments, and also stay
+//! on the scanner.
 
 use std::collections::HashSet;
 
@@ -42,7 +43,7 @@ fn language_for(lang: &str) -> Option<tree_sitter::Language> {
 ///
 /// `frozen` carries zero-based line numbers the caller has ruled out, which
 /// is how `snapper:off` regions and the pragma lines themselves survive.
-pub(crate) fn reflow_line_comments(
+pub(crate) fn reflow_grammar_comments(
     lang: &str,
     body: &str,
     cfg: &CodeLang,

--- a/tests/code_block_reflow.rs
+++ b/tests/code_block_reflow.rs
@@ -433,6 +433,36 @@ fn main() {
 }
 
 #[test]
+fn rust_block_comment_close_inside_string_does_not_end_comment() {
+    // A `*/` sitting inside a string must not close the comment. The rest of
+    // the comment is still prose and must reflow as such.
+    let input = "\
+```rust
+/*
+let s = \"*/\";
+This is still the comment. Second sentence.
+*/
+fn x() {}
+```
+";
+    let cfg = config(
+        Format::Markdown,
+        code_map(&[("rust", Some("//"), Some(["/*", "*/"]))]),
+    );
+    let out = round_trip(input, &cfg);
+    let expected = "\
+```rust
+/*
+ let s = \"*/\"; This is still the comment.
+ Second sentence.
+*/
+fn x() {}
+```
+";
+    assert_eq!(out, expected);
+}
+
+#[test]
 fn rust_marker_inside_string_literal_is_not_a_comment() {
     let input = "\
 ```rust

--- a/tests/pandoc_ast_backend.rs
+++ b/tests/pandoc_ast_backend.rs
@@ -459,3 +459,31 @@ fn default_path_numbered_atx_source_line_not_split() {
             .any(|l| l.trim() == "### 1." || l.trim() == "### 1")
     );
 }
+
+/// Pandoc's org reader already emits each `=...=` as one Code inline
+/// (class verbatim). The walker keeps that as Structure, so a closer
+/// cannot land on its own line. Native pairing is meant to match this.
+#[test]
+fn pandoc_org_verbatim_inner_equals_stays_one_span() {
+    if !snapper_fmt::parser::pandoc::pandoc_available() {
+        eprintln!("skipping: pandoc CLI not on PATH");
+        return;
+    }
+    let input = "so =x = 1 -- note.= reflows while =s = \"x\"= does not.\n";
+    let cfg = FormatConfig {
+        format: Format::Org,
+        use_pandoc: true,
+        pandoc_backend: PandocBackend::Cli,
+        pandoc_format: Some("org".into()),
+        ..Default::default()
+    };
+    let out = format_text(input, &cfg).expect("pandoc org format");
+    assert!(
+        !out.lines().any(|l| l.trim() == "=" || l.starts_with("= ")),
+        "pandoc path must not orphan a verbatim closer, got:\n{out}"
+    );
+    assert!(
+        out.contains("x = 1") && out.contains("s ="),
+        "both verbatim bodies must survive, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Two pairing bugs, one of them corrupts markup.

Native org pairing now matches `pandoc -f org`.
`pandoc` already emits `=x = 1 note.=` as one `Code` inline (class `verbatim`); the regex `=[^=]+=` closed on the inner `=` instead.
A second span on the same line then left the period unprotected, and the next line started with a stray `=`.
The walk is pandoc's `verbatimBetween` / Emacs `org-emphasis-regexp-components` defaults.
Markdown inline code uses fence-length matching, so a double-backtick span can hold a backtick.
`--use-pandoc` already kept these as Structure; the native path had to recover the same spans from bytes.

Block comments took the first `*/` on a later line.
A `/*` block with a closer inside a string cut the comment there.
`find_close` skips a closer inside quotes; `"""` still matches naively so Python docstrings reflow.
A grammar does not help here for Rust or C: those languages end a comment at the first `*/` even inside a string, so the parse span is already short.

Install docs list `conda install -c conda-forge snapper-fmt`.

https://github.com/conda-forge/snapper-fmt-feedstock/pull/1 (autotick, v0.9.1) passed CI.
The package on the channel remains 0.8.1.
