### PR TITLE
fix: hang list and quote continuations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. See [conven
 ## Unreleased (main)
 
 #### Bug Fixes
+- (**reflow**) list and quote continuation sentences hang at the marker width so Org rejoins the item on reparse; Markdown `-` / `1.` / `>` match
 - (**latex**) a trailing `%` eats the newline (TeX nospace join), so `foo%\\nbar` is no longer emitted as `foo% bar` (which comments out `bar`); mid-line `%` comments leave prose
 - (**sentence**) `w.r.t.` is a multi-word abbreviation; `\\(...\\)` and `$$...$$` stay atomic like `$...$`
 - (**cli**) unknown source extensions (`.rs`, `.py`, no extension) are refused unless `--format` is explicit; `.txt` remains plaintext

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file. See [conven
 ## Unreleased (main)
 
 #### Bug Fixes
-- (**reflow**) list and quote continuation sentences hang at the marker width so Org rejoins the item on reparse; Markdown `-` / `1.` / `>` match
+- (**reflow**) list continuation sentences hang at the marker width so Org rejoins the item on reparse; Markdown quotes repeat the `>` prefix (`> One.` / `> Two.`, nested `> >`)
 - (**latex**) a trailing `%` eats the newline (TeX nospace join), so `foo%\\nbar` is no longer emitted as `foo% bar` (which comments out `bar`); mid-line `%` comments leave prose
 - (**sentence**) `w.r.t.` is a multi-word abbreviation; `\\(...\\)` and `$$...$$` stay atomic like `$...$`
 - (**cli**) unknown source extensions (`.rs`, `.py`, no extension) are refused unless `--format` is explicit; `.txt` remains plaintext

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -26,7 +26,7 @@ The classification depends on the format.
 - Table rows (lines starting with =|=)
 - Comment lines (starting with =#= but not =#+= )
 - Full headline lines (stars, optional TODO keyword, and title text)
-- List item markers (=-=, =+=, =1.=)
+- List item markers (=-=, =+=, =1.=); continuation sentences hang at the marker width
 - LaTeX environments (=\begin{equation}= ... =\end{equation}=, =\begin{align}=, etc.)
 - Display math (=\[= ... =\]=)
 - Inline export snippets (=@@latex:\newpage@@=, =@@html:<br>@@=)
@@ -45,7 +45,7 @@ The classification depends on the format.
 :CUSTOM_ID: org-prose
 :END:
 - Paragraph text
-- List item text (after the marker)
+- List item text (after the marker); continuation sentences hang at the marker width so Org rejoins the item
 
 *** Inline tokens (kept atomic)
 :PROPERTIES:
@@ -101,7 +101,7 @@ These tokens within prose are not split across lines:
 - Front matter (=---= or =+++=  delimited at file start)
 - Full ATX heading lines (=#= … =######= including title text)
 - Setext headings (title line plus ====== or ------ underline)
-- List item markers (=-=, =*=, =+=, =1.=)
+- List item markers (=-=, =*=, =+=, =1.=) and blockquote markers (=>=); continuation sentences hang at the marker width
 - Pipe tables
 
 *** Code regions (fenced =```= / =~~~=)
@@ -117,7 +117,7 @@ These tokens within prose are not split across lines:
 :CUSTOM_ID: markdown-prose
 :END:
 - Paragraph text
-- List item text (after the marker)
+- List item and blockquote text (after the marker); continuation sentences hang at the marker width
 
 ** reStructuredText (=--format rst=)
 :PROPERTIES:

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -101,7 +101,8 @@ These tokens within prose are not split across lines:
 - Front matter (=---= or =+++=  delimited at file start)
 - Full ATX heading lines (=#= … =######= including title text)
 - Setext headings (title line plus ====== or ------ underline)
-- List item markers (=-=, =*=, =+=, =1.=) and blockquote markers (=>=); continuation sentences hang at the marker width
+- List item markers (=-=, =*=, =+=, =1.=); continuation sentences hang at the marker width
+- Blockquote markers (=>= / nested => > =); continuation sentences repeat the quote prefix
 - Pipe tables
 
 *** Code regions (fenced =```= / =~~~=)
@@ -117,7 +118,8 @@ These tokens within prose are not split across lines:
 :CUSTOM_ID: markdown-prose
 :END:
 - Paragraph text
-- List item and blockquote text (after the marker); continuation sentences hang at the marker width
+- List item text (after the marker); continuation sentences hang at the marker width
+- Blockquote text (after the prefix); continuation sentences repeat the quote prefix
 
 ** reStructuredText (=--format rst=)
 :PROPERTIES:

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -13,7 +13,11 @@ static FENCED_LANG_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(?:`{3,}|~{3,})\s*([A-Za-z0-9_+.\-]+)").unwrap());
 
 static LIST_ITEM_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\s*(?:[-*+]|\d+[.)]|>) )(.*)$").unwrap());
+    LazyLock::new(|| Regex::new(r"^(\s*(?:[-*+]|\d+[.)]) )(.*)$").unwrap());
+
+/// Markdown blockquote prefix: optional indent plus one or more `> `.
+/// Nested `> > text` keeps the full prefix so reflow can repeat it.
+static QUOTE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(\s*(?:> )+)(.*)$").unwrap());
 
 /// Match a markdown table row: line whose trimmed form starts and ends with `|`.
 /// Also matches separator rows like `|---|---|`.
@@ -57,7 +61,7 @@ fn is_setext_title_line(line: &str) -> bool {
     if TABLE_ROW_RE.is_match(line) {
         return false;
     }
-    if LIST_ITEM_RE.is_match(line) {
+    if LIST_ITEM_RE.is_match(line) || QUOTE_RE.is_match(line) {
         return false;
     }
     if FENCED_CODE_RE.is_match(line.trim_start()) {
@@ -220,8 +224,24 @@ impl FormatParser for MarkdownParser {
                 continue;
             }
 
-            // List item or blockquote: emit marker as Structure, start accumulating
-            // text as prose. Continuation lines are appended until a block boundary.
+            // Blockquote: emit the full `> ` / `> > ` prefix as Structure.
+            // Checked before list items so nested `> >` is not flattened.
+            if let Some(caps) = QUOTE_RE.captures(line) {
+                close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
+                flush_prose(&mut current_prose, &mut regions);
+                let marker = caps.get(1).unwrap().as_str();
+                let text = caps.get(2).unwrap().as_str();
+                regions.push(Region::Structure(marker.to_string()));
+                in_list_item = true;
+                if !text.is_empty() {
+                    current_prose.push_str(text);
+                }
+                i += 1;
+                continue;
+            }
+
+            // List item: emit marker as Structure, start accumulating text as prose.
+            // Continuation lines are appended until a block boundary.
             if let Some(caps) = LIST_ITEM_RE.captures(line) {
                 close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
                 flush_prose(&mut current_prose, &mut regions);
@@ -562,8 +582,39 @@ mod tests {
         assert_eq!(format_text(&numbered, &cfg).unwrap(), numbered);
 
         let quote = format_text("> One. Two.\n", &cfg).unwrap();
-        assert_eq!(quote, "> One.\n  Two.\n");
+        assert_eq!(quote, "> One.\n> Two.\n");
         assert_eq!(format_text(&quote, &cfg).unwrap(), quote);
+    }
+
+    #[test]
+    fn nested_blockquote_keeps_full_prefix() {
+        let input = "> > Nested one. Nested two.";
+        let regions = MarkdownParser.parse(input);
+        assert_eq!(regions[0], Region::Structure("> > ".to_string()));
+        assert_eq!(
+            regions[1],
+            Region::Prose("Nested one. Nested two.".to_string())
+        );
+        assert_eq!(regions[2], Region::Structure("\n".to_string()));
+        assert_eq!(regions.len(), 3);
+    }
+
+    #[test]
+    fn nested_blockquote_reflow_repeats_prefix() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "> Quoted one. Quoted two.\n> > Nested one. Nested two.\n";
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out,
+            "> Quoted one.\n> Quoted two.\n> > Nested one.\n> > Nested two.\n"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 
     #[test]

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -13,7 +13,7 @@ static FENCED_LANG_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(?:`{3,}|~{3,})\s*([A-Za-z0-9_+.\-]+)").unwrap());
 
 static LIST_ITEM_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\s*(?:[-*+]|\d+[.)]) )(.*)$").unwrap());
+    LazyLock::new(|| Regex::new(r"^(\s*(?:[-*+]|\d+[.)]|>) )(.*)$").unwrap());
 
 /// Match a markdown table row: line whose trimmed form starts and ends with `|`.
 /// Also matches separator rows like `|---|---|`.
@@ -220,8 +220,8 @@ impl FormatParser for MarkdownParser {
                 continue;
             }
 
-            // List item: emit marker as Structure, start accumulating text as prose.
-            // Continuation lines are appended until a block boundary.
+            // List item or blockquote: emit marker as Structure, start accumulating
+            // text as prose. Continuation lines are appended until a block boundary.
             if let Some(caps) = LIST_ITEM_RE.captures(line) {
                 close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
                 flush_prose(&mut current_prose, &mut regions);
@@ -532,5 +532,69 @@ mod tests {
                 .iter()
                 .any(|r| matches!(r, Region::Structure(s) if s == "Heading Here\n"))
         );
+    }
+
+    #[test]
+    fn blockquote_marker_is_structure() {
+        let input = "> One. Two.";
+        let regions = MarkdownParser.parse(input);
+        assert_eq!(regions[0], Region::Structure("> ".to_string()));
+        assert_eq!(regions[1], Region::Prose("One. Two.".to_string()));
+        assert_eq!(regions[2], Region::Structure("\n".to_string()));
+        assert_eq!(regions.len(), 3);
+    }
+
+    #[test]
+    fn list_and_quote_multi_sentence_hangs() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let dash = format_text("- One. Two.\n", &cfg).unwrap();
+        assert_eq!(dash, "- One.\n  Two.\n");
+        assert_eq!(format_text(&dash, &cfg).unwrap(), dash);
+
+        let numbered = format_text("1. One. Two.\n", &cfg).unwrap();
+        assert_eq!(numbered, "1. One.\n   Two.\n");
+        assert_eq!(format_text(&numbered, &cfg).unwrap(), numbered);
+
+        let quote = format_text("> One. Two.\n", &cfg).unwrap();
+        assert_eq!(quote, "> One.\n  Two.\n");
+        assert_eq!(format_text(&quote, &cfg).unwrap(), quote);
+    }
+
+    #[test]
+    fn nested_list_stays_two_items_after_reflow() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "1. Parent one. Parent two.\n   - Child one. Child two.\n";
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out,
+            "1. Parent one.\n   Parent two.\n   - Child one.\n     Child two.\n"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+
+        let regions = MarkdownParser.parse(&out);
+        assert_eq!(regions[0], Region::Structure("1. ".to_string()));
+        assert_eq!(
+            regions[1],
+            Region::Prose("Parent one. Parent two.".to_string())
+        );
+        assert_eq!(regions[2], Region::Structure("\n".to_string()));
+        assert_eq!(regions[3], Region::Structure("   - ".to_string()));
+        assert_eq!(
+            regions[4],
+            Region::Prose("Child one. Child two.".to_string())
+        );
+        assert_eq!(regions[5], Region::Structure("\n".to_string()));
     }
 }

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -624,4 +624,59 @@ mod tests {
             .count();
         assert!(struct_count >= 4); // \begin, two content lines, \end
     }
