### PR TITLE
fix: keep LaTeX Eq.~ref attached after org tilde pairing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. See [conven
 - (**org** / **sentence**) verbatim and inline-code spans pair to the first closer that satisfies Org's border and post rules, so an `=` or `~` inside the span no longer orphans the real closer onto the next line
 - (**markdown** / **sentence**) inline code delimited by two or more backticks can contain a shorter backtick run
 - (**code-block**) a block-comment closer inside a string no longer ends the comment; quote-sequence closers (`"""`) still match naively so Python docstrings reflow
+- (**sentence**) abbreviation merge does not invent a space before LaTeX `~` (so `Eq.~\ref{}` stays attached once org `~code~` pairing no longer swallows that tilde)
 
 - - -
 

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -377,12 +377,20 @@ fn merge_abbreviation_splits(
 
 /// Append `piece` to `dest`, inserting a single space if neural/UAX segments
 /// were trimmed and would otherwise glue `world.` + `How` into `world.How`.
+///
+/// Do not invent a space before a mark that was attached to the period in
+/// the source. LaTeX `Eq.~\ref{}` uses `~` as a non-breaking space. Org
+/// `~code~` pairing does not close before `\`, so abbreviation merge sees
+/// `Eq.` + `~\ref` as two segments.
 fn push_segment_preserving_space(dest: &mut String, piece: &str) {
     if piece.is_empty() {
         return;
     }
+    let next = piece.chars().next();
     let need_space = dest.chars().last().is_some_and(|c| !c.is_whitespace())
-        && !piece.chars().next().is_some_and(|c| c.is_whitespace());
+        && next.is_some_and(|c| {
+            !c.is_whitespace() && (c.is_alphanumeric() || matches!(c, '"' | '\'' | '`' | '('))
+        });
     if need_space {
         dest.push(' ');
     }
@@ -683,6 +691,21 @@ mod tests {
         assert_eq!(
             split("See Fig. 3 for details. The results are clear."),
             vec!["See Fig. 3 for details.", "The results are clear."]
+        );
+    }
+
+    #[test]
+    fn latex_nbsp_after_abbrev_stays_attached() {
+        // `Eq.~\ref{}` is one token in LaTeX. Org `~code~` pairing does
+        // not take a closer before `\`, so abbreviation merge must not
+        // insert a space between `Eq.` and `~`.
+        let text = r"See Fig. ~1, Eq.~\ref{eq:diff}, and Dr. Smith. Next.";
+        assert_eq!(
+            split(text),
+            vec![
+                r"See Fig. ~1, Eq.~\ref{eq:diff}, and Dr. Smith.".to_string(),
+                "Next.".to_string(),
+            ]
         );
     }
 


### PR DESCRIPTION
PR 11 matched pandoc's org reader for `~code~`, so `~1, Eq.~` is no longer a span: the closer sits before `\`.
Abbreviation merge then saw `Eq.` plus `~\ref` and inserted a space, which turns LaTeX `Eq.~\ref{}` into `Eq. ~\ref{}` and trips dogfood on `examples/paper.tex`.

Invent a space when the next segment starts a word or quote, not before `~`.
`Eq.~\ref{}` and `Fig.~1` stay attached.
