### PR TITLE
feat: fused wrap long line diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file. See [conven
 ## Unreleased (main)
 
 #### Features
+- (**cli** / **check**) `--check --output-format json|sarif` emits 1-indexed `fused` / `wrap` / `long` diagnostics with excerpts; `long` is advisory unless `--strict-long`; stdin `--check` honors the same JSON/SARIF and exit codes; SARIF URIs are repo-relative (or `file:` plus `invocations[0].workingDirectory`)
+- (**mcp**) `check_formatting` returns `would_reformat` identical to CLI `--check`, plus the same line diagnostics
 - (**safety**) native parsers record source byte ranges and splice reflowed prose into the original document; Structure/Code/Blank are input slices
 - (**safety**) `format_text` runs to a byte fixpoint (cap 4, including A/B cycles) or returns the original; a format-local oracle (region-kind + slice tree; Markdown HTML plus a code-byte check) mismatch also returns the original
 - (**safety**) `format_bytes` refuses invalid UTF-8 with `InvalidUtf8Error`; `--use-pandoc` refuses (`PandocCannotSplice`) because the AST has no source offsets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. See [conven
 - (**code-block**) comment reflow copies non-comment lines as original slices; only comment spans are rewritten
 #### Bug Fixes
 - (**check**) fused and long run on the parser prose payload, so `1. Hello world.` and `See Fig. 1. % TODO cite` are not false fused
+- (**reflow**) splice keeps the trailing space before a mid-line TeX `%` comment so that line stays one source line
 - (**reflow**) list continuation sentences hang at the marker width so Org rejoins the item on reparse; Markdown quotes repeat the `>` prefix (`> One.` / `> Two.`, nested `> >`)
 - (**latex**) a trailing `%` eats the newline (TeX nospace join), so `foo%\\nbar` is no longer emitted as `foo% bar` (which comments out `bar`); mid-line `%` comments leave prose
 - (**sentence**) `w.r.t.` is a multi-word abbreviation; `\\(...\\)` and `$$...$$` stay atomic like `$...$`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. See [conven
 - (**safety**) property tests and a `cargo fuzz` target (fixture corpus) drive `format_text` per format with the backstops off
 - (**code-block**) comment reflow copies non-comment lines as original slices; only comment spans are rewritten
 #### Bug Fixes
+- (**check**) fused and long run on the parser prose payload, so `1. Hello world.` and `See Fig. 1. % TODO cite` are not false fused
 - (**reflow**) list continuation sentences hang at the marker width so Org rejoins the item on reparse; Markdown quotes repeat the `>` prefix (`> One.` / `> Two.`, nested `> >`)
 - (**latex**) a trailing `%` eats the newline (TeX nospace join), so `foo%\\nbar` is no longer emitted as `foo% bar` (which comments out `bar`); mid-line `%` comments leave prose
 - (**sentence**) `w.r.t.` is a multi-word abbreviation; `\\(...\\)` and `$$...$$` stay atomic like `$...$`

--- a/docs/orgmode/howto/mcp-integration.org
+++ b/docs/orgmode/howto/mcp-integration.org
@@ -88,8 +88,13 @@ Check text for semantic line break violations.
 Parameters:
 - =text= (string, required): Text to check
 - =format= (string): Document format (default: "plaintext")
+- =max_width= (integer): Maximum line width; also the =long= threshold when set (default: 0)
 
-Returns line numbers with violations and a pass/fail status.
+Returns:
+- =would_reformat= (boolean): identical to CLI =--check= (formatted output differs from input)
+- =passed= (boolean): =not would_reformat=
+- =diagnostics= (array): 1-indexed =line= / =kind= (=fused= / =wrap= / =long=) / =excerpt=
+- =violations= (array): 1-indexed fused line numbers (compat)
 
 ** split_sentences
 :PROPERTIES:

--- a/docs/orgmode/howto/vale-integration.org
+++ b/docs/orgmode/howto/vale-integration.org
@@ -39,7 +39,9 @@ BasedOnStyles = snapper
 Level: warning.
 - =LongProseLine= :: Flags prose lines exceeding 120 characters.
 Level: suggestion.
-- =SnapperCheck= :: External action. Runs =snapper --check --output-format json= and reports =fused= / =wrap= on the matching lines when =snapper= is on =PATH=. Advisory =long= stays on =LongProseLine=.
+- =SnapperCheck= :: External action.
+  Runs =snapper --check --output-format json= and reports =fused= / =wrap= on the matching lines when =snapper= is on =PATH=.
+  Advisory =long= stays on =LongProseLine=.
 
 * Precise CI enforcement
 :PROPERTIES:

--- a/docs/orgmode/howto/vale-integration.org
+++ b/docs/orgmode/howto/vale-integration.org
@@ -39,6 +39,7 @@ BasedOnStyles = snapper
 Level: warning.
 - =LongProseLine= :: Flags prose lines exceeding 120 characters.
 Level: suggestion.
+- =SnapperCheck= :: External action. Runs =snapper --check --output-format json= and reports =fused= / =wrap= on the matching lines when =snapper= is on =PATH=. Advisory =long= stays on =LongProseLine=.
 
 * Precise CI enforcement
 :PROPERTIES:

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -90,6 +90,7 @@ Missing binaries, non-zero exits, and a ~30s timeout are non-fatal; the reflowed
 Check mode for CI.
 Exits with code 1 if any file would change, without modifying anything.
 Prints the paths of files that would be reformatted to stderr.
+With no file arguments, checks stdin (JSON/SARIF on stdout, same exit codes).
 
 *** =--diff=
 :PROPERTIES:

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -119,8 +119,18 @@ Example: =snapper --range 10:20 paper.org=
 Output format for =--check= mode.
 Default: =text= (prints filenames to stderr).
 
-- =json= : outputs a JSON array with file paths and line counts
-- =sarif= : outputs SARIF v2.1.0 for GitHub Code Scanning integration
+- =json= : outputs a JSON array of files, each with =would_reformat= and a =diagnostics= array of 1-indexed =line= / =kind= (=fused= / =wrap= / =long=) / =excerpt=
+- =sarif= : outputs SARIF v2.1.0 for GitHub Code Scanning, with one result per diagnostic (=snapper/fused=, =snapper/wrap=, =snapper/long=) plus =snapper/needs-reformat= when the file would change
+
+*** =--strict-long=
+:PROPERTIES:
+:CUSTOM_ID: opt-strict-long
+:END:
+
+Treat advisory =long= diagnostics as =--check= failures.
+
+A =long= finding is never the sole cause of exit 1 unless this flag is set.
+The threshold is =--max-width= when that is non-zero, otherwise =long_threshold= from =.snapperrc.toml= (default 120).
 
 *** =--neural=
 :PROPERTIES:
@@ -245,5 +255,5 @@ Works with any LSP-compatible editor (Neovim, Emacs eglot, VS Code, Helix).
 :CUSTOM_ID: exit-codes
 :END:
 
-- =0= : Success (or =--check= / =--diff= with no changes needed)
-- =1= : =--check= or =--diff= found files that would change, or any error
+- =0= : Success (or =--check= / =--diff= with no changes needed; advisory =long= diagnostics do not fail =--check= unless =--strict-long=)
+- =1= : =--check= or =--diff= found files that would change, =--strict-long= saw a =long= diagnostic, or any error

--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -107,6 +107,16 @@ Sentences exceeding this width get wrapped at word boundaries.
 Set to =0= for unlimited (the default).
 Also respects =max_line_length= from =.editorconfig= if present.
 
+** long_threshold
+:PROPERTIES:
+:CUSTOM_ID: field-long-threshold
+:END:
+
+Integer.
+Character threshold for advisory =long= diagnostics when =max_width= is unset.
+Default: 120.
+A =long= finding is never the sole cause of =--check= exit 1 unless =--strict-long= is set.
+
 * Per-format sections
 :PROPERTIES:
 :CUSTOM_ID: per-format-sections

--- a/docs/source/cli-reference.md
+++ b/docs/source/cli-reference.md
@@ -51,6 +51,9 @@ Semantic line break formatter
 
   Default value: `auto`
 * `--check` — Exit with code 1 if any file would change
+* `--strict-long` — Treat advisory `long` diagnostics as `--check` failures
+
+  Default value: `false`
 * `--diff` — Show a unified diff of what would change
 * `--config <CONFIG>` — Path to config file (default: .snapperrc.toml in current or parent dirs)
 * `--range <RANGE>` — Only format lines in this range (1-indexed, inclusive). Format: START:END

--- a/npm/README.md
+++ b/npm/README.md
@@ -31,7 +31,7 @@ Add to your MCP configuration:
 
 - **format_text** -- Format text with semantic line breaks (supports Org, LaTeX, Markdown, RST, plaintext)
 - **detect_format** -- Detect document format from content
-- **check_formatting** -- Find lines with multiple sentences
+- **check_formatting** -- `would_reformat` (same as CLI `--check`) plus fused/wrap/long line diagnostics
 - **split_sentences** -- Split text into individual sentences
 
 ## Links

--- a/src/check.rs
+++ b/src/check.rs
@@ -6,6 +6,7 @@
 use serde::Serialize;
 
 use crate::format::Format;
+use crate::parser::source_line_payloads;
 use crate::sentence::SentenceSplitter;
 use crate::{FormatConfig, format_text};
 
@@ -78,24 +79,31 @@ pub fn collect_diagnostics(
     long_threshold: usize,
 ) -> Vec<LineDiagnostic> {
     let lines: Vec<&str> = input.lines().collect();
-    let prose = classify_prose_lines(&lines, format);
+    let payloads = source_line_payloads(input, format);
+    debug_assert_eq!(
+        payloads.len(),
+        lines.len(),
+        "parser line map must cover every source line (got {} payloads for {} lines)",
+        payloads.len(),
+        lines.len()
+    );
     let mut diagnostics = Vec::new();
-    let mut prev_prose: Option<&str> = None;
+    let mut prev_prose: Option<String> = None;
 
     for (idx, line) in lines.iter().enumerate() {
         if line.trim().is_empty() {
             prev_prose = None;
             continue;
         }
-        if !prose[idx] {
+        let Some(payload) = payloads.get(idx).and_then(|p| p.as_deref()) else {
             prev_prose = None;
             continue;
-        }
+        };
 
         let line_no = idx + 1;
         let excerpt = excerpt_of(line);
 
-        if splitter.split(line.trim()).len() > 1 {
+        if splitter.split(payload.trim()).len() > 1 {
             diagnostics.push(LineDiagnostic {
                 line: line_no,
                 kind: DiagnosticKind::Fused,
@@ -103,9 +111,9 @@ pub fn collect_diagnostics(
             });
         }
 
-        if let Some(prev) = prev_prose {
+        if let Some(prev) = prev_prose.as_deref() {
             if !ends_clause_or_quote(prev) {
-                if let Some(word) = leading_lowercase_word(line) {
+                if let Some(word) = leading_lowercase_word(payload) {
                     if !WRAP_CONNECTORS.contains(&word.as_str()) {
                         diagnostics.push(LineDiagnostic {
                             line: line_no,
@@ -117,8 +125,8 @@ pub fn collect_diagnostics(
             }
         }
 
-        let width = line.chars().count();
-        if width > long_threshold && has_clause_boundary_hint(line) {
+        let width = payload.chars().count();
+        if width > long_threshold && has_clause_boundary_hint(payload) {
             diagnostics.push(LineDiagnostic {
                 line: line_no,
                 kind: DiagnosticKind::Long,
@@ -126,7 +134,7 @@ pub fn collect_diagnostics(
             });
         }
 
-        prev_prose = Some(line);
+        prev_prose = Some(payload.to_string());
     }
 
     diagnostics
@@ -206,196 +214,6 @@ fn has_clause_boundary_hint(line: &str) -> bool {
         i += len;
     }
     false
-}
-
-fn classify_prose_lines(lines: &[&str], format: Format) -> Vec<bool> {
-    let mut prose = vec![false; lines.len()];
-    let mut in_code = false;
-    let mut rst_code_indent: Option<usize> = None;
-
-    for (idx, line) in lines.iter().enumerate() {
-        if line.trim().is_empty() {
-            continue;
-        }
-        match format {
-            Format::Plaintext => {
-                prose[idx] = true;
-            }
-            Format::Markdown => {
-                if is_md_fence(line) {
-                    in_code = !in_code;
-                    continue;
-                }
-                if in_code || is_md_structure(line) {
-                    continue;
-                }
-                prose[idx] = true;
-            }
-            Format::Org => {
-                if is_org_src_begin(line) {
-                    in_code = true;
-                    continue;
-                }
-                if is_org_src_end(line) {
-                    in_code = false;
-                    continue;
-                }
-                if in_code || is_org_structure(line) {
-                    continue;
-                }
-                prose[idx] = true;
-            }
-            Format::Latex => {
-                if let Some(name) = latex_begin_env(line) {
-                    if is_latex_code_env(name) {
-                        in_code = true;
-                    }
-                    continue;
-                }
-                if let Some(name) = latex_end_env(line) {
-                    if is_latex_code_env(name) {
-                        in_code = false;
-                    }
-                    continue;
-                }
-                if in_code || is_latex_structure(line) {
-                    continue;
-                }
-                prose[idx] = true;
-            }
-            Format::Rst => {
-                if is_rst_code_directive(line) {
-                    rst_code_indent = Some(leading_spaces(line));
-                    continue;
-                }
-                if let Some(indent) = rst_code_indent {
-                    if leading_spaces(line) > indent {
-                        continue;
-                    }
-                    rst_code_indent = None;
-                }
-                if is_rst_structure(line) {
-                    continue;
-                }
-                prose[idx] = true;
-            }
-        }
-    }
-    prose
-}
-
-fn is_md_fence(line: &str) -> bool {
-    let t = line.trim_start();
-    t.starts_with("```") || t.starts_with("~~~")
-}
-
-fn is_md_structure(line: &str) -> bool {
-    let t = line.trim_start();
-    let hashes = t.bytes().take_while(|&b| b == b'#').count();
-    if (1..=6).contains(&hashes) && t.as_bytes().get(hashes) == Some(&b' ') {
-        return true;
-    }
-    let trimmed = line.trim();
-    if trimmed.starts_with('|') && trimmed.ends_with('|') {
-        return true;
-    }
-    if trimmed == "---" || trimmed == "+++" {
-        return true;
-    }
-    let end_trimmed = line.trim_end();
-    let indent = line.len() - line.trim_start().len();
-    let body = end_trimmed.trim_start();
-    if indent <= 3
-        && !body.is_empty()
-        && (body.chars().all(|c| c == '=') || body.chars().all(|c| c == '-'))
-    {
-        return true;
-    }
-    trimmed.starts_with("<!--")
-}
-
-fn is_org_src_begin(line: &str) -> bool {
-    let u = line.trim_start().to_ascii_uppercase();
-    u.starts_with("#+BEGIN_SRC") || u.starts_with("#+BEGIN_EXAMPLE")
-}
-
-fn is_org_src_end(line: &str) -> bool {
-    let u = line.trim_start().to_ascii_uppercase();
-    u.starts_with("#+END_SRC") || u.starts_with("#+END_EXAMPLE")
-}
-
-fn is_org_structure(line: &str) -> bool {
-    let t = line.trim_start();
-    let stars = t.bytes().take_while(|&b| b == b'*').count();
-    if stars > 0 && t.as_bytes().get(stars) == Some(&b' ') {
-        return true;
-    }
-    if t.starts_with("#+") {
-        return true;
-    }
-    let trimmed = line.trim();
-    if trimmed.starts_with(':') && trimmed.ends_with(':') && trimmed.len() > 2 {
-        return true;
-    }
-    trimmed.starts_with('|')
-}
-
-fn latex_begin_env(line: &str) -> Option<&str> {
-    let t = line.trim_start();
-    let rest = t.strip_prefix("\\begin{")?;
-    rest.split('}').next()
-}
-
-fn latex_end_env(line: &str) -> Option<&str> {
-    let t = line.trim_start();
-    let rest = t.strip_prefix("\\end{")?;
-    rest.split('}').next()
-}
-
-fn is_latex_code_env(name: &str) -> bool {
-    matches!(name, "verbatim" | "lstlisting" | "minted")
-}
-
-fn is_latex_structure(line: &str) -> bool {
-    let t = line.trim_start();
-    if t.starts_with('%') {
-        return true;
-    }
-    t.starts_with("\\documentclass")
-        || t.starts_with("\\usepackage")
-        || t.starts_with("\\section")
-        || t.starts_with("\\subsection")
-        || t.starts_with("\\subsubsection")
-        || t.starts_with("\\chapter")
-        || t.starts_with("\\part")
-        || t.starts_with("\\paragraph")
-        || t.starts_with("\\title")
-        || t.starts_with("\\author")
-        || t.starts_with("\\maketitle")
-}
-
-fn is_rst_code_directive(line: &str) -> bool {
-    let t = line.trim_start();
-    t.starts_with(".. code-block::")
-        || t.starts_with(".. sourcecode::")
-        || t.starts_with(".. code::")
-}
-
-fn is_rst_structure(line: &str) -> bool {
-    let t = line.trim_start();
-    if t.starts_with(".. ") {
-        return true;
-    }
-    let body = line.trim();
-    !body.is_empty()
-        && (body.chars().all(|c| c == '=')
-            || body.chars().all(|c| c == '-')
-            || body.chars().all(|c| c == '~')
-            || body.chars().all(|c| c == '`'))
-}
-
-fn leading_spaces(line: &str) -> usize {
-    line.bytes().take_while(|&b| b == b' ').count()
 }
 
 #[cfg(test)]
@@ -579,6 +397,171 @@ mod tests {
         );
     }
 
+    fn assert_no_kind_on(
+        found: &[LineDiagnostic],
+        kind: DiagnosticKind,
+        lines: &[usize],
+        msg: &str,
+    ) {
+        for line in lines {
+            assert!(
+                found.iter().all(|d| !(d.line == *line && d.kind == kind)),
+                "{msg}: line {line} has {kind:?} in {found:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn org_quote_comment_drawer_are_not_prose() {
+        let input = concat!(
+            "#+BEGIN_QUOTE\n",
+            "Quoted hello. Quoted world.\n",
+            "#+END_QUOTE\n",
+            "# Comment hello. Comment world.\n",
+            ":PROPERTIES:\n",
+            ":ID: drawer-value-hello. Drawer world with extra padding so a comma, stays structure.\n",
+            ":END:\n",
+            "\n",
+            "Real prose. Second sentence.\n",
+        );
+        let splitter = UnicodeSentenceSplitter::new();
+        let found = collect_diagnostics(input, Format::Org, &splitter, DEFAULT_LONG_THRESHOLD);
+        assert_no_kind_on(
+            &found,
+            DiagnosticKind::Fused,
+            &[2, 4, 6],
+            "org quote/comment/drawer must not be fused",
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 9 && d.kind == DiagnosticKind::Fused),
+            "real org prose should still be fused, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn markdown_front_matter_and_setext_are_not_prose() {
+        let input = concat!(
+            "---\n",
+            "title: Hello. World in front matter.\n",
+            "---\n",
+            "\n",
+            "Setext Title. Still Title\n",
+            "=========================\n",
+            "\n",
+            "Body one. Body two.\n",
+        );
+        let splitter = UnicodeSentenceSplitter::new();
+        let found = collect_diagnostics(input, Format::Markdown, &splitter, DEFAULT_LONG_THRESHOLD);
+        assert_no_kind_on(
+            &found,
+            DiagnosticKind::Fused,
+            &[2, 5],
+            "front matter and setext title must not be fused",
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 8 && d.kind == DiagnosticKind::Fused),
+            "markdown body should still be fused, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn latex_preamble_and_equation_are_not_prose() {
+        let input = concat!(
+            "\\documentclass{article}\n",
+            "\\usepackage{amsmath}\n",
+            "\\begin{document}\n",
+            "\\begin{equation}\n",
+            "E = mc^2 + a very long expression, with commas, that exceeds one hundred twenty characters easily xxxxxxxxxxxxxxxxx\n",
+            "\\end{equation}\n",
+            "Body one. Body two.\n",
+            "\\end{document}\n",
+        );
+        let splitter = UnicodeSentenceSplitter::new();
+        let found = collect_diagnostics(input, Format::Latex, &splitter, DEFAULT_LONG_THRESHOLD);
+        assert_no_kind_on(
+            &found,
+            DiagnosticKind::Fused,
+            &[1, 2, 3, 4, 5, 6, 8],
+            "latex preamble and equation must not be fused",
+        );
+        assert!(
+            found
+                .iter()
+                .all(|d| !(d.line == 5 && d.kind == DiagnosticKind::Long)),
+            "equation body must not be long, got {found:?}"
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 7 && d.kind == DiagnosticKind::Fused),
+            "latex body should still be fused, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn rst_title_and_note_body_are_not_prose() {
+        let input = concat!(
+            "Title Here. With Period.\n",
+            "========================\n",
+            "\n",
+            ".. note::\n",
+            "\n",
+            "   This is a note. With two sentences.\n",
+            "\n",
+            "Body one. Body two.\n",
+        );
+        let splitter = UnicodeSentenceSplitter::new();
+        let found = collect_diagnostics(input, Format::Rst, &splitter, DEFAULT_LONG_THRESHOLD);
+        assert_no_kind_on(
+            &found,
+            DiagnosticKind::Fused,
+            &[1, 4, 6],
+            "rst title and note body must not be fused",
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 8 && d.kind == DiagnosticKind::Fused),
+            "rst body should still be fused, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn snapper_off_region_is_not_prose() {
+        let input = concat!(
+            "Hello world. This is a test.\n",
+            "snapper:off\n",
+            "Do not. Touch this.\n",
+            "snapper:on\n",
+            "After one. After two.\n",
+        );
+        let splitter = UnicodeSentenceSplitter::new();
+        let found =
+            collect_diagnostics(input, Format::Plaintext, &splitter, DEFAULT_LONG_THRESHOLD);
+        assert_no_kind_on(
+            &found,
+            DiagnosticKind::Fused,
+            &[2, 3, 4],
+            "snapper:off body must not be fused",
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 1 && d.kind == DiagnosticKind::Fused),
+            "prose before snapper:off should be fused, got {found:?}"
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 5 && d.kind == DiagnosticKind::Fused),
+            "prose after snapper:on should be fused, got {found:?}"
+        );
+    }
+
     #[test]
     fn would_reformat_matches_format_identity() {
         let config = FormatConfig {
@@ -587,6 +570,133 @@ mod tests {
         };
         assert!(would_reformat("Hello world. This is a test.\n", &config).unwrap());
         assert!(!would_reformat("Hello world.\nThis is a test.\n", &config).unwrap());
+    }
+
+    fn no_fused(input: &str, format: Format) -> Vec<LineDiagnostic> {
+        let splitter = UnicodeSentenceSplitter::new();
+        collect_diagnostics(input, format, &splitter, DEFAULT_LONG_THRESHOLD)
+    }
+
+    #[test]
+    fn numbered_list_payload_is_item_text() {
+        use crate::parser::source_line_payloads;
+        let md = source_line_payloads("1. Hello world.\n", Format::Markdown);
+        assert_eq!(md[0].as_deref(), Some("Hello world."));
+        let org = source_line_payloads("1. Hello world.\n", Format::Org);
+        assert_eq!(org[0].as_deref(), Some("Hello world."));
+        let tex = source_line_payloads(
+            "\\begin{document}\nSee Fig. 1. % TODO cite\n\\end{document}\n",
+            Format::Latex,
+        );
+        assert_eq!(tex[1].as_deref(), Some("See Fig. 1. "));
+    }
+
+    #[test]
+    fn numbered_list_item_is_not_fused_markdown() {
+        let input = "1. Hello world.\n";
+        let found = no_fused(input, Format::Markdown);
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Fused),
+            "numbered list body is one sentence; marker is not fused, got {found:?}"
+        );
+        let config = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        assert!(
+            !would_reformat(input, &config).unwrap(),
+            "1. Hello world. must be identity under markdown"
+        );
+    }
+
+    #[test]
+    fn numbered_list_item_is_not_fused_org() {
+        let input = "1. Hello world.\n";
+        let found = no_fused(input, Format::Org);
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Fused),
+            "org numbered list body is one sentence; marker is not fused, got {found:?}"
+        );
+        let config = FormatConfig {
+            format: Format::Org,
+            ..Default::default()
+        };
+        assert!(
+            !would_reformat(input, &config).unwrap(),
+            "1. Hello world. must be identity under org"
+        );
+    }
+
+    #[test]
+    fn latex_mid_line_comment_is_not_fused() {
+        let input = "See Fig. 1. % TODO cite\n";
+        let found = no_fused(input, Format::Latex);
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Fused),
+            "latex comment is structure; Fig. 1. is one sentence, got {found:?}"
+        );
+        let config = FormatConfig {
+            format: Format::Latex,
+            ..Default::default()
+        };
+        assert!(
+            !would_reformat(input, &config).unwrap(),
+            "See Fig. 1. % TODO cite must be identity under latex"
+        );
+    }
+
+    #[test]
+    fn latex_body_mid_line_comment_is_not_fused() {
+        let input = "\\begin{document}\nSee Fig. 1. % TODO cite\n\\end{document}\n";
+        let found = no_fused(input, Format::Latex);
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Fused),
+            "body-line comment must not fuse Fig. 1. with TODO, got {found:?}"
+        );
+        let config = FormatConfig {
+            format: Format::Latex,
+            ..Default::default()
+        };
+        assert!(
+            !would_reformat(input, &config).unwrap(),
+            "document with See Fig. 1. % TODO cite must be identity, got {}",
+            crate::format_text(input, &config).unwrap()
+        );
+    }
+
+    #[test]
+    fn parser_line_map_covers_every_source_line() {
+        use crate::parser::source_line_payloads;
+        let cases = [
+            (
+                Format::Org,
+                "#+BEGIN_QUOTE\nQuoted hello. Quoted world.\n#+END_QUOTE\n# Comment.\n:PROPERTIES:\n:ID: x\n:END:\n\nReal. Two.\n",
+            ),
+            (
+                Format::Markdown,
+                "---\ntitle: Hello. World.\n---\n\nSetext Title. Still\n===================\n\nBody. Two.\n",
+            ),
+            (
+                Format::Latex,
+                "\\documentclass{article}\n\\begin{document}\n\\begin{equation}\nE=mc^2\n\\end{equation}\nBody. Two.\n\\end{document}\n",
+            ),
+            (
+                Format::Rst,
+                "Title Here. With Period.\n========================\n\n.. note::\n\n   Note. Two.\n\nBody. Two.\n",
+            ),
+            (
+                Format::Plaintext,
+                "Hello. World.\nsnapper:off\nDo not. Touch.\nsnapper:on\nAfter. Two.\n",
+            ),
+        ];
+        for (fmt, input) in cases {
+            let kinds = source_line_payloads(input, fmt);
+            assert_eq!(
+                kinds.len(),
+                input.lines().count(),
+                "line map length mismatch for {fmt:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/check.rs
+++ b/src/check.rs
@@ -1,0 +1,598 @@
+//! Line-level `--check` diagnostics: fused, wrap, and long.
+//!
+//! These kinds describe the source as written. They share the same sentence
+//! splitter as format so abbreviations do not produce false fused hits.
+
+use serde::Serialize;
+
+use crate::format::Format;
+use crate::sentence::SentenceSplitter;
+use crate::{FormatConfig, format_text};
+
+/// Default character threshold for the advisory `long` kind when `max_width`
+/// is unset (0).
+pub const DEFAULT_LONG_THRESHOLD: usize = 120;
+
+/// Kind of a line-level check diagnostic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum DiagnosticKind {
+    /// Splitter finds more than one sentence on a prose line.
+    Fused,
+    /// Mid-clause continuation: the previous prose line does not end a clause
+    /// and this line starts with a lowercase non-connector word.
+    Wrap,
+    /// Advisory: prose line exceeds the width threshold and has a clause
+    /// boundary where a break could go.
+    Long,
+}
+
+impl DiagnosticKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            DiagnosticKind::Fused => "fused",
+            DiagnosticKind::Wrap => "wrap",
+            DiagnosticKind::Long => "long",
+        }
+    }
+}
+
+/// One 1-indexed diagnostic on a source line.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct LineDiagnostic {
+    pub line: usize,
+    pub kind: DiagnosticKind,
+    pub excerpt: String,
+}
+
+/// Width used for `long`: `max_width` when set, otherwise the configured
+/// default (120 if unset).
+pub fn resolve_long_threshold(max_width: usize, configured: Option<usize>) -> usize {
+    if max_width > 0 {
+        max_width
+    } else {
+        configured.unwrap_or(DEFAULT_LONG_THRESHOLD)
+    }
+}
+
+/// Identity check used by CLI `--check` and MCP `would_reformat`.
+pub fn would_reformat(input: &str, config: &FormatConfig) -> anyhow::Result<bool> {
+    let output = format_text(input, config)?;
+    Ok(output != input)
+}
+
+/// Connector words that start an intentional semantic break, not a wrap.
+const WRAP_CONNECTORS: &[&str] = &[
+    "and", "but", "so", "or", "nor", "yet", "which", "that", "where", "who", "whose", "whom",
+    "when", "while", "because", "although", "though", "unless", "until", "if", "as",
+];
+
+/// Collect fused / wrap / long diagnostics for `input`.
+///
+/// `long_threshold` is character count, already resolved by
+/// [`resolve_long_threshold`].
+pub fn collect_diagnostics(
+    input: &str,
+    format: Format,
+    splitter: &dyn SentenceSplitter,
+    long_threshold: usize,
+) -> Vec<LineDiagnostic> {
+    let lines: Vec<&str> = input.lines().collect();
+    let prose = classify_prose_lines(&lines, format);
+    let mut diagnostics = Vec::new();
+    let mut prev_prose: Option<&str> = None;
+
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            prev_prose = None;
+            continue;
+        }
+        if !prose[idx] {
+            prev_prose = None;
+            continue;
+        }
+
+        let line_no = idx + 1;
+        let excerpt = excerpt_of(line);
+
+        if splitter.split(line.trim()).len() > 1 {
+            diagnostics.push(LineDiagnostic {
+                line: line_no,
+                kind: DiagnosticKind::Fused,
+                excerpt: excerpt.clone(),
+            });
+        }
+
+        if let Some(prev) = prev_prose {
+            if !ends_clause_or_quote(prev) {
+                if let Some(word) = leading_lowercase_word(line) {
+                    if !WRAP_CONNECTORS.contains(&word.as_str()) {
+                        diagnostics.push(LineDiagnostic {
+                            line: line_no,
+                            kind: DiagnosticKind::Wrap,
+                            excerpt: excerpt.clone(),
+                        });
+                    }
+                }
+            }
+        }
+
+        let width = line.chars().count();
+        if width > long_threshold && has_clause_boundary_hint(line) {
+            diagnostics.push(LineDiagnostic {
+                line: line_no,
+                kind: DiagnosticKind::Long,
+                excerpt,
+            });
+        }
+
+        prev_prose = Some(line);
+    }
+
+    diagnostics
+}
+
+fn excerpt_of(line: &str) -> String {
+    const MAX: usize = 200;
+    let trimmed = line.trim();
+    if trimmed.chars().count() <= MAX {
+        return trimmed.to_string();
+    }
+    let mut out: String = trimmed.chars().take(MAX).collect();
+    out.push_str("...");
+    out
+}
+
+fn ends_clause_or_quote(line: &str) -> bool {
+    let trimmed = line.trim_end();
+    if trimmed.is_empty() {
+        return false;
+    }
+    if trimmed.ends_with('\u{2014}') || trimmed.ends_with("--") {
+        return true;
+    }
+    matches!(
+        trimmed.chars().last(),
+        Some(
+            '.' | '!'
+                | '?'
+                | ';'
+                | ':'
+                | ','
+                | '"'
+                | '\''
+                | '\u{201d}'
+                | '\u{2019}'
+                | ')'
+                | ']'
+                | '}'
+        )
+    )
+}
+
+fn leading_lowercase_word(line: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    let mut chars = trimmed.chars();
+    let first = chars.next()?;
+    if !first.is_lowercase() {
+        return None;
+    }
+    let mut word = String::new();
+    word.push(first);
+    for c in chars {
+        if c.is_alphabetic() || c == '\'' {
+            word.push(c);
+        } else {
+            break;
+        }
+    }
+    Some(word)
+}
+
+fn has_clause_boundary_hint(line: &str) -> bool {
+    if line.contains('\u{2014}') || line.contains("--") {
+        return true;
+    }
+    let mut i = 0;
+    while i < line.len() {
+        let c = line[i..].chars().next().unwrap();
+        let len = c.len_utf8();
+        if matches!(c, ',' | ';' | ':' | '.' | '!' | '?') {
+            let rest = &line[i + len..];
+            if rest.starts_with(|n: char| n.is_whitespace()) {
+                return true;
+            }
+        }
+        i += len;
+    }
+    false
+}
+
+fn classify_prose_lines(lines: &[&str], format: Format) -> Vec<bool> {
+    let mut prose = vec![false; lines.len()];
+    let mut in_code = false;
+    let mut rst_code_indent: Option<usize> = None;
+
+    for (idx, line) in lines.iter().enumerate() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        match format {
+            Format::Plaintext => {
+                prose[idx] = true;
+            }
+            Format::Markdown => {
+                if is_md_fence(line) {
+                    in_code = !in_code;
+                    continue;
+                }
+                if in_code || is_md_structure(line) {
+                    continue;
+                }
+                prose[idx] = true;
+            }
+            Format::Org => {
+                if is_org_src_begin(line) {
+                    in_code = true;
+                    continue;
+                }
+                if is_org_src_end(line) {
+                    in_code = false;
+                    continue;
+                }
+                if in_code || is_org_structure(line) {
+                    continue;
+                }
+                prose[idx] = true;
+            }
+            Format::Latex => {
+                if let Some(name) = latex_begin_env(line) {
+                    if is_latex_code_env(name) {
+                        in_code = true;
+                    }
+                    continue;
+                }
+                if let Some(name) = latex_end_env(line) {
+                    if is_latex_code_env(name) {
+                        in_code = false;
+                    }
+                    continue;
+                }
+                if in_code || is_latex_structure(line) {
+                    continue;
+                }
+                prose[idx] = true;
+            }
+            Format::Rst => {
+                if is_rst_code_directive(line) {
+                    rst_code_indent = Some(leading_spaces(line));
+                    continue;
+                }
+                if let Some(indent) = rst_code_indent {
+                    if leading_spaces(line) > indent {
+                        continue;
+                    }
+                    rst_code_indent = None;
+                }
+                if is_rst_structure(line) {
+                    continue;
+                }
+                prose[idx] = true;
+            }
+        }
+    }
+    prose
+}
+
+fn is_md_fence(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with("```") || t.starts_with("~~~")
+}
+
+fn is_md_structure(line: &str) -> bool {
+    let t = line.trim_start();
+    let hashes = t.bytes().take_while(|&b| b == b'#').count();
+    if (1..=6).contains(&hashes) && t.as_bytes().get(hashes) == Some(&b' ') {
+        return true;
+    }
+    let trimmed = line.trim();
+    if trimmed.starts_with('|') && trimmed.ends_with('|') {
+        return true;
+    }
+    if trimmed == "---" || trimmed == "+++" {
+        return true;
+    }
+    let end_trimmed = line.trim_end();
+    let indent = line.len() - line.trim_start().len();
+    let body = end_trimmed.trim_start();
+    if indent <= 3
+        && !body.is_empty()
+        && (body.chars().all(|c| c == '=') || body.chars().all(|c| c == '-'))
+    {
+        return true;
+    }
+    trimmed.starts_with("<!--")
+}
+
+fn is_org_src_begin(line: &str) -> bool {
+    let u = line.trim_start().to_ascii_uppercase();
+    u.starts_with("#+BEGIN_SRC") || u.starts_with("#+BEGIN_EXAMPLE")
+}
+
+fn is_org_src_end(line: &str) -> bool {
+    let u = line.trim_start().to_ascii_uppercase();
+    u.starts_with("#+END_SRC") || u.starts_with("#+END_EXAMPLE")
+}
+
+fn is_org_structure(line: &str) -> bool {
+    let t = line.trim_start();
+    let stars = t.bytes().take_while(|&b| b == b'*').count();
+    if stars > 0 && t.as_bytes().get(stars) == Some(&b' ') {
+        return true;
+    }
+    if t.starts_with("#+") {
+        return true;
+    }
+    let trimmed = line.trim();
+    if trimmed.starts_with(':') && trimmed.ends_with(':') && trimmed.len() > 2 {
+        return true;
+    }
+    trimmed.starts_with('|')
+}
+
+fn latex_begin_env(line: &str) -> Option<&str> {
+    let t = line.trim_start();
+    let rest = t.strip_prefix("\\begin{")?;
+    rest.split('}').next()
+}
+
+fn latex_end_env(line: &str) -> Option<&str> {
+    let t = line.trim_start();
+    let rest = t.strip_prefix("\\end{")?;
+    rest.split('}').next()
+}
+
+fn is_latex_code_env(name: &str) -> bool {
+    matches!(name, "verbatim" | "lstlisting" | "minted")
+}
+
+fn is_latex_structure(line: &str) -> bool {
+    let t = line.trim_start();
+    if t.starts_with('%') {
+        return true;
+    }
+    t.starts_with("\\documentclass")
+        || t.starts_with("\\usepackage")
+        || t.starts_with("\\section")
+        || t.starts_with("\\subsection")
+        || t.starts_with("\\subsubsection")
+        || t.starts_with("\\chapter")
+        || t.starts_with("\\part")
+        || t.starts_with("\\paragraph")
+        || t.starts_with("\\title")
+        || t.starts_with("\\author")
+        || t.starts_with("\\maketitle")
+}
+
+fn is_rst_code_directive(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with(".. code-block::")
+        || t.starts_with(".. sourcecode::")
+        || t.starts_with(".. code::")
+}
+
+fn is_rst_structure(line: &str) -> bool {
+    let t = line.trim_start();
+    if t.starts_with(".. ") {
+        return true;
+    }
+    let body = line.trim();
+    !body.is_empty()
+        && (body.chars().all(|c| c == '=')
+            || body.chars().all(|c| c == '-')
+            || body.chars().all(|c| c == '~')
+            || body.chars().all(|c| c == '`'))
+}
+
+fn leading_spaces(line: &str) -> usize {
+    line.bytes().take_while(|&b| b == b' ').count()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sentence::unicode::UnicodeSentenceSplitter;
+
+    fn diags(input: &str) -> Vec<LineDiagnostic> {
+        let splitter = UnicodeSentenceSplitter::new();
+        collect_diagnostics(input, Format::Plaintext, &splitter, DEFAULT_LONG_THRESHOLD)
+    }
+
+    fn kinds_on(diags: &[LineDiagnostic], line: usize) -> Vec<DiagnosticKind> {
+        diags
+            .iter()
+            .filter(|d| d.line == line)
+            .map(|d| d.kind)
+            .collect()
+    }
+
+    #[test]
+    fn fused_two_sentences_on_one_line() {
+        let found = diags("Hello world. This is a test.\n");
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 1 && d.kind == DiagnosticKind::Fused),
+            "expected fused on line 1, got {found:?}"
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.kind == DiagnosticKind::Fused && d.excerpt.contains("Hello world")),
+            "fused excerpt should carry the source line, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn fused_abbreviation_is_not_a_sentence_break() {
+        let found = diags("See Fig. 3 for details.\n");
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Fused),
+            "Fig. must not produce fused, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_mid_clause_continuation() {
+        let found = diags("The experiment ran for several\nweeks using the usual protocol.\n");
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 2 && d.kind == DiagnosticKind::Wrap),
+            "expected wrap on the continuation line, got {found:?}"
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.kind == DiagnosticKind::Wrap && d.excerpt.contains("weeks")),
+            "wrap excerpt should be the continuation line, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_skips_connector_and() {
+        let found = diags("The experiment ran for several weeks\nand used the usual protocol.\n");
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Wrap),
+            "connector-led and is not wrap, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_skips_connector_which() {
+        let found = diags("The results were significant\nwhich surprised the team.\n");
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Wrap),
+            "connector-led which is not wrap, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_skips_after_comma() {
+        let found = diags("The experiment ran for several weeks,\nusing the usual protocol.\n");
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Wrap),
+            "a comma-ended previous line is a clause break, not wrap, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_skips_after_em_dash() {
+        let found =
+            diags("The experiment ran for several weeks \u{2014}\nusing the usual protocol.\n");
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Wrap),
+            "an em-dash-ended previous line is not wrap, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_skips_after_closing_quote() {
+        let found = diags("He said \"yes\"\nwithout any pause.\n");
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Wrap),
+            "a closing-quote-ended previous line is not wrap, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn wrap_skips_uppercase_start() {
+        let found = diags(
+            "The experiment ran for several weeks\nUsing a different protocol is possible.\n",
+        );
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Wrap),
+            "uppercase start is not a mid-clause wrap, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn long_advisory_needs_clause_boundary() {
+        let long_with_comma = format!(
+            "The quick brown fox jumps over the lazy dog, then continues running across a very long meadow without pausing for breath at all today.\n"
+        );
+        assert!(
+            long_with_comma.trim_end().chars().count() > DEFAULT_LONG_THRESHOLD,
+            "fixture must exceed the default long threshold"
+        );
+        let found = diags(&long_with_comma);
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 1 && d.kind == DiagnosticKind::Long),
+            "long line with a comma should be long, got {found:?}"
+        );
+
+        let no_hint = format!("{}\n", "A".repeat(DEFAULT_LONG_THRESHOLD + 10));
+        let found = diags(&no_hint);
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Long),
+            "a long line with no clause-boundary hint is not long, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn long_uses_resolved_threshold() {
+        let splitter = UnicodeSentenceSplitter::new();
+        let line = "Short clause, still short.\n";
+        let found = collect_diagnostics(line, Format::Plaintext, &splitter, 5);
+        assert!(
+            found.iter().any(|d| d.kind == DiagnosticKind::Long),
+            "threshold 5 must flag a comma-bearing line, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn fused_and_long_can_share_a_line() {
+        let line = "Hello world. This is a test that goes on and on, with extra words to exceed the default long threshold of one hundred twenty characters easily.\n";
+        assert!(line.trim_end().chars().count() > DEFAULT_LONG_THRESHOLD);
+        let found = diags(line);
+        let kinds = kinds_on(&found, 1);
+        assert!(
+            kinds.contains(&DiagnosticKind::Fused),
+            "expected fused, got {found:?}"
+        );
+        assert!(
+            kinds.contains(&DiagnosticKind::Long),
+            "expected long, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn structure_and_code_are_not_prose() {
+        let md = "# Title. Still a heading.\n\n```\nHello. World.\n```\n\nBody sentence.\n";
+        let splitter = UnicodeSentenceSplitter::new();
+        let found = collect_diagnostics(md, Format::Markdown, &splitter, DEFAULT_LONG_THRESHOLD);
+        assert!(
+            found.iter().all(|d| d.kind != DiagnosticKind::Fused),
+            "headings and fenced code must not produce fused, got {found:?}"
+        );
+    }
+
+    #[test]
+    fn would_reformat_matches_format_identity() {
+        let config = FormatConfig {
+            format: Format::Plaintext,
+            ..Default::default()
+        };
+        assert!(would_reformat("Hello world. This is a test.\n", &config).unwrap());
+        assert!(!would_reformat("Hello world.\nThis is a test.\n", &config).unwrap());
+    }
+
+    #[test]
+    fn resolve_long_threshold_prefers_max_width() {
+        assert_eq!(resolve_long_threshold(80, Some(200)), 80);
+        assert_eq!(resolve_long_threshold(0, Some(200)), 200);
+        assert_eq!(resolve_long_threshold(0, None), DEFAULT_LONG_THRESHOLD);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -131,6 +131,12 @@ pub struct Cli {
     #[arg(long, default_value = "text")]
     pub output_format: OutputFormat,
 
+    /// Treat advisory `long` diagnostics as `--check` failures.
+    ///
+    /// `long` never fails the check on its own unless this flag is set.
+    #[arg(long, default_value_t = false)]
+    pub strict_long: bool,
+
     /// Pipe each code block's body through the per-language formatter
     /// configured under `[code.<lang>.formatter]` in `.snapperrc.toml`.
     /// The formatter runs after the in-block comment reflow. Missing

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,6 +71,9 @@ pub struct ProjectConfig {
     pub default_format: Option<String>,
     /// Default max width.
     pub max_width: Option<usize>,
+    /// Character threshold for advisory `long` diagnostics when `max_width` is
+    /// unset. Defaults to 120 when omitted.
+    pub long_threshold: Option<usize>,
     /// Prefer soft breaks after independent-clause punctuation when wrapping.
     pub clause_breaks: Option<bool>,
     /// Default language for abbreviation sets.
@@ -205,8 +208,15 @@ lang = "de"
         assert_eq!(config.ignore_patterns, vec!["*.bib", "*.cls"]);
         assert_eq!(config.default_format, Some("org".to_string()));
         assert_eq!(config.max_width, Some(80));
+        assert_eq!(config.long_threshold, None);
         assert_eq!(config.clause_breaks, Some(true));
         assert_eq!(config.lang, Some("de".to_string()));
+    }
+
+    #[test]
+    fn parse_long_threshold() {
+        let config = ProjectConfig::parse("long_threshold = 100\n").unwrap();
+        assert_eq!(config.long_threshold, Some(100));
     }
 
     #[test]

--- a/src/init.rs
+++ b/src/init.rs
@@ -62,6 +62,9 @@ format = "{default_format}"
 # Maximum line width (0 = unlimited)
 max_width = 0
 
+# Advisory long-line threshold when max_width is 0 (default 120)
+# long_threshold = 120
+
 # Per-language code-block reflow and formatter delegation.
 # Each language entry may set any combination of:
 #   line_comment   -- marker for single-line comments

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@
 //! ```
 
 pub mod abbreviations;
+pub mod check;
 #[cfg(feature = "cli")]
 pub mod cli;
 pub mod code_block;

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -6,9 +6,10 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer, LspService, Server};
 
+use crate::check::{DiagnosticKind, collect_diagnostics, resolve_long_threshold};
 use crate::config::ProjectConfig;
 use crate::format::Format;
-use crate::{FormatConfig, format_text};
+use crate::{FormatConfig, build_splitter, format_text};
 
 pub struct SnapperLsp {
     client: Client,
@@ -81,39 +82,40 @@ impl SnapperLsp {
 
     fn compute_diagnostics(&self, uri: &Url) -> Vec<Diagnostic> {
         let docs = self.documents.lock().expect("document store poisoned");
-        let Some((text, _)) = docs.get(uri) else {
+        let Some((text, format)) = docs.get(uri) else {
             return vec![];
         };
+        let config = self.make_config(*format);
+        let Ok(splitter) = build_splitter(&config) else {
+            return vec![];
+        };
+        let threshold = {
+            let project = self.project_config.lock().expect("config lock poisoned");
+            resolve_long_threshold(config.max_width, project.long_threshold)
+        };
 
-        let mut diagnostics = Vec::new();
-        // Flag lines that contain multiple sentences (period + space + capital)
-        for (i, line) in text.lines().enumerate() {
-            let chars: Vec<char> = line.chars().collect();
-            if chars.is_empty() {
-                continue;
-            }
-
-            // Highlight the exact space character where a split should occur
-            for j in 1..chars.len().saturating_sub(1) {
-                if (chars[j - 1] == '.' || chars[j - 1] == '!' || chars[j - 1] == '?')
-                    && chars[j] == ' '
-                    && chars.get(j + 1).is_some_and(|c| c.is_uppercase())
-                {
-                    diagnostics.push(Diagnostic {
-                        range: Range {
-                            start: Position::new(i as u32, j as u32),
-                            end: Position::new(i as u32, (j + 1) as u32),
-                        },
-                        severity: Some(DiagnosticSeverity::HINT),
-                        source: Some("snapper".to_string()),
-                        message: "Semantic line break recommended here. Consider running snapper."
-                            .to_string(),
-                        ..Default::default()
-                    });
+        collect_diagnostics(text, *format, splitter.as_ref(), threshold)
+            .into_iter()
+            .map(|d| {
+                let line = d.line.saturating_sub(1) as u32;
+                let end_col = d.excerpt.chars().count() as u32;
+                let severity = match d.kind {
+                    DiagnosticKind::Long => DiagnosticSeverity::INFORMATION,
+                    DiagnosticKind::Fused | DiagnosticKind::Wrap => DiagnosticSeverity::WARNING,
+                };
+                Diagnostic {
+                    range: Range {
+                        start: Position::new(line, 0),
+                        end: Position::new(line, end_col),
+                    },
+                    severity: Some(severity),
+                    source: Some("snapper".to_string()),
+                    code: Some(NumberOrString::String(d.kind.as_str().to_string())),
+                    message: format!("{}: {}", d.kind.as_str(), d.excerpt),
+                    ..Default::default()
                 }
-            }
-        }
-        diagnostics
+            })
+            .collect()
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use rayon::prelude::*;
 
+use snapper_fmt::check::{DiagnosticKind, collect_diagnostics, resolve_long_threshold};
 use snapper_fmt::cli::{Cli, ColorWhen, Commands, OutputFormat, parse_range};
 use snapper_fmt::config::ProjectConfig;
 use snapper_fmt::diff::ColorMode;
@@ -186,6 +187,7 @@ fn run() -> Result<()> {
         };
 
         let mut any_changed = false;
+        let mut check_failed = false;
         let mut check_results: Vec<CheckResult> = Vec::new();
 
         let color = resolve_color(cli.color, false);
@@ -196,16 +198,49 @@ fn run() -> Result<()> {
                     any_changed = true;
                 }
             } else if cli.check {
-                if output != input {
+                let path = Path::new(path_str);
+                let format = resolve_format(
+                    cli.format.map(Format::from_arg),
+                    Some(path),
+                    &project_config,
+                )?;
+                let config = build_format_config(&cli, &project_config, format, Some(path));
+                let key = SplitterKey::from_config(&config);
+                let splitter = cache
+                    .get(&key)
+                    .ok_or_else(|| anyhow::anyhow!("splitter cache miss for {path_str}"))?;
+                let threshold =
+                    resolve_long_threshold(config.max_width, project_config.long_threshold);
+                let diagnostics = collect_diagnostics(input, format, splitter.as_ref(), threshold);
+                let would = output != input;
+                let long_fail =
+                    cli.strict_long && diagnostics.iter().any(|d| d.kind == DiagnosticKind::Long);
+                if would || !diagnostics.is_empty() {
                     match cli.output_format {
-                        OutputFormat::Text => eprintln!("would reformat: {path_str}"),
+                        OutputFormat::Text => {
+                            if would {
+                                eprintln!("would reformat: {path_str}");
+                            }
+                            for d in &diagnostics {
+                                eprintln!(
+                                    "{path_str}:{}:{}: {}",
+                                    d.line,
+                                    d.kind.as_str(),
+                                    d.excerpt
+                                );
+                            }
+                        }
                         _ => check_results.push(CheckResult {
                             file: path_str.clone(),
                             original_lines: input.lines().count(),
                             formatted_lines: output.lines().count(),
+                            would_reformat: would,
+                            diagnostics,
                         }),
                     }
-                    any_changed = true;
+                }
+                if would || long_fail {
+                    check_failed = true;
                 }
             } else if cli.in_place {
                 if output != input {
@@ -220,8 +255,8 @@ fn run() -> Result<()> {
             }
         }
 
-        // Structured output for check mode
-        if cli.check && !check_results.is_empty() {
+        // Structured output for check mode (empty array/run is still valid JSON).
+        if cli.check {
             match cli.output_format {
                 OutputFormat::Json => output_json(&check_results),
                 OutputFormat::Sarif => output_sarif(&check_results),
@@ -229,7 +264,10 @@ fn run() -> Result<()> {
             }
         }
 
-        if (cli.check || cli.diff) && any_changed {
+        if cli.diff && any_changed {
+            process::exit(1);
+        }
+        if cli.check && check_failed {
             process::exit(1);
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,9 +135,52 @@ fn run() -> Result<()> {
             format_text(&input, &config)?
         };
 
-        if cli.diff {
+        if cli.check {
+            let splitter = build_splitter(&config).context("failed to build sentence splitter")?;
+            let threshold = resolve_long_threshold(config.max_width, project_config.long_threshold);
+            let diagnostics = collect_diagnostics(&input, format, splitter.as_ref(), threshold);
+            let would = output != input;
+            let long_fail =
+                cli.strict_long && diagnostics.iter().any(|d| d.kind == DiagnosticKind::Long);
+            let file = cli
+                .stdin_filepath
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "<stdin>".to_string());
+            let check_results = if would || !diagnostics.is_empty() {
+                vec![CheckResult {
+                    file,
+                    original_lines: input.lines().count(),
+                    formatted_lines: output.lines().count(),
+                    would_reformat: would,
+                    diagnostics,
+                }]
+            } else {
+                Vec::new()
+            };
+            match cli.output_format {
+                OutputFormat::Json => output_json(&check_results),
+                OutputFormat::Sarif => output_sarif(&check_results),
+                OutputFormat::Text => {
+                    if would {
+                        eprintln!("would reformat: <stdin>");
+                    }
+                    if let Some(r) = check_results.first() {
+                        for d in &r.diagnostics {
+                            eprintln!("<stdin>:{}:{}: {}", d.line, d.kind.as_str(), d.excerpt);
+                        }
+                    }
+                }
+            }
+            if would || long_fail {
+                process::exit(1);
+            }
+        } else if cli.diff {
             let color = resolve_color(cli.color, false);
             snapper_fmt::diff::print_diff("<stdin>", &input, &output, color);
+            if output != input {
+                process::exit(1);
+            }
         } else if let Some(ref path) = cli.output {
             fs::write(path, &output)
                 .with_context(|| format!("failed to write {}", path.display()))?;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,7 +1,7 @@
 //! MCP (Model Context Protocol) server for snapper.
 //!
-//! Exposes formatting tools to AI assistants (Claude Desktop/Code, etc.)
-//! via the standard MCP protocol on stdin/stdout.
+//! Exposes formatting tools to MCP clients via the standard MCP protocol
+//! on stdin/stdout.
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
@@ -9,8 +9,8 @@ use rmcp::{Json, ServerHandler, ServiceExt, tool, tool_router};
 use serde::{Deserialize, Serialize};
 
 use crate::FormatConfig;
+use crate::check::{DiagnosticKind, collect_diagnostics, resolve_long_threshold, would_reformat};
 use crate::format::Format;
-use crate::sentence::SentenceSplitter;
 
 // -- Tool parameter types --
 
@@ -42,6 +42,9 @@ pub struct CheckFormattingParams {
     /// Document format: "org", "latex", "markdown", "rst", or "plaintext".
     #[serde(default = "default_format")]
     pub format: String,
+    /// Maximum line width (0 = unlimited). Used as the `long` threshold when set.
+    #[serde(default)]
+    pub max_width: usize,
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
@@ -80,11 +83,25 @@ pub struct DetectFormatResult {
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
+pub struct LineDiagnosticDto {
+    /// 1-indexed source line.
+    pub line: usize,
+    /// `fused`, `wrap`, or `long`.
+    pub kind: String,
+    /// Source line excerpt.
+    pub excerpt: String,
+}
+
+#[derive(Debug, Serialize, schemars::JsonSchema)]
 pub struct CheckFormattingResult {
-    /// Line numbers (1-indexed) containing multiple sentences.
+    /// Line numbers (1-indexed) containing multiple sentences (fused).
     pub violations: Vec<usize>,
-    /// Whether the text passes the formatting check.
+    /// Whether the text matches formatted output (same as CLI `--check` without `--strict-long`).
     pub passed: bool,
+    /// True when `format_text` would change the input. Identical to CLI `--check`.
+    pub would_reformat: bool,
+    /// Line-level fused / wrap / long diagnostics.
+    pub diagnostics: Vec<LineDiagnosticDto>,
 }
 
 #[derive(Debug, Serialize, schemars::JsonSchema)]
@@ -142,18 +159,37 @@ impl SnapperMcpServer {
 
     #[tool(
         name = "check_formatting",
-        description = "Check text for semantic line break violations. Returns line numbers where multiple sentences appear on a single line."
+        description = "Check text for semantic line break violations. Returns would_reformat (identical to CLI --check), line diagnostics (fused/wrap/long), and fused line numbers."
     )]
     fn check_formatting(
         &self,
         Parameters(params): Parameters<CheckFormattingParams>,
     ) -> Json<CheckFormattingResult> {
         let format = parse_format(&params.format);
-        let config = make_config(format, 0, vec![]);
+        let config = make_config(format, params.max_width, vec![]);
         let splitter = crate::build_splitter(&config).unwrap();
-        let violations = find_violations(&params.text, splitter.as_ref());
-        let passed = violations.is_empty();
-        Json(CheckFormattingResult { violations, passed })
+        let would = would_reformat(&params.text, &config).unwrap_or(true);
+        let threshold = resolve_long_threshold(params.max_width, None);
+        let diagnostics = collect_diagnostics(&params.text, format, splitter.as_ref(), threshold);
+        let violations: Vec<usize> = diagnostics
+            .iter()
+            .filter(|d| d.kind == DiagnosticKind::Fused)
+            .map(|d| d.line)
+            .collect();
+        let dto = diagnostics
+            .into_iter()
+            .map(|d| LineDiagnosticDto {
+                line: d.line,
+                kind: d.kind.as_str().to_string(),
+                excerpt: d.excerpt,
+            })
+            .collect();
+        Json(CheckFormattingResult {
+            violations,
+            passed: !would,
+            would_reformat: would,
+            diagnostics: dto,
+        })
     }
 
     #[tool(
@@ -222,22 +258,6 @@ fn format_name(f: Format) -> String {
         Format::Plaintext => "plaintext",
     }
     .to_string()
-}
-
-/// Find lines containing multiple sentences.
-fn find_violations(input: &str, splitter: &dyn SentenceSplitter) -> Vec<usize> {
-    let mut violations = Vec::new();
-    for (idx, line) in input.lines().enumerate() {
-        let trimmed = line.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        let sentences = splitter.split(trimmed);
-        if sentences.len() > 1 {
-            violations.push(idx + 1);
-        }
-    }
-    violations
 }
 
 /// Run the MCP server on stdin/stdout.

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,10 +1,14 @@
 use serde_json::{Value, json};
 
-/// Summary of a file that needs reformatting, used by `--check` output modes.
+use crate::check::{DiagnosticKind, LineDiagnostic};
+
+/// Summary of a file inspected by `--check`, including line diagnostics.
 pub struct CheckResult {
     pub file: String,
     pub original_lines: usize,
     pub formatted_lines: usize,
+    pub would_reformat: bool,
+    pub diagnostics: Vec<LineDiagnostic>,
 }
 
 /// Output check results in JSON format.
@@ -16,6 +20,8 @@ pub fn output_json(results: &[CheckResult]) {
                 "file": r.file,
                 "original_lines": r.original_lines,
                 "formatted_lines": r.formatted_lines,
+                "would_reformat": r.would_reformat,
+                "diagnostics": r.diagnostics,
             })
         })
         .collect();
@@ -24,10 +30,10 @@ pub fn output_json(results: &[CheckResult]) {
 
 /// Output check results in SARIF v2.1.0 format for GitHub Code Scanning.
 pub fn output_sarif(results: &[CheckResult]) {
-    let sarif_results: Vec<Value> = results
-        .iter()
-        .map(|r| {
-            json!({
+    let mut sarif_results: Vec<Value> = Vec::new();
+    for r in results {
+        if r.would_reformat {
+            sarif_results.push(json!({
                 "ruleId": "snapper/needs-reformat",
                 "level": "warning",
                 "message": {
@@ -43,9 +49,36 @@ pub fn output_sarif(results: &[CheckResult]) {
                         }
                     }
                 }]
-            })
-        })
-        .collect();
+            }));
+        }
+        for d in &r.diagnostics {
+            let (rule_id, level) = match d.kind {
+                DiagnosticKind::Fused => ("snapper/fused", "warning"),
+                DiagnosticKind::Wrap => ("snapper/wrap", "warning"),
+                DiagnosticKind::Long => ("snapper/long", "note"),
+            };
+            sarif_results.push(json!({
+                "ruleId": rule_id,
+                "level": level,
+                "message": {
+                    "text": format!("{}: {}", d.kind.as_str(), d.excerpt)
+                },
+                "locations": [{
+                    "physicalLocation": {
+                        "artifactLocation": {
+                            "uri": r.file
+                        },
+                        "region": {
+                            "startLine": d.line,
+                            "snippet": {
+                                "text": d.excerpt
+                            }
+                        }
+                    }
+                }]
+            }));
+        }
+    }
 
     let sarif = json!({
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
@@ -55,12 +88,32 @@ pub fn output_sarif(results: &[CheckResult]) {
                 "driver": {
                     "name": "snapper",
                     "informationUri": "https://snapper.turtletech.us",
-                    "rules": [{
-                        "id": "snapper/needs-reformat",
-                        "shortDescription": {
-                            "text": "File needs semantic line break formatting"
+                    "rules": [
+                        {
+                            "id": "snapper/needs-reformat",
+                            "shortDescription": {
+                                "text": "File needs semantic line break formatting"
+                            }
+                        },
+                        {
+                            "id": "snapper/fused",
+                            "shortDescription": {
+                                "text": "Prose line contains more than one sentence"
+                            }
+                        },
+                        {
+                            "id": "snapper/wrap",
+                            "shortDescription": {
+                                "text": "Prose line continues a clause from the previous line"
+                            }
+                        },
+                        {
+                            "id": "snapper/long",
+                            "shortDescription": {
+                                "text": "Prose line exceeds the width threshold at a clause boundary"
+                            }
                         }
-                    }]
+                    ]
                 }
             },
             "results": sarif_results

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,6 +1,39 @@
+use std::path::{Path, PathBuf};
+
 use serde_json::{Value, json};
 
 use crate::check::{DiagnosticKind, LineDiagnostic};
+
+/// SARIF artifact URI: repo-relative when `path` is under `cwd`, else `file:`.
+pub fn sarif_artifact_uri(path: &str, cwd: Option<&Path>) -> String {
+    if path == "<stdin>" || path == "stdin" {
+        return "stdin".to_string();
+    }
+    let given = Path::new(path);
+    if let Some(cwd) = cwd {
+        if let Ok(rel) = given.strip_prefix(cwd) {
+            return rel.to_string_lossy().replace('\\', "/");
+        }
+        if given.is_relative() {
+            return given.to_string_lossy().replace('\\', "/");
+        }
+        if let (Ok(abs), Ok(cwd_abs)) = (given.canonicalize(), cwd.canonicalize()) {
+            if let Ok(rel) = abs.strip_prefix(cwd_abs) {
+                return rel.to_string_lossy().replace('\\', "/");
+            }
+        }
+    }
+    if given.is_relative() {
+        return given.to_string_lossy().replace('\\', "/");
+    }
+    let abs = given.canonicalize().unwrap_or_else(|_| PathBuf::from(path));
+    format!("file://{}", abs.display())
+}
+
+fn file_uri(path: &Path) -> String {
+    let abs = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+    format!("file://{}", abs.display())
+}
 
 /// Summary of a file inspected by `--check`, including line diagnostics.
 pub struct CheckResult {
@@ -30,8 +63,11 @@ pub fn output_json(results: &[CheckResult]) {
 
 /// Output check results in SARIF v2.1.0 format for GitHub Code Scanning.
 pub fn output_sarif(results: &[CheckResult]) {
+    let cwd = std::env::current_dir().ok();
+    let cwd_ref = cwd.as_deref();
     let mut sarif_results: Vec<Value> = Vec::new();
     for r in results {
+        let uri = sarif_artifact_uri(&r.file, cwd_ref);
         if r.would_reformat {
             sarif_results.push(json!({
                 "ruleId": "snapper/needs-reformat",
@@ -45,7 +81,7 @@ pub fn output_sarif(results: &[CheckResult]) {
                 "locations": [{
                     "physicalLocation": {
                         "artifactLocation": {
-                            "uri": r.file
+                            "uri": uri.clone()
                         }
                     }
                 }]
@@ -66,7 +102,7 @@ pub fn output_sarif(results: &[CheckResult]) {
                 "locations": [{
                     "physicalLocation": {
                         "artifactLocation": {
-                            "uri": r.file
+                            "uri": uri.clone()
                         },
                         "region": {
                             "startLine": d.line,
@@ -79,6 +115,8 @@ pub fn output_sarif(results: &[CheckResult]) {
             }));
         }
     }
+
+    let working_directory = cwd.as_ref().map(|p| json!({ "uri": file_uri(p) }));
 
     let sarif = json!({
         "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json",
@@ -116,6 +154,10 @@ pub fn output_sarif(results: &[CheckResult]) {
                     ]
                 }
             },
+            "invocations": [{
+                "executionSuccessful": true,
+                "workingDirectory": working_directory
+            }],
             "results": sarif_results
         }]
     });
@@ -124,4 +166,23 @@ pub fn output_sarif(results: &[CheckResult]) {
         "{}",
         serde_json::to_string_pretty(&sarif).unwrap_or_default()
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+
+    #[test]
+    fn relative_path_stays_relative() {
+        assert_eq!(
+            sarif_artifact_uri("fused.txt", Some(Path::new("/tmp/work"))),
+            "fused.txt"
+        );
+    }
+
+    #[test]
+    fn stdin_uri_is_literal() {
+        assert_eq!(sarif_artifact_uri("<stdin>", None), "stdin");
+    }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -48,6 +48,44 @@ pub trait FormatParser {
     }
 }
 
+/// Per-source-line prose payload from the same `parse_full` walk format uses.
+///
+/// `None` means the line has no prose rewrite range (structure, code, blank,
+/// pragma-off). `Some` is the original-source slice the parser sent to the
+/// splitter for that line (list/quote body, mid-line comment prefix).
+pub fn source_line_payloads(input: &str, format: crate::format::Format) -> Vec<Option<String>> {
+    let spanned = parser_for_format(format).parse_full(input);
+    iter_lines(input)
+        .into_iter()
+        .map(|line| line_prose_payload(input, line, &spanned))
+        .collect()
+}
+
+fn line_prose_payload(input: &str, line: Line<'_>, spanned: &[SpannedRegion]) -> Option<String> {
+    let lo = line.start;
+    let hi = line.start + line.text.len();
+    let mut out = String::new();
+    for sr in spanned {
+        if !matches!(sr.region, Region::Prose(_)) {
+            continue;
+        }
+        let Some(origin) = sr.origin else {
+            continue;
+        };
+        let span = origin.whole();
+        let start = span.start.max(lo);
+        let end = span.end.min(hi);
+        if start < end {
+            out.push_str(&input[start..end]);
+        }
+    }
+    if out.trim().is_empty() {
+        None
+    } else {
+        Some(out)
+    }
+}
+
 /// Create the appropriate parser for a given format.
 pub fn parser_for_format(format: crate::format::Format) -> Box<dyn FormatParser> {
     use crate::format::Format;

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -245,12 +245,29 @@ fn reflow_prose(
         }
     }
     if !sentences.is_empty() {
+        // Splitter trims; keep a mid-line TeX ` % comment` space (not newlines).
+        if text.ends_with([' ', '\t']) && !output.ends_with(char::is_whitespace) {
+            let trail: String = text
+                .chars()
+                .rev()
+                .take_while(|c| *c == ' ' || *c == '\t')
+                .collect::<String>()
+                .chars()
+                .rev()
+                .collect();
+            output.push_str(&trail);
+        }
         // No forced paragraph break before inline islands (math/code) or
         // tight punctuation structures — those continue the same line.
-        let suppress = matches!(
-            regions.get(idx + 1),
-            Some(Region::Structure(s)) if suppress_prose_trailing_newline(s)
-        );
+        let suppress = match regions.get(idx + 1) {
+            Some(Region::Structure(s)) if suppress_prose_trailing_newline(s) => true,
+            Some(Region::Structure(s))
+                if s.trim_start().starts_with('%') && text.ends_with([' ', '\t']) =>
+            {
+                true
+            }
+            _ => false,
+        };
         if !suppress {
             output.push('\n');
         }

--- a/tests/check_line_diagnostics.rs
+++ b/tests/check_line_diagnostics.rs
@@ -228,3 +228,144 @@ fn would_reformat_matches_cli_check_identity() {
         }
     }
 }
+
+fn pipe_check(input: &str, extra: &[&str]) -> (bool, String, String) {
+    let mut cmd = snapper_binary();
+    let mut args = vec!["--check", "--format", "plaintext"];
+    args.extend_from_slice(extra);
+    cmd.args(&args)
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = cmd.spawn().expect("spawn snapper");
+    {
+        use std::io::Write;
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(input.as_bytes())
+            .unwrap();
+    }
+    let out = child.wait_with_output().expect("wait snapper");
+    (
+        out.status.success(),
+        String::from_utf8(out.stdout).unwrap(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn stdin_check_json_emits_diagnostics_and_exit_1() {
+    let (ok, stdout, stderr) = pipe_check(
+        "Hello world. This is a test.\n",
+        &["--output-format", "json"],
+    );
+    assert!(!ok, "stdin fused check must exit 1, stderr={stderr}");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("stdin json: {stdout:?}: {e}"));
+    let diags = diagnostics(&parsed);
+    assert!(
+        diags.iter().any(|d| d["kind"] == "fused" && d["line"] == 1),
+        "stdin json must include fused, got {parsed}"
+    );
+}
+
+#[test]
+fn stdin_check_json_clean_exits_0() {
+    let (ok, stdout, stderr) = pipe_check(
+        "Hello world.\nThis is a test.\n",
+        &["--output-format", "json"],
+    );
+    assert!(ok, "clean stdin check must exit 0, stderr={stderr}");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).unwrap_or_else(|e| panic!("stdin json: {stdout:?}: {e}"));
+    assert!(
+        parsed.as_array().is_some(),
+        "clean stdin json must be an array, got {parsed}"
+    );
+}
+
+#[test]
+fn strict_long_does_not_fail_structure_equation() {
+    let dir = tempfile::tempdir().unwrap();
+    let body = concat!(
+        "\\documentclass{article}\n",
+        "\\begin{document}\n",
+        "\\begin{equation}\n",
+        "E = mc^2 + a very long expression, with commas, that exceeds one hundred twenty characters easily xxxxxxxxxxxxxxxxx\n",
+        "\\end{equation}\n",
+        "\\end{document}\n",
+    );
+    let path = dir.path().join("eq.tex");
+    fs::write(&path, body).unwrap();
+    let output = snapper_binary()
+        .args([
+            "--check",
+            "--strict-long",
+            "--output-format",
+            "json",
+            "--format",
+            "latex",
+            &path.to_string_lossy(),
+        ])
+        .output()
+        .expect("run snapper");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "--strict-long must not fail a structure-only equation, stderr={stderr} stdout={stdout}"
+    );
+    if !stdout.trim().is_empty() {
+        let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        let diags = diagnostics(&parsed);
+        assert!(
+            diags.iter().all(|d| d["kind"] != "long"),
+            "equation must not yield long: {parsed}"
+        );
+        for file in parsed.as_array().unwrap() {
+            assert_ne!(file["would_reformat"], true, "{parsed}");
+        }
+    }
+}
+
+#[test]
+fn sarif_uri_is_repo_relative_or_file_with_workdir() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_txt(dir.path(), "fused.txt", "Hello world. This is a test.\n");
+    let output = snapper_binary()
+        .current_dir(dir.path())
+        .args([
+            "--check",
+            "--output-format",
+            "sarif",
+            "--format",
+            "plaintext",
+            "fused.txt",
+        ])
+        .output()
+        .expect("run snapper");
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("sarif json");
+    let uri = parsed["runs"][0]["results"][0]["locations"][0]["physicalLocation"]
+        ["artifactLocation"]["uri"]
+        .as_str()
+        .unwrap_or("");
+    let wd = parsed["runs"][0]["invocations"][0]["workingDirectory"]["uri"]
+        .as_str()
+        .unwrap_or("");
+    let relative = uri == "fused.txt" || uri == "./fused.txt";
+    let file_uri = uri.starts_with("file:");
+    assert!(
+        relative || (file_uri && wd.starts_with("file:")),
+        "SARIF uri must be repo-relative or file: with workingDirectory, got uri={uri:?} wd={wd:?} path={path}"
+    );
+    if !relative {
+        assert!(
+            wd.starts_with("file:"),
+            "file: uri requires invocations[0].workingDirectory.uri, wd={wd:?}"
+        );
+    }
+}

--- a/tests/check_line_diagnostics.rs
+++ b/tests/check_line_diagnostics.rs
@@ -1,0 +1,230 @@
+//! CLI `--check` line-level fused / wrap / long diagnostics.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn snapper_binary() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_snapper"))
+}
+
+fn write_txt(dir: &Path, name: &str, body: &str) -> String {
+    let path = dir.join(name);
+    fs::write(&path, body).unwrap();
+    path.to_string_lossy().into_owned()
+}
+
+fn check_json(path: &str, extra: &[&str]) -> (bool, serde_json::Value, String) {
+    let mut args = vec![
+        "--check",
+        "--output-format",
+        "json",
+        "--format",
+        "plaintext",
+        path,
+    ];
+    args.extend_from_slice(extra);
+    let output = snapper_binary()
+        .args(&args)
+        .output()
+        .expect("failed to run snapper");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("expected JSON on stdout, got {stdout:?} stderr={stderr:?}: {e}")
+    });
+    (output.status.success(), parsed, stderr)
+}
+
+fn diagnostics(parsed: &serde_json::Value) -> Vec<&serde_json::Value> {
+    parsed
+        .as_array()
+        .expect("json check output is a file array")
+        .iter()
+        .flat_map(|file| {
+            file.get("diagnostics")
+                .and_then(|d| d.as_array())
+                .into_iter()
+                .flatten()
+        })
+        .collect()
+}
+
+#[test]
+fn check_json_emits_fused_line_kind_excerpt() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_txt(dir.path(), "fused.txt", "Hello world. This is a test.\n");
+    let (ok, parsed, _) = check_json(&path, &[]);
+    assert!(!ok, "fused prose should fail --check");
+    let diags = diagnostics(&parsed);
+    let fused = diags.iter().find(|d| d["kind"] == "fused");
+    let fused = fused.unwrap_or_else(|| panic!("missing fused diagnostic in {parsed}"));
+    assert_eq!(fused["line"], 1);
+    let excerpt = fused["excerpt"].as_str().unwrap();
+    assert!(excerpt.contains("Hello world"), "excerpt={excerpt:?}");
+}
+
+#[test]
+fn check_json_fused_is_abbrev_aware() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_txt(dir.path(), "fig.txt", "See Fig. 3 for details.\n");
+    let (ok, parsed, _) = check_json(&path, &[]);
+    assert!(ok, "a single abbreviated sentence should pass --check");
+    let diags = diagnostics(&parsed);
+    assert!(
+        diags.iter().all(|d| d["kind"] != "fused"),
+        "Fig. must not be fused: {parsed}"
+    );
+}
+
+#[test]
+fn check_json_emits_wrap_on_mid_clause() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_txt(
+        dir.path(),
+        "wrap.txt",
+        "The experiment ran for several\nweeks using the usual protocol.\n",
+    );
+    let (ok, parsed, _) = check_json(&path, &[]);
+    assert!(!ok, "wrap should fail --check (identity changes on join)");
+    let diags = diagnostics(&parsed);
+    let wrap = diags.iter().find(|d| d["kind"] == "wrap");
+    let wrap = wrap.unwrap_or_else(|| panic!("missing wrap diagnostic in {parsed}"));
+    assert_eq!(wrap["line"], 2);
+    assert!(
+        wrap["excerpt"].as_str().unwrap().contains("weeks"),
+        "excerpt={wrap}"
+    );
+}
+
+#[test]
+fn check_json_wrap_skips_connector_and() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_txt(
+        dir.path(),
+        "and.txt",
+        "The experiment ran for several weeks\nand used the usual protocol.\n",
+    );
+    let (_ok, parsed, _) = check_json(&path, &[]);
+    let diags = diagnostics(&parsed);
+    assert!(
+        diags.iter().all(|d| d["kind"] != "wrap"),
+        "connector-led and is not wrap: {parsed}"
+    );
+}
+
+#[test]
+fn check_json_long_is_advisory_without_strict() {
+    let dir = tempfile::tempdir().unwrap();
+    let body = "The quick brown fox jumps over the lazy dog, then continues running across a very long meadow without pausing for breath at all today.\n";
+    assert!(body.trim_end().chars().count() > 120);
+    let path = write_txt(dir.path(), "long.txt", body);
+    let (ok, parsed, _) = check_json(&path, &[]);
+    assert!(ok, "long alone must not fail --check unless --strict-long");
+    let diags = diagnostics(&parsed);
+    let long = diags.iter().find(|d| d["kind"] == "long");
+    let long = long.unwrap_or_else(|| panic!("missing long diagnostic in {parsed}"));
+    assert_eq!(long["line"], 1);
+    assert!(
+        long["excerpt"]
+            .as_str()
+            .unwrap()
+            .contains("quick brown fox"),
+        "excerpt={long}"
+    );
+}
+
+#[test]
+fn check_strict_long_fails_on_advisory_long() {
+    let dir = tempfile::tempdir().unwrap();
+    let body = "The quick brown fox jumps over the lazy dog, then continues running across a very long meadow without pausing for breath at all today.\n";
+    let path = write_txt(dir.path(), "long.txt", body);
+    let (ok, parsed, _) = check_json(&path, &["--strict-long"]);
+    assert!(!ok, "--strict-long must fail when a long diagnostic exists");
+    assert!(
+        diagnostics(&parsed).iter().any(|d| d["kind"] == "long"),
+        "expected long diagnostic under --strict-long: {parsed}"
+    );
+}
+
+#[test]
+fn check_sarif_includes_start_line_and_kind() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_txt(dir.path(), "fused.txt", "Hello world. This is a test.\n");
+    let output = snapper_binary()
+        .args([
+            "--check",
+            "--output-format",
+            "sarif",
+            "--format",
+            "plaintext",
+            &path,
+        ])
+        .output()
+        .expect("failed to run snapper");
+    assert!(!output.status.success());
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("sarif json");
+    let results = parsed["runs"][0]["results"]
+        .as_array()
+        .expect("sarif results");
+    let fused = results
+        .iter()
+        .find(|r| r["ruleId"] == "snapper/fused")
+        .unwrap_or_else(|| panic!("missing snapper/fused in {parsed}"));
+    assert_eq!(
+        fused["locations"][0]["physicalLocation"]["region"]["startLine"],
+        1
+    );
+    let snippet = fused["locations"][0]["physicalLocation"]["region"]["snippet"]["text"]
+        .as_str()
+        .unwrap_or("");
+    assert!(
+        snippet.contains("Hello world"),
+        "sarif snippet should carry the excerpt, got {snippet:?}"
+    );
+}
+
+#[test]
+fn would_reformat_matches_cli_check_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let dirty = write_txt(dir.path(), "dirty.txt", "Hello world. This is a test.\n");
+    let clean = write_txt(dir.path(), "clean.txt", "Hello world.\nThis is a test.\n");
+
+    let dirty_out = snapper_binary()
+        .args(["--check", "--format", "plaintext", &dirty])
+        .output()
+        .unwrap();
+    let clean_out = snapper_binary()
+        .args(["--check", "--format", "plaintext", &clean])
+        .output()
+        .unwrap();
+    assert!(!dirty_out.status.success());
+    assert!(clean_out.status.success());
+
+    let (_ok, dirty_json, _) = check_json(&dirty, &[]);
+    let file = &dirty_json.as_array().unwrap()[0];
+    assert_eq!(file["would_reformat"], true);
+
+    let clean_json_run = snapper_binary()
+        .args([
+            "--check",
+            "--output-format",
+            "json",
+            "--format",
+            "plaintext",
+            &clean,
+        ])
+        .output()
+        .unwrap();
+    assert!(clean_json_run.status.success());
+    let stdout = String::from_utf8(clean_json_run.stdout).unwrap();
+    if !stdout.trim().is_empty() {
+        let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+        if let Some(arr) = parsed.as_array() {
+            for file in arr {
+                assert_ne!(file["would_reformat"], true);
+            }
+        }
+    }
+}

--- a/tests/check_line_diagnostics.rs
+++ b/tests/check_line_diagnostics.rs
@@ -185,6 +185,67 @@ fn check_sarif_includes_start_line_and_kind() {
     );
 }
 
+fn check_json_fmt(path: &str, format: &str) -> (bool, serde_json::Value) {
+    let output = snapper_binary()
+        .args([
+            "--check",
+            "--output-format",
+            "json",
+            "--format",
+            format,
+            path,
+        ])
+        .output()
+        .expect("failed to run snapper");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr).into_owned();
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).unwrap_or_else(|e| {
+        panic!("expected JSON on stdout, got {stdout:?} stderr={stderr:?}: {e}")
+    });
+    (output.status.success(), parsed)
+}
+
+#[test]
+fn numbered_list_markdown_is_not_fused_and_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_txt(dir.path(), "list.md", "1. Hello world.\n");
+    let (ok, parsed) = check_json_fmt(&path, "markdown");
+    assert!(ok, "1. Hello world. must pass --check: {parsed}");
+    assert!(
+        diagnostics(&parsed).iter().all(|d| d["kind"] != "fused"),
+        "numbered list must not fused: {parsed}"
+    );
+    if let Some(arr) = parsed.as_array() {
+        for file in arr {
+            assert_ne!(file["would_reformat"], true, "{parsed}");
+        }
+    }
+}
+
+#[test]
+fn numbered_list_org_is_not_fused_and_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_txt(dir.path(), "list.org", "1. Hello world.\n");
+    let (ok, parsed) = check_json_fmt(&path, "org");
+    assert!(ok, "1. Hello world. must pass --check: {parsed}");
+    assert!(
+        diagnostics(&parsed).iter().all(|d| d["kind"] != "fused"),
+        "org numbered list must not fused: {parsed}"
+    );
+}
+
+#[test]
+fn latex_mid_line_comment_is_not_fused_and_identity() {
+    let dir = tempfile::tempdir().unwrap();
+    let path = write_txt(dir.path(), "cite.tex", "See Fig. 1. % TODO cite\n");
+    let (ok, parsed) = check_json_fmt(&path, "latex");
+    assert!(ok, "See Fig. 1. % TODO cite must pass --check: {parsed}");
+    assert!(
+        diagnostics(&parsed).iter().all(|d| d["kind"] != "fused"),
+        "latex comment must not fused: {parsed}"
+    );
+}
+
 #[test]
 fn would_reformat_matches_cli_check_identity() {
     let dir = tempfile::tempdir().unwrap();

--- a/vale/snapper/SnapperCheck.yml
+++ b/vale/snapper/SnapperCheck.yml
@@ -22,8 +22,28 @@ script: |
     exit 0
   fi
   # Vale external actions expect line:column:message on stdout for violations.
-  if ! snapper --check "$file" >/dev/null 2>&1; then
-    # Report one alert at the top of the file; precise line mapping would need
-    # a dedicated --check-lines mode. Prefer `snapper --check` in CI for SARIF.
+  json="$(snapper --check --output-format json "$file" 2>/dev/null || true)"
+  if [ -z "$json" ]; then
+    exit 0
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    printf '%s\n' "$json" | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+if not isinstance(data, list):
+    sys.exit(0)
+for item in data:
+    for d in item.get("diagnostics") or []:
+        kind = d.get("kind") or "fused"
+        if kind == "long":
+            continue
+        line = d.get("line") or 1
+        excerpt = (d.get("excerpt") or "").replace("\n", " ")
+        print(f"{line}:1:{kind}: {excerpt}")
+'
+  elif ! snapper --check "$file" >/dev/null 2>&1; then
     echo "1:1:file needs semantic line break formatting (snapper --check failed)"
   fi


### PR DESCRIPTION
`--check --output-format json|sarif` emits 1-indexed line + kind + excerpt.

fused uses the same splitter as format, on the parser's prose payload (so `1. Hello world.` is not fused). wrap is mid-clause continuation. long is advisory unless `--strict-long`.

stdin `--check` honors the same contract. MCP `would_reformat` is identity.