### PR TITLE
docs: record required checks on main

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -68,8 +68,15 @@ gh workflow run crates.yml --ref main -f dry_run=true
    cargo test --no-default-features --lib
    ```
 
-4. Open the release PR, wait for **all** checks (CI, Pre-checks, WASM,
-   Python wheels, Build and Deploy) to pass, then merge.
+4. Open the release PR. `main` is branch-protected with `enforce_admins`:
+   `gh pr merge` is refused until the required checks are green (not pending).
+   Required on every PR: `check (ubuntu-latest)`, `check (macos-latest)`,
+   `Public availability contract`, `Link check`, `build-deploy`.
+   Those include the dogfood `--check` on docs and examples.
+   Path-filtered jobs (WASM, wheels, crates) are not required because they
+   do not run on every PR; still wait for them when they do run.
+   Use `gh pr merge --auto` to queue; do not merge while anything required
+   is pending.
 
 ## The tag
 


### PR DESCRIPTION
`main` now has branch protection with `enforce_admins`.
Required checks: `check (ubuntu-latest)`, `check (macos-latest)`, `Public availability contract`, `Link check`, `build-deploy`.
`gh pr merge` is refused while any of those is pending or red.
Path-filtered jobs are not in that list; they do not run on every PR.