+
+    #[test]
+    fn list_multi_sentence_hangs_and_rejoins() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "- One. Two.\n";
+        let cfg = FormatConfig {
+            format: Format::Org,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(out, "- One.\n  Two.\n");
+        let second = format_text(&out, &cfg).unwrap();
+        assert_eq!(second, out, "format_text twice must equal once");
+
+        let regions = OrgParser.parse(&out);
+        assert_eq!(regions[0], Region::Structure("- ".to_string()));
+        assert_eq!(regions[1], Region::Prose("One. Two.".to_string()));
+        assert_eq!(regions[2], Region::Structure("\n".to_string()));
+        assert_eq!(regions.len(), 3);
+    }
+
+    #[test]
+    fn nested_list_stays_two_items_after_reflow() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "1. Parent one. Parent two.\n   - Child one. Child two.\n";
+        let cfg = FormatConfig {
+            format: Format::Org,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out,
+            "1. Parent one.\n   Parent two.\n   - Child one.\n     Child two.\n"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+
+        let regions = OrgParser.parse(&out);
+        assert_eq!(regions[0], Region::Structure("1. ".to_string()));
+        assert_eq!(
+            regions[1],
+            Region::Prose("Parent one. Parent two.".to_string())
+        );
+        assert_eq!(regions[2], Region::Structure("\n".to_string()));
+        assert_eq!(regions[3], Region::Structure("   - ".to_string()));
+        assert_eq!(
+            regions[4],
+            Region::Prose("Child one. Child two.".to_string())
+        );
+        assert_eq!(regions[5], Region::Structure("\n".to_string()));
+        assert_eq!(regions.len(), 6);
+    }
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -109,11 +109,11 @@ fn reflow_one(
             output.push_str(footer);
         }
         Region::Prose(text) => {
-            let hanging = match idx.checked_sub(1).and_then(|i| regions.get(i)) {
-                Some(Region::Structure(s)) => hanging_indent_width(s),
-                _ => 0,
+            let hang = match idx.checked_sub(1).and_then(|i| regions.get(i)) {
+                Some(Region::Structure(s)) => hanging_prefix(s),
+                _ => String::new(),
             };
-            let hang = " ".repeat(hanging);
+            let hanging = hang.chars().count();
             let wrap_width = if config.max_width > 0 && hanging > 0 {
                 config.max_width.saturating_sub(hanging).max(1)
             } else {
@@ -232,8 +232,38 @@ fn wrap_words_preferring_clause(text: &str, max_width: usize) -> Vec<String> {
     lines
 }
 
-/// Column width of a list or quote marker that continuation lines must hang
-/// at. Zero when `s` is not a marker (headings, fences, inline islands).
+/// Prefix emitted on continuation lines after a list or quote marker.
+/// Lists hang with spaces of marker width; Markdown quotes repeat the
+/// quote prefix (`> `, `> > `, including leading indent). Empty when `s`
+/// is not a marker (headings, fences, inline islands).
+fn hanging_prefix(s: &str) -> String {
+    if is_quote_marker(s) {
+        return s.to_string();
+    }
+    let width = hanging_indent_width(s);
+    if width > 0 {
+        " ".repeat(width)
+    } else {
+        String::new()
+    }
+}
+
+/// True when `s` is a Markdown quote marker: optional indent plus one or
+/// more `> ` runs, and nothing else.
+fn is_quote_marker(s: &str) -> bool {
+    if s.is_empty() || s.contains('\n') || !s.ends_with(' ') {
+        return false;
+    }
+    let trimmed = s.trim_start();
+    let bytes = trimmed.as_bytes();
+    if bytes.len() < 2 || bytes.len() % 2 != 0 {
+        return false;
+    }
+    bytes.chunks_exact(2).all(|c| c == b"> ")
+}
+
+/// Column width of a list marker that continuation lines hang at with
+/// spaces. Zero for quotes and non-markers.
 fn hanging_indent_width(s: &str) -> usize {
     if s.is_empty() || s.contains('\n') || !s.ends_with(' ') {
         return 0;
@@ -245,7 +275,7 @@ fn hanging_indent_width(s: &str) -> usize {
     // Parser markers are `core` plus one trailing space; leading indent is
     // part of the hang so nested `   - ` continues at column 5.
     let core = &trimmed[..trimmed.len() - 1];
-    let is_bullet = matches!(core, "-" | "*" | "+" | ">");
+    let is_bullet = matches!(core, "-" | "*" | "+");
     let is_ordered = (core.ends_with('.') || core.ends_with(')'))
         && core.len() > 1
         && core[..core.len() - 1].bytes().all(|b| b.is_ascii_digit());
@@ -496,7 +526,14 @@ without additional human intervention.";
         assert_eq!(hanging_indent_width("10. "), 4);
         assert_eq!(hanging_indent_width("1) "), 3);
         assert_eq!(hanging_indent_width("   - "), 5);
-        assert_eq!(hanging_indent_width("> "), 2);
+        // Quotes are a prefix hang, not a space-hang bullet.
+        assert_eq!(hanging_indent_width("> "), 0);
+        assert_eq!(hanging_indent_width("> > "), 0);
+        assert_eq!(hanging_prefix("> "), "> ");
+        assert_eq!(hanging_prefix("> > "), "> > ");
+        assert_eq!(hanging_prefix("  > "), "  > ");
+        assert_eq!(hanging_prefix("- "), "  ");
+        assert_eq!(hanging_prefix("1. "), "   ");
         assert_eq!(hanging_indent_width("\n"), 0);
         assert_eq!(hanging_indent_width("#+TITLE: Test\n"), 0);
         assert_eq!(hanging_indent_width("$x$"), 0);
@@ -531,7 +568,23 @@ without additional human intervention.";
             Region::Prose("One. Two.".to_string()),
             Region::Structure("\n".to_string()),
         ]);
-        assert_eq!(result, "> One.\n  Two.\n");
+        assert_eq!(result, "> One.\n> Two.\n");
+    }
+
+    #[test]
+    fn nested_quote_repeats_full_prefix() {
+        let result = reflow_regions(vec![
+            Region::Structure("> ".to_string()),
+            Region::Prose("Quoted one. Quoted two.".to_string()),
+            Region::Structure("\n".to_string()),
+            Region::Structure("> > ".to_string()),
+            Region::Prose("Nested one. Nested two.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            "> Quoted one.\n> Quoted two.\n> > Nested one.\n> > Nested two.\n"
+        );
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -109,19 +109,39 @@ fn reflow_one(
             output.push_str(footer);
         }
         Region::Prose(text) => {
+            let hanging = match idx.checked_sub(1).and_then(|i| regions.get(i)) {
+                Some(Region::Structure(s)) => hanging_indent_width(s),
+                _ => 0,
+            };
+            let hang = " ".repeat(hanging);
+            let wrap_width = if config.max_width > 0 && hanging > 0 {
+                config.max_width.saturating_sub(hanging).max(1)
+            } else {
+                config.max_width
+            };
             let sentences = splitter.split(text);
+            let nsent = sentences.len();
             for (i, sentence) in sentences.iter().enumerate() {
-                if config.max_width > 0 {
-                    let wrapped = if config.clause_breaks {
-                        wrap_with_clause_breaks(sentence, config.max_width)
+                let wrapped = if wrap_width > 0 {
+                    if config.clause_breaks {
+                        wrap_with_clause_breaks(sentence, wrap_width)
                     } else {
-                        textwrap::fill(sentence, config.max_width)
-                    };
-                    output.push_str(&wrapped);
+                        textwrap::fill(sentence, wrap_width)
+                    }
                 } else {
-                    output.push_str(sentence);
+                    sentence.clone()
+                };
+                let lines: Vec<&str> = wrapped.lines().collect();
+                for (j, line) in lines.iter().enumerate() {
+                    if hanging > 0 && (i > 0 || j > 0) {
+                        output.push_str(&hang);
+                    }
+                    output.push_str(line);
+                    if j + 1 < lines.len() {
+                        output.push('\n');
+                    }
                 }
-                if i < sentences.len() - 1 {
+                if i + 1 < nsent {
                     output.push('\n');
                 }
             }
@@ -210,6 +230,30 @@ fn wrap_words_preferring_clause(text: &str, max_width: usize) -> Vec<String> {
         start = break_at;
     }
     lines
+}
+
+/// Column width of a list or quote marker that continuation lines must hang
+/// at. Zero when `s` is not a marker (headings, fences, inline islands).
+fn hanging_indent_width(s: &str) -> usize {
+    if s.is_empty() || s.contains('\n') || !s.ends_with(' ') {
+        return 0;
+    }
+    let trimmed = s.trim_start();
+    if trimmed.len() < 2 {
+        return 0;
+    }
+    // Parser markers are `core` plus one trailing space; leading indent is
+    // part of the hang so nested `   - ` continues at column 5.
+    let core = &trimmed[..trimmed.len() - 1];
+    let is_bullet = matches!(core, "-" | "*" | "+" | ">");
+    let is_ordered = (core.ends_with('.') || core.ends_with(')'))
+        && core.len() > 1
+        && core[..core.len() - 1].bytes().all(|b| b.is_ascii_digit());
+    if is_bullet || is_ordered {
+        s.chars().count()
+    } else {
+        0
+    }
 }
 
 /// When the next region is an inline structure island (pandoc `Math`/`Code` as
@@ -433,5 +477,143 @@ without additional human intervention.";
             );
         }
         assert!(wrapped.contains('\n'));
+    }
+
+    fn reflow_regions(regions: Vec<Region>) -> String {
+        reflow(
+            &regions,
+            &UnicodeSentenceSplitter::new(),
+            &ReflowConfig::default(),
+        )
+    }
+
+    #[test]
+    fn hanging_indent_width_markers_only() {
+        assert_eq!(hanging_indent_width("- "), 2);
+        assert_eq!(hanging_indent_width("* "), 2);
+        assert_eq!(hanging_indent_width("+ "), 2);
+        assert_eq!(hanging_indent_width("1. "), 3);
+        assert_eq!(hanging_indent_width("10. "), 4);
+        assert_eq!(hanging_indent_width("1) "), 3);
+        assert_eq!(hanging_indent_width("   - "), 5);
+        assert_eq!(hanging_indent_width("> "), 2);
+        assert_eq!(hanging_indent_width("\n"), 0);
+        assert_eq!(hanging_indent_width("#+TITLE: Test\n"), 0);
+        assert_eq!(hanging_indent_width("$x$"), 0);
+        assert_eq!(hanging_indent_width("`code`"), 0);
+        assert_eq!(hanging_indent_width("## heading\n"), 0);
+    }
+
+    #[test]
+    fn list_hanging_indent_second_sentence() {
+        let result = reflow_regions(vec![
+            Region::Structure("- ".to_string()),
+            Region::Prose("One. Two.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(result, "- One.\n  Two.\n");
+    }
+
+    #[test]
+    fn numbered_list_hanging_indent() {
+        let result = reflow_regions(vec![
+            Region::Structure("1. ".to_string()),
+            Region::Prose("One. Two.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(result, "1. One.\n   Two.\n");
+    }
+
+    #[test]
+    fn quote_hanging_indent() {
+        let result = reflow_regions(vec![
+            Region::Structure("> ".to_string()),
+            Region::Prose("One. Two.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(result, "> One.\n  Two.\n");
+    }
+
+    #[test]
+    fn nested_list_items_do_not_flatten() {
+        let result = reflow_regions(vec![
+            Region::Structure("1. ".to_string()),
+            Region::Prose("Parent one. Parent two.".to_string()),
+            Region::Structure("\n".to_string()),
+            Region::Structure("   - ".to_string()),
+            Region::Prose("Child one. Child two.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            "1. Parent one.\n   Parent two.\n   - Child one.\n     Child two.\n"
+        );
+        assert!(
+            result.contains("\n   - Child one."),
+            "nested marker must stay its own item: {result:?}"
+        );
+    }
+
+    #[test]
+    fn adjacent_list_items_are_not_merged() {
+        let result = reflow_regions(vec![
+            Region::Structure("- ".to_string()),
+            Region::Prose("First item. More first.".to_string()),
+            Region::Structure("\n".to_string()),
+            Region::Structure("- ".to_string()),
+            Region::Prose("Second item. More second.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            "- First item.\n  More first.\n- Second item.\n  More second.\n"
+        );
+    }
+
+    #[test]
+    fn single_sentence_list_item_has_no_extra_indent() {
+        let result = reflow_regions(vec![
+            Region::Structure("- ".to_string()),
+            Region::Prose("Only one sentence.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(result, "- Only one sentence.\n");
+    }
+
+    #[test]
+    fn wrap_lines_under_list_also_hang() {
+        let regions = vec![
+            Region::Structure("- ".to_string()),
+            Region::Prose(
+                "This is a deliberately long first sentence that must wrap. Short.".to_string(),
+            ),
+            Region::Structure("\n".to_string()),
+        ];
+        let config = ReflowConfig {
+            max_width: 32,
+            ..Default::default()
+        };
+        let result = reflow(&regions, &UnicodeSentenceSplitter::new(), &config);
+        let lines: Vec<&str> = result.lines().collect();
+        assert!(
+            lines[0].starts_with("- "),
+            "first line keeps marker: {result:?}"
+        );
+        for line in &lines[1..] {
+            assert!(
+                line.starts_with("  "),
+                "wrap/continuation must hang at marker width: {result:?}"
+            );
+            assert!(
+                !line.starts_with("- "),
+                "must not invent a new list item: {result:?}"
+            );
+        }
+        for line in &lines {
+            assert!(
+                line.chars().count() <= 32,
+                "line exceeds max_width: {line:?}"
+            );
+        }
     }
 }

--- a/tests/fixtures/mixed_list.md
+++ b/tests/fixtures/mixed_list.md
@@ -1,0 +1,7 @@
+- One. Two.
+- Lone item.
+
+1. Numbered one. Numbered two.
+   - Nested dash. Nested second.
+
+> Quoted one. Quoted two.

--- a/tests/fixtures/mixed_list.md
+++ b/tests/fixtures/mixed_list.md
@@ -5,3 +5,4 @@
    - Nested dash. Nested second.
 
 > Quoted one. Quoted two.
+> > Nested one. Nested two.

--- a/tests/fixtures/mixed_list.org
+++ b/tests/fixtures/mixed_list.org
@@ -1,0 +1,11 @@
+* Mixed lists
+
+- One. Two.
+- Lone item.
+
+1. Numbered one. Numbered two.
+   - Nested dash. Nested second.
+2. After nested. Still after.
+
+- Parent again. More parent.
+  1. Nested numbered. Nested numbered two.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -139,8 +139,12 @@ fn mixed_list_markdown_hangs_and_is_idempotent() {
         "markdown nested list must hang and stay two items: {first}"
     );
     assert!(
-        first.contains("> Quoted one.\n  Quoted two.\n"),
-        "markdown quote continuation must hang: {first}"
+        first.contains("> Quoted one.\n> Quoted two.\n"),
+        "markdown quote continuation must repeat the prefix: {first}"
+    );
+    assert!(
+        first.contains("> > Nested one.\n> > Nested two.\n"),
+        "nested markdown quote must keep the full prefix: {first}"
     );
     let tmp = tempfile::NamedTempFile::new().unwrap();
     fs::write(tmp.path(), &first).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -103,6 +103,52 @@ fn idempotent_org() {
 }
 
 #[test]
+fn mixed_list_org_hangs_and_is_idempotent() {
+    let first = run_format("org", &fixture_path("mixed_list.org"));
+    assert!(
+        first.contains("- One.\n  Two.\n"),
+        "org dash continuation must hang: {first}"
+    );
+    assert!(
+        first.contains(
+            "1. Numbered one.\n   Numbered two.\n   - Nested dash.\n     Nested second.\n"
+        ),
+        "org nested list must hang and stay two items: {first}"
+    );
+    assert!(
+        first.contains("  1. Nested numbered.\n     Nested numbered two.\n"),
+        "org nested ordered continuation must hang: {first}"
+    );
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    fs::write(tmp.path(), &first).unwrap();
+    let second = run_format("org", &tmp.path().to_string_lossy());
+    pretty_assertions::assert_eq!(first, second, "mixed_list.org must be idempotent");
+}
+
+#[test]
+fn mixed_list_markdown_hangs_and_is_idempotent() {
+    let first = run_format("markdown", &fixture_path("mixed_list.md"));
+    assert!(
+        first.contains("- One.\n  Two.\n"),
+        "markdown dash continuation must hang: {first}"
+    );
+    assert!(
+        first.contains(
+            "1. Numbered one.\n   Numbered two.\n   - Nested dash.\n     Nested second.\n"
+        ),
+        "markdown nested list must hang and stay two items: {first}"
+    );
+    assert!(
+        first.contains("> Quoted one.\n  Quoted two.\n"),
+        "markdown quote continuation must hang: {first}"
+    );
+    let tmp = tempfile::NamedTempFile::new().unwrap();
+    fs::write(tmp.path(), &first).unwrap();
+    let second = run_format("markdown", &tmp.path().to_string_lossy());
+    pretty_assertions::assert_eq!(first, second, "mixed_list.md must be idempotent");
+}
+
+#[test]
 fn idempotent_plaintext() {
     let first = run_format("plaintext", &fixture_path("sample.txt"));
     let tmp = tempfile::NamedTempFile::new().unwrap();


### PR DESCRIPTION
Org `- One. Two.` used to emit `Two.` at column 0, which Org treats as a new paragraph.

List continuations hang at marker width (`- ` → two spaces, `1. ` → three). Markdown quotes repeat the prefix (`> `, `> > `). Nested `1.` / `-` stay two items. `format_text` twice is identity on the mixed-list fixtures.

Reviewer asked for quote prefixes instead of spaces; that is in `eb4d31d`.