### PR TITLE
fix: Markdown emphasis, quotes, hard breaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project will be documented in this file. See [conven
 - (**sentence**) `w.r.t.` is a multi-word abbreviation; `\\(...\\)` and `$$...$$` stay atomic like `$...$`
 - (**cli**) unknown source extensions (`.rs`, `.py`, no extension) are refused unless `--format` is explicit; `.txt` remains plaintext
 - (**org** / **sentence**) verbatim and inline-code spans pair to the first closer that satisfies Org's border and post rules, so an `=` or `~` inside the span no longer orphans the real closer onto the next line
+- (**sentence**) CommonMark `*`/`**` and GFM `~~` pair by flanking rules, so `**the end. Still bold**` stays one sentence while `**complex**. Equity` may split after the closer
+- (**markdown**) `>` is kept on each reflowed content line; two-space and backslash hard breaks are not joined with a space; multiline `<!-- ... -->` is structure (`<!-- snapper:off -->` still works)
 #### Documentation
 - README distinguishes snapper from admk/sembr and sembr/skills; crate keywords include `sembr` and `markdown`
 - (**markdown** / **sentence**) inline code delimited by two or more backticks can contain a shorter backtick run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file. See [conven
 - (**cli**) unknown source extensions (`.rs`, `.py`, no extension) are refused unless `--format` is explicit; `.txt` remains plaintext
 - (**org** / **sentence**) verbatim and inline-code spans pair to the first closer that satisfies Org's border and post rules, so an `=` or `~` inside the span no longer orphans the real closer onto the next line
 - (**sentence**) CommonMark `*`/`**` and GFM `~~` pair by flanking rules, so `**the end. Still bold**` stays one sentence while `**complex**. Equity` may split after the closer
-- (**markdown**) `>` is kept on each reflowed content line; two-space and backslash hard breaks are not joined with a space; multiline `<!-- ... -->` is structure (`<!-- snapper:off -->` still works)
+- (**markdown**) `>` is kept on each reflowed content line (including `max_width` wraps; prefix counts toward width); two-space and backslash hard breaks are not joined with a space; a quote hard break does not leave a stray `>` on the next non-quote line; multiline `<!-- ... -->` is structure (`<!-- snapper:off -->` still works)
 #### Documentation
 - README distinguishes snapper from admk/sembr and sembr/skills; crate keywords include `sembr` and `markdown`
 - (**markdown** / **sentence**) inline code delimited by two or more backticks can contain a shorter backtick run

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Fenced and delimited source blocks are `Region::Code`: fence/open/close lines st
 Pass `--format-code` to also pipe each block body through an optional per-language `formatter` argv (missing binary, non-zero exit, and timeouts degrade to the reflowed body).
 Sentence detection relies on Unicode UAX #29 segmentation with abbreviation-aware post-processing that avoids false breaks at titles (Dr., Prof.), references (Fig., Eq.), and Latin terms (e.g., i.e., et al.).
 Org emphasis (`*bold*`, `/italic/`, `_underline_`, `+strike+`) is kept atomic so splits cannot open a pseudo-headline mid-span.
+Markdown `*em*` / `**strong**` (CommonMark flanking) and GFM `~~strike~~` are kept atomic the same way.
 
 
 <a id="installation"></a>

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -103,6 +103,8 @@ These tokens within prose are not split across lines:
 - Setext headings (title line plus ====== or ------ underline)
 - List item markers (=-=, =*=, =+=, =1.=); continuation sentences hang at the marker width
 - Blockquote markers (=>= / nested => > =); continuation sentences repeat the quote prefix
+- Hard line breaks (two trailing spaces, or a trailing backslash)
+- HTML comments (=<!-- ... -->=, including multiline); =<!-- snapper:off -->= / =<!-- snapper:on -->= remain pragmas
 - Pipe tables
 
 *** Code regions (fenced =```= / =~~~=)
@@ -119,7 +121,17 @@ These tokens within prose are not split across lines:
 :END:
 - Paragraph text
 - List item text (after the marker); continuation sentences hang at the marker width
-- Blockquote text (after the prefix); continuation sentences repeat the quote prefix
+- Blockquote inner text (after the =>= marker); continuation sentences repeat the quote prefix
+
+*** Inline tokens (kept atomic)
+:PROPERTIES:
+:CUSTOM_ID: markdown-inline
+:END:
+- Emphasis: =*em*=, =**strong**= (CommonMark flanking; a period inside the span does not split)
+- Strikethrough: =~~strike~~= (GFM)
+- Inline code: a run of =n= backticks closes on the next run of the same length
+- Links and images: =[text](url)=, =![alt](url)=
+- Inline math: =$...$= / =$$...$$=
 
 ** reStructuredText (=--format rst=)
 :PROPERTIES:

--- a/readme_src.org
+++ b/readme_src.org
@@ -33,6 +33,7 @@ Fenced and delimited source blocks are =Region::Code=: fence/open/close lines st
 Pass =--format-code= to also pipe each block body through an optional per-language =formatter= argv (missing binary, non-zero exit, and timeouts degrade to the reflowed body).
 Sentence detection relies on Unicode UAX #29 segmentation with abbreviation-aware post-processing that avoids false breaks at titles (Dr., Prof.), references (Fig., Eq.), and Latin terms (e.g., i.e., et al.).
 Org emphasis (=*bold*=, =/italic/=, =_underline_=, =+strike+=) is kept atomic so splits cannot open a pseudo-headline mid-span.
+Markdown =*em*= / =**strong**= (CommonMark flanking) and GFM =~~strike~~= are kept atomic the same way.
 * Installation
 :PROPERTIES:
 :CUSTOM_ID: installation

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -52,6 +52,110 @@ fn close_list_item(
     }
 }
 
+fn starts_html_comment(line: &str) -> bool {
+    line.trim_start().starts_with("<!--")
+}
+
+fn html_comment_closed(text: &str) -> bool {
+    match text.find("<!--") {
+        Some(i) => text[i + 4..].contains("-->"),
+        None => text.contains("-->"),
+    }
+}
+
+/// Two or more trailing spaces, or an unescaped trailing backslash.
+/// Returns `(content_len, hard_at)` relative to `text`.
+fn hard_break_rel(text: &str) -> Option<(usize, usize)> {
+    let bytes = text.as_bytes();
+    if !bytes.is_empty() && *bytes.last().unwrap() == b'\\' {
+        let mut n = 0usize;
+        let mut i = bytes.len();
+        while i > 0 && bytes[i - 1] == b'\\' {
+            n += 1;
+            i -= 1;
+        }
+        if n % 2 == 1 {
+            return Some((text.len() - 1, text.len() - 1));
+        }
+        return None;
+    }
+    let stripped = text.trim_end_matches(' ');
+    if text.len() - stripped.len() >= 2 {
+        return Some((stripped.len(), stripped.len()));
+    }
+    None
+}
+
+/// Append `line.text[piece_from..]` to the running prose buffer.
+///
+/// A hard break flushes prose and emits the break (spaces or `\`, plus the
+/// line terminator) as Structure so splice copies those source bytes.
+fn append_piece(
+    prose: &mut String,
+    prose_span: &mut Option<ByteSpan>,
+    list_term: &mut Option<ByteSpan>,
+    line: &Line<'_>,
+    piece_from: usize,
+    join_space: bool,
+    include_term_if_soft: bool,
+    input: &str,
+    regions: &mut Vec<SpannedRegion>,
+) {
+    let piece = &line.text[piece_from..];
+    if let Some((content_end, hard_at)) = hard_break_rel(piece) {
+        let raw = &piece[..content_end];
+        let trimmed = raw.trim_start();
+        let left = raw.len() - trimmed.len();
+        if !trimmed.is_empty() {
+            if !prose.is_empty() && join_space {
+                prose.push(' ');
+            }
+            prose.push_str(trimmed);
+            let start = line.start + piece_from + left;
+            let end = line.start + piece_from + content_end;
+            match prose_span {
+                None => *prose_span = Some(ByteSpan::new(start, end)),
+                Some(s) => s.end = end,
+            }
+        }
+        flush_prose_spanned(prose, prose_span, regions);
+        let hard = ByteSpan::new(line.start + piece_from + hard_at, line.end);
+        if !hard.is_empty() {
+            regions.push(SpannedRegion::structure(input, hard));
+        }
+        *list_term = None;
+        return;
+    }
+    if piece_from == 0 {
+        push_prose_line(
+            prose,
+            prose_span,
+            line,
+            join_space,
+            include_term_if_soft,
+        );
+        *list_term = if include_term_if_soft {
+            None
+        } else {
+            Some(line.terminator_span())
+        };
+        return;
+    }
+    if !piece.is_empty() {
+        if !prose.is_empty() && join_space {
+            prose.push(' ');
+        }
+        prose.push_str(piece);
+        let start = line.start + piece_from;
+        let end = line.start + line.text.len();
+        match prose_span {
+            None => *prose_span = Some(ByteSpan::new(start, end)),
+            Some(s) => s.end = end,
+        }
+    }
+    *list_term = Some(line.terminator_span());
+}
+
 /// True when `line` is a CommonMark setext underline (`===` or `---`).
 fn is_setext_underline(line: &str) -> bool {
     let trimmed = line.trim_end();
@@ -296,8 +400,41 @@ impl FormatParser for MarkdownParser {
                 continue;
             }
 
+            // HTML comment block (not a snapper pragma — those are handled above).
+            if starts_html_comment(line_text) {
+                close_list_item(
+                    &mut in_list_item,
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    input,
+                    &mut regions,
+                );
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                if html_comment_closed(line_text) {
+                    regions.push(SpannedRegion::structure(input, line.span()));
+                    i += 1;
+                    continue;
+                }
+                let start = line.start;
+                i += 1;
+                while i < total {
+                    let done = lines[i].text.contains("-->");
+                    i += 1;
+                    if done {
+                        break;
+                    }
+                }
+                let end = lines.get(i.saturating_sub(1)).map(|l| l.end).unwrap_or(input.len());
+                regions.push(SpannedRegion::structure(input, ByteSpan::new(start, end)));
+                continue;
+            }
+
             // Blockquote: emit the full `> ` / `> > ` prefix as Structure.
             // Checked before list items so nested `> >` is not flattened.
+            // Each source quote line is its own item so splice ranges stay
+            // contiguous. A hard break is Structure; the next line supplies
+            // its own `>` (no pre-emitted resume marker).
             if let Some(caps) = QUOTE_RE.captures(line_text) {
                 close_list_item(
                     &mut in_list_item,
@@ -310,17 +447,33 @@ impl FormatParser for MarkdownParser {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 let marker = caps.get(1).unwrap().as_str();
                 let text = caps.get(2).unwrap().as_str();
+                if text.trim().is_empty() {
+                    regions.push(SpannedRegion::structure(input, line.span()));
+                    i += 1;
+                    continue;
+                }
+                if HEADING_RE.is_match(text)
+                    || TABLE_ROW_RE.is_match(text)
+                    || FENCED_CODE_RE.is_match(text.trim_start())
+                {
+                    regions.push(SpannedRegion::structure(input, line.span()));
+                    i += 1;
+                    continue;
+                }
                 let marker_span = ByteSpan::new(line.start, line.start + marker.len());
                 regions.push(SpannedRegion::structure(input, marker_span));
                 in_list_item = true;
-                list_term = Some(line.terminator_span());
-                if !text.is_empty() {
-                    current_prose.push_str(text);
-                    prose_span = Some(ByteSpan::new(
-                        line.start + marker.len(),
-                        line.start + line_text.len(),
-                    ));
-                }
+                append_piece(
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    line,
+                    marker.len(),
+                    false,
+                    false,
+                    input,
+                    &mut regions,
+                );
                 i += 1;
                 continue;
             }
@@ -338,28 +491,49 @@ impl FormatParser for MarkdownParser {
                 );
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 let marker = caps.get(1).unwrap().as_str();
-                let text = caps.get(2).unwrap().as_str();
                 let marker_span = ByteSpan::new(line.start, line.start + marker.len());
                 regions.push(SpannedRegion::structure(input, marker_span));
                 in_list_item = true;
-                list_term = Some(line.terminator_span());
-                if !text.is_empty() {
-                    current_prose.push_str(text);
-                    prose_span = Some(ByteSpan::new(
-                        line.start + marker.len(),
-                        line.start + line_text.len(),
-                    ));
-                }
+                append_piece(
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    line,
+                    marker.len(),
+                    false,
+                    false,
+                    input,
+                    &mut regions,
+                );
                 i += 1;
                 continue;
             }
 
             // Regular prose (also serves as list-item continuation when in_list_item)
             if in_list_item {
-                push_prose_line(&mut current_prose, &mut prose_span, line, true, false);
-                list_term = Some(line.terminator_span());
+                append_piece(
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    line,
+                    0,
+                    true,
+                    false,
+                    input,
+                    &mut regions,
+                );
             } else {
-                push_prose_line(&mut current_prose, &mut prose_span, line, true, true);
+                append_piece(
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    line,
+                    0,
+                    true,
+                    true,
+                    input,
+                    &mut regions,
+                );
             }
             i += 1;
         }
@@ -928,5 +1102,83 @@ mod tests {
         assert!(out.contains("Final thing.\nLast sentence."));
         assert!(out.contains("<!-- snapper:off -->"));
         assert!(out.contains("<!-- snapper:on -->"));
+    }
+
+    #[test]
+    fn quote_hard_break_then_nonquote_has_no_stray_marker() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "> line  \nNext sentence.\n";
+        let regions = MarkdownParser.parse(input);
+        let after_break = regions
+            .iter()
+            .skip_while(|r| !matches!(r, Region::Structure(s) if s.ends_with("  \n")));
+        assert!(
+            !after_break.clone().any(|r| matches!(r, Region::Structure(s) if is_quote_resume(s))),
+            "must not emit `>` after a quote hard break into non-quote, got: {regions:?}"
+        );
+
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            !out.contains("> \n") && !out.lines().any(|l| l == ">" || l.trim() == ">"),
+            "stray empty quote line, got:\n{out:?}"
+        );
+        assert!(
+            out.starts_with("> line  \nNext sentence."),
+            "hard break then non-quote body, got:\n{out:?}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+
+        let still_quote = format_text("> line  \n> continued.\n", &cfg).unwrap();
+        assert!(
+            still_quote.starts_with("> line  \n> continued."),
+            "in-quote hard break must still resume `>`, got:\n{still_quote:?}"
+        );
+    }
+
+    fn is_quote_resume(s: &str) -> bool {
+        !s.is_empty()
+            && !s.contains('\n')
+            && s.contains('>')
+            && s.bytes().all(|b| b == b'>' || b == b' ')
+    }
+
+    #[test]
+    fn quote_wrap_repeats_prefix_under_max_width() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "> One two three four five six seven eight.\n";
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            max_width: 20,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        let lines: Vec<_> = out.lines().filter(|l| !l.is_empty()).collect();
+        assert!(
+            lines.len() > 1,
+            "sentence must wrap under max_width=20, got:\n{out}"
+        );
+        for line in &lines {
+            assert!(
+                line.starts_with("> "),
+                "every wrap line keeps `>`, not a space hang, got:\n{out}"
+            );
+            assert!(
+                line.chars().count() <= 20,
+                "prefix counts toward max_width: {line:?} ({out})"
+            );
+        }
+        assert!(
+            !out.contains("\n  "),
+            "must not hang quote wrap with spaces: {out:?}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 }

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -676,6 +676,24 @@ mod tests {
         assert_eq!(regions[1], Region::Prose("One. Two.".to_string()));
         // No trailing newline in the source, so no terminator Structure.
         assert_eq!(regions.len(), 2);
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains('>'))),
+            "quote marker must not leak into Prose: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn blockquote_multiline_keeps_each_marker() {
+        // Each source quote line is its own item so splice ranges stay
+        // contiguous. Reflow of already-split quotes is identity.
+        let regions = MarkdownParser.parse("> One.\n> Two.");
+        assert_eq!(regions[0], Region::Structure("> ".to_string()));
+        assert_eq!(regions[1], Region::Prose("One.".to_string()));
+        assert_eq!(regions[2], Region::Structure("\n".to_string()));
+        assert_eq!(regions[3], Region::Structure("> ".to_string()));
+        assert_eq!(regions[4], Region::Prose("Two.".to_string()));
     }
 
     #[test]
@@ -698,6 +716,27 @@ mod tests {
         let quote = format_text("> One. Two.\n", &cfg).unwrap();
         assert_eq!(quote, "> One.\n> Two.\n");
         assert_eq!(format_text(&quote, &cfg).unwrap(), quote);
+    }
+
+    #[test]
+    fn blockquote_keeps_marker_on_each_content_line() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        for input in ["> One. Two.\n", "> One.\n> Two.\n"] {
+            let out = format_text(input, &cfg).unwrap();
+            let quote_lines: Vec<_> = out.lines().filter(|l| !l.is_empty()).collect();
+            assert_eq!(
+                quote_lines,
+                vec!["> One.", "> Two."],
+                "each content line needs `>`, input {input:?}, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &cfg).unwrap(), out);
+        }
     }
 
     #[test]
@@ -760,5 +799,134 @@ mod tests {
             Region::Prose("Child one. Child two.".to_string())
         );
         assert_eq!(regions[5], Region::Structure("\n".to_string()));
+    }
+
+    #[test]
+    fn hard_break_two_spaces_not_joined_with_space() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "line  \ncontinued. Next sentence.\n";
+        let regions = MarkdownParser.parse(input);
+        let joined: String = regions
+            .iter()
+            .map(|r| match r {
+                Region::Prose(p) | Region::Structure(p) | Region::BlankLines(p) => p.as_str(),
+                Region::Code { .. } => "",
+            })
+            .collect();
+        assert!(
+            !joined.contains("line continued"),
+            "two trailing spaces are a hard break, not a space join: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| match r {
+                Region::Structure(s) => s.contains("  \n") || s.ends_with("  \n"),
+                _ => false,
+            }) || joined.contains("line  \n"),
+            "hard-break spaces must survive classification: {regions:?}"
+        );
+
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            !out.contains("line continued"),
+            "must not collapse hard break to a space, got:\n{out}"
+        );
+        assert!(
+            out.contains("line  \n") || out.contains("line  \r"),
+            "two trailing spaces must remain, got:\n{out:?}"
+        );
+        assert!(out.contains("Next sentence."));
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn hard_break_backslash_not_joined_with_space() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "line\\\ncontinued. Next sentence.\n";
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            !out.contains("line continued") && !out.contains("line\\ continued"),
+            "backslash hard break must not become a space, got:\n{out}"
+        );
+        assert!(
+            out.contains("line\\\ncontinued"),
+            "backslash hard break must remain, got:\n{out:?}"
+        );
+        assert!(out.contains("Next sentence."));
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn html_comment_multiline_is_structure() {
+        let input =
+            "Before sentence. After.\n<!--\nHidden. With a period.\nStill comment.\n-->\nMore. Text.";
+        let regions = MarkdownParser.parse(input);
+        let comment = regions.iter().find_map(|r| match r {
+            Region::Structure(s) if s.contains("<!--") => Some(s.as_str()),
+            _ => None,
+        });
+        let comment = comment.expect(&format!("comment must be Structure, got {regions:?}"));
+        assert!(comment.contains("<!--"), "{comment}");
+        assert!(comment.contains("Hidden. With a period."), "{comment}");
+        assert!(comment.contains("Still comment."), "{comment}");
+        assert!(comment.contains("-->"), "{comment}");
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("Hidden") || p.contains("Still comment"))),
+            "comment body must not be Prose: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn html_comment_multiline_passes_through_format() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "Before sentence. After.\n<!--\nHidden. With a period.\nStill comment.\n-->\nMore. Text.\n";
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains("<!--\nHidden. With a period.\nStill comment.\n-->\n"),
+            "multiline comment must pass through, got:\n{out}"
+        );
+        assert!(out.contains("Before sentence.\nAfter."));
+        assert!(out.contains("More.\nText."));
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn html_comment_pragma_still_disables_reflow() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "Hello world. Goodbye world.\n<!-- snapper:off -->\nKeep this. Exactly here.\n<!-- snapper:on -->\nFinal thing. Last sentence.\n";
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert!(out.contains("Hello world.\nGoodbye world.\n"));
+        assert!(
+            out.contains("Keep this. Exactly here.\n"),
+            "pragma-off body must stay untouched, got:\n{out}"
+        );
+        assert!(out.contains("Final thing.\nLast sentence."));
+        assert!(out.contains("<!-- snapper:off -->"));
+        assert!(out.contains("<!-- snapper:on -->"));
     }
 }

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -127,13 +127,7 @@ fn append_piece(
         return;
     }
     if piece_from == 0 {
-        push_prose_line(
-            prose,
-            prose_span,
-            line,
-            join_space,
-            include_term_if_soft,
-        );
+        push_prose_line(prose, prose_span, line, join_space, include_term_if_soft);
         *list_term = if include_term_if_soft {
             None
         } else {
@@ -425,7 +419,10 @@ impl FormatParser for MarkdownParser {
                         break;
                     }
                 }
-                let end = lines.get(i.saturating_sub(1)).map(|l| l.end).unwrap_or(input.len());
+                let end = lines
+                    .get(i.saturating_sub(1))
+                    .map(|l| l.end)
+                    .unwrap_or(input.len());
                 regions.push(SpannedRegion::structure(input, ByteSpan::new(start, end)));
                 continue;
             }
@@ -1114,7 +1111,9 @@ mod tests {
             .iter()
             .skip_while(|r| !matches!(r, Region::Structure(s) if s.ends_with("  \n")));
         assert!(
-            !after_break.clone().any(|r| matches!(r, Region::Structure(s) if is_quote_resume(s))),
+            !after_break
+                .clone()
+                .any(|r| matches!(r, Region::Structure(s) if is_quote_resume(s))),
             "must not emit `>` after a quote hard break into non-quote, got: {regions:?}"
         );
 

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -1043,8 +1043,7 @@ mod tests {
 
     #[test]
     fn html_comment_multiline_is_structure() {
-        let input =
-            "Before sentence. After.\n<!--\nHidden. With a period.\nStill comment.\n-->\nMore. Text.";
+        let input = "Before sentence. After.\n<!--\nHidden. With a period.\nStill comment.\n-->\nMore. Text.";
         let regions = MarkdownParser.parse(input);
         let comment = regions.iter().find_map(|r| match r {
             Region::Structure(s) if s.contains("<!--") => Some(s.as_str()),

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -86,14 +86,18 @@ fn hard_break_rel(text: &str) -> Option<(usize, usize)> {
     None
 }
 
+struct ProseAcc<'a> {
+    text: &'a mut String,
+    span: &'a mut Option<ByteSpan>,
+    term: &'a mut Option<ByteSpan>,
+}
+
 /// Append `line.text[piece_from..]` to the running prose buffer.
 ///
 /// A hard break flushes prose and emits the break (spaces or `\`, plus the
 /// line terminator) as Structure so splice copies those source bytes.
 fn append_piece(
-    prose: &mut String,
-    prose_span: &mut Option<ByteSpan>,
-    list_term: &mut Option<ByteSpan>,
+    acc: &mut ProseAcc<'_>,
     line: &Line<'_>,
     piece_from: usize,
     join_space: bool,
@@ -107,28 +111,28 @@ fn append_piece(
         let trimmed = raw.trim_start();
         let left = raw.len() - trimmed.len();
         if !trimmed.is_empty() {
-            if !prose.is_empty() && join_space {
-                prose.push(' ');
+            if !acc.text.is_empty() && join_space {
+                acc.text.push(' ');
             }
-            prose.push_str(trimmed);
+            acc.text.push_str(trimmed);
             let start = line.start + piece_from + left;
             let end = line.start + piece_from + content_end;
-            match prose_span {
-                None => *prose_span = Some(ByteSpan::new(start, end)),
+            match acc.span {
+                None => *acc.span = Some(ByteSpan::new(start, end)),
                 Some(s) => s.end = end,
             }
         }
-        flush_prose_spanned(prose, prose_span, regions);
+        flush_prose_spanned(acc.text, acc.span, regions);
         let hard = ByteSpan::new(line.start + piece_from + hard_at, line.end);
         if !hard.is_empty() {
             regions.push(SpannedRegion::structure(input, hard));
         }
-        *list_term = None;
+        *acc.term = None;
         return;
     }
     if piece_from == 0 {
-        push_prose_line(prose, prose_span, line, join_space, include_term_if_soft);
-        *list_term = if include_term_if_soft {
+        push_prose_line(acc.text, acc.span, line, join_space, include_term_if_soft);
+        *acc.term = if include_term_if_soft {
             None
         } else {
             Some(line.terminator_span())
@@ -136,18 +140,18 @@ fn append_piece(
         return;
     }
     if !piece.is_empty() {
-        if !prose.is_empty() && join_space {
-            prose.push(' ');
+        if !acc.text.is_empty() && join_space {
+            acc.text.push(' ');
         }
-        prose.push_str(piece);
+        acc.text.push_str(piece);
         let start = line.start + piece_from;
         let end = line.start + line.text.len();
-        match prose_span {
-            None => *prose_span = Some(ByteSpan::new(start, end)),
+        match acc.span {
+            None => *acc.span = Some(ByteSpan::new(start, end)),
             Some(s) => s.end = end,
         }
     }
-    *list_term = Some(line.terminator_span());
+    *acc.term = Some(line.terminator_span());
 }
 
 /// True when `line` is a CommonMark setext underline (`===` or `---`).
@@ -461,9 +465,11 @@ impl FormatParser for MarkdownParser {
                 regions.push(SpannedRegion::structure(input, marker_span));
                 in_list_item = true;
                 append_piece(
-                    &mut current_prose,
-                    &mut prose_span,
-                    &mut list_term,
+                    &mut ProseAcc {
+                        text: &mut current_prose,
+                        span: &mut prose_span,
+                        term: &mut list_term,
+                    },
                     line,
                     marker.len(),
                     false,
@@ -492,9 +498,11 @@ impl FormatParser for MarkdownParser {
                 regions.push(SpannedRegion::structure(input, marker_span));
                 in_list_item = true;
                 append_piece(
-                    &mut current_prose,
-                    &mut prose_span,
-                    &mut list_term,
+                    &mut ProseAcc {
+                        text: &mut current_prose,
+                        span: &mut prose_span,
+                        term: &mut list_term,
+                    },
                     line,
                     marker.len(),
                     false,
@@ -509,9 +517,11 @@ impl FormatParser for MarkdownParser {
             // Regular prose (also serves as list-item continuation when in_list_item)
             if in_list_item {
                 append_piece(
-                    &mut current_prose,
-                    &mut prose_span,
-                    &mut list_term,
+                    &mut ProseAcc {
+                        text: &mut current_prose,
+                        span: &mut prose_span,
+                        term: &mut list_term,
+                    },
                     line,
                     0,
                     true,
@@ -521,9 +531,11 @@ impl FormatParser for MarkdownParser {
                 );
             } else {
                 append_piece(
-                    &mut current_prose,
-                    &mut prose_span,
-                    &mut list_term,
+                    &mut ProseAcc {
+                        text: &mut current_prose,
+                        span: &mut prose_span,
+                        term: &mut list_term,
+                    },
                     line,
                     0,
                     true,

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -336,8 +336,8 @@ pub(crate) fn is_hanging_marker(s: &str) -> bool {
 
 /// Prefix emitted on continuation lines after a list or quote marker.
 /// Lists hang with spaces of marker width; Markdown quotes repeat the
-/// quote prefix (`> `, `> > `, including leading indent). Empty when `s`
-/// is not a marker (headings, fences, inline islands).
+/// quote prefix (`> `, `> > `, `>> `, including leading indent). Empty
+/// when `s` is not a marker (headings, fences, inline islands).
 fn hanging_prefix(s: &str) -> String {
     if is_quote_marker(s) {
         return s.to_string();
@@ -350,18 +350,14 @@ fn hanging_prefix(s: &str) -> String {
     }
 }
 
-/// True when `s` is a Markdown quote marker: optional indent plus one or
-/// more `> ` runs, and nothing else.
+/// True when `s` is a Markdown quote marker: optional indent plus `>`
+/// runs (`> `, `> > `, `>> `).
 fn is_quote_marker(s: &str) -> bool {
-    if s.is_empty() || s.contains('\n') || !s.ends_with(' ') {
+    if s.is_empty() || s.contains('\n') {
         return false;
     }
-    let trimmed = s.trim_start();
-    let bytes = trimmed.as_bytes();
-    if bytes.len() < 2 || bytes.len() % 2 != 0 {
-        return false;
-    }
-    bytes.chunks_exact(2).all(|c| c == b"> ")
+    let trimmed = s.trim_start_matches(' ');
+    !trimmed.is_empty() && trimmed.contains('>') && trimmed.bytes().all(|b| b == b'>' || b == b' ')
 }
 
 /// Column width of a list marker that continuation lines hang at with
@@ -489,6 +485,44 @@ mod tests {
         assert_eq!(
             result,
             "#+TITLE: Test\n\nFirst sentence.\nSecond sentence.\n"
+        );
+    }
+
+    #[test]
+    fn hanging_prefix_quote_repeats_marker_list_uses_spaces() {
+        assert_eq!(hanging_prefix("> "), "> ");
+        assert_eq!(hanging_prefix(">> "), ">> ");
+        assert_eq!(hanging_prefix("  > "), "  > ");
+        assert_eq!(hanging_prefix("- "), "  ");
+        assert_eq!(hanging_prefix("1. "), "   ");
+        assert_eq!(hanging_indent_width("> "), 0);
+        assert_eq!(hanging_indent_width("- "), 2);
+    }
+
+    #[test]
+    fn quote_wrap_lines_repeat_prefix_under_max_width() {
+        let regions = vec![
+            Region::Structure("> ".to_string()),
+            Region::Prose("One two three four five six seven eight.".to_string()),
+            Region::Structure("\n".to_string()),
+        ];
+        let config = ReflowConfig {
+            max_width: 20,
+            ..Default::default()
+        };
+        let result = reflow(&regions, &UnicodeSentenceSplitter::new(), &config);
+        let lines: Vec<&str> = result.lines().filter(|l| !l.is_empty()).collect();
+        assert!(lines.len() > 1, "must wrap: {result:?}");
+        for line in &lines {
+            assert!(line.starts_with("> "), "quote wrap keeps `>`: {result:?}");
+            assert!(
+                line.chars().count() <= 20,
+                "prefix counts toward width: {line:?}"
+            );
+        }
+        assert!(
+            !result.contains("\n  "),
+            "quotes do not space-hang: {result:?}"
         );
     }
 

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -388,10 +388,22 @@ fn hanging_indent_width(s: &str) -> usize {
     }
 }
 
-/// When the next region is an inline structure island (pandoc `Math`/`Code` as
-/// Structure), do not end the preceding prose with a hard line break.
+/// Markdown hard break payloads: two or more spaces plus newline, or `\\\n`.
+fn is_hard_break_structure(s: &str) -> bool {
+    let Some(body) = s.strip_suffix('\n') else {
+        return false;
+    };
+    if body == "\\" {
+        return true;
+    }
+    body.len() >= 2 && body.bytes().all(|b| b == b' ')
+}
+
 fn suppress_prose_trailing_newline(s: &str) -> bool {
     if s == "\n" || s.starts_with('}') || s.starts_with(']') || s.starts_with(')') {
+        return true;
+    }
+    if is_hard_break_structure(s) {
         return true;
     }
     // Islands may carry a leading space for glue after reflow trims prose.

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -1158,4 +1158,89 @@ mod tests {
             vec![r#"End of quote: "done.""#, "Start again."]
         );
     }
+
+    #[test]
+    fn markdown_strong_with_internal_period_not_split() {
+        // CommonMark `**`: a period next to the closer is still inside the span.
+        let text = "This is **the end. Still bold** after.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == "**the end. Still bold**"),
+            "strong span must be one token, got {placeholders:?}"
+        );
+        assert_eq!(split(text), vec![text.to_string()]);
+    }
+
+    #[test]
+    fn markdown_strong_may_split_after_closer() {
+        assert_eq!(
+            split("It is **complex**. Equity is hard."),
+            vec!["It is **complex**.".to_string(), "Equity is hard.".to_string()]
+        );
+    }
+
+    #[test]
+    fn markdown_em_with_internal_period_not_split() {
+        let text = "This is *the end. Still em* after.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == "*the end. Still em*"),
+            "em span must be one token, got {placeholders:?}"
+        );
+        assert_eq!(split(text), vec![text.to_string()]);
+    }
+
+    #[test]
+    fn markdown_strike_with_internal_period_not_split() {
+        let text = "This is ~~the end. Still strike~~ after.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == "~~the end. Still strike~~"),
+            "strike span must be one token, got {placeholders:?}"
+        );
+        assert_eq!(split(text), vec![text.to_string()]);
+    }
+
+    #[test]
+    fn markdown_strong_inner_star_does_not_close_early() {
+        // Org `*bold*` closes on the first inner `*`. CommonMark flanking
+        // keeps `**a * b. C**` as one strong span, so the period stays inside.
+        let text = "Wrap **a * b. C** after. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == "**a * b. C**"),
+            "must not close strong on the inner star, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec!["Wrap **a * b. C** after.".to_string(), "Next.".to_string()]
+        );
+    }
+
+    #[test]
+    fn markdown_emphasis_format_text_does_not_break_inside_span() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let out = format_text("This is **the end. Still bold** after.\n", &cfg).unwrap();
+        assert!(
+            !out.contains("end.\nStill"),
+            "must not split inside **...**, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+
+        let out = format_text("It is **complex**. Equity is hard.\n", &cfg).unwrap();
+        assert!(
+            out.contains("**complex**.") && out.contains("Equity is hard."),
+            "may split after the closer, got:\n{out}"
+        );
+        assert!(
+            !out.contains("**complex.\n"),
+            "must not split before the closer, got:\n{out}"
+        );
+    }
 }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -116,7 +116,8 @@ pub fn protect_inline_tokens(text: &str) -> (String, Vec<String>) {
     (protected.into_owned(), placeholders)
 }
 
-/// Org `=`/`~` and Markdown backtick spans, paired to the real closer.
+/// Org `=`/`~`, Markdown backtick spans, CommonMark `*`/`**`, and GFM `~~`,
+/// paired to the real closer.
 ///
 /// Org markers follow the same walk as pandoc's org reader
 /// (`verbatimBetween` / `emphasisStart` / `emphasisEnd`, the Emacs
@@ -131,6 +132,9 @@ pub fn protect_inline_tokens(text: &str) -> (String, Vec<String>) {
 /// Markdown inline code uses CommonMark / pandoc fence-length matching: a
 /// run of `n` backticks closes on the next run of exactly `n` backticks, so
 /// a double span can hold a single backtick.
+///
+/// Markdown `*` / `**` use CommonMark flanking (not Org's pre/post classes).
+/// GFM `~~strike~~` is an exact two-tilde run.
 fn protect_paired_spans(text: &str, placeholders: &mut Vec<String>) -> String {
     let mut out = String::with_capacity(text.len());
     let bytes = text.as_bytes();
@@ -142,9 +146,27 @@ fn protect_paired_spans(text: &str, placeholders: &mut Vec<String>) -> String {
                 i = end;
                 continue;
             }
-        } else if bytes[i] == b'=' || bytes[i] == b'~' {
-            let marker = bytes[i] as char;
-            if let Some(end) = find_org_paired_span(text, i, marker) {
+        } else if bytes[i] == b'=' {
+            if let Some(end) = find_org_paired_span(text, i, '=') {
+                push_placeholder(&mut out, placeholders, &text[i..end]);
+                i = end;
+                continue;
+            }
+        } else if bytes[i] == b'~' {
+            // GFM `~~strike~~` before Org `~code~` so a double run is not
+            // eaten as one org span that happens to close at the last tilde.
+            if let Some(end) = find_md_strike_span(text, i) {
+                push_placeholder(&mut out, placeholders, &text[i..end]);
+                i = end;
+                continue;
+            }
+            if let Some(end) = find_org_paired_span(text, i, '~') {
+                push_placeholder(&mut out, placeholders, &text[i..end]);
+                i = end;
+                continue;
+            }
+        } else if bytes[i] == b'*' {
+            if let Some(end) = find_md_emphasis_span(text, i) {
                 push_placeholder(&mut out, placeholders, &text[i..end]);
                 i = end;
                 continue;
@@ -204,6 +226,127 @@ fn find_org_paired_span(text: &str, open_at: usize, marker: char) -> Option<usiz
         j += ch.len_utf8();
     }
     None
+}
+
+/// CommonMark flanking for `*` / `**` (and longer runs).
+///
+/// Edges of the text count as whitespace. A run can open when it is
+/// left-flanking (and not also right-flanking unless the previous character
+/// is punctuation). It closes on the nearest later run of `*` that is
+/// right-flanking and satisfies the rule of three: the sum of opener and
+/// closer lengths is not a multiple of 3, unless both lengths are.
+fn find_md_emphasis_span(text: &str, open_at: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if bytes.get(open_at) != Some(&b'*') {
+        return None;
+    }
+    let n = count_ascii_run(bytes, open_at, b'*');
+    if n == 0 {
+        return None;
+    }
+    let before = md_edge_char(text, open_at, false);
+    let after = md_edge_char(text, open_at + n, true);
+    let (left, right) = md_flanking(before, after);
+    if !(left && (!right || is_md_punctuation(before))) {
+        return None;
+    }
+
+    let mut j = open_at + n;
+    while j < text.len() {
+        let ch = text[j..].chars().next()?;
+        if ch == '*' {
+            let m = count_ascii_run(bytes, j, b'*');
+            let c_before = md_edge_char(text, j, false);
+            let c_after = md_edge_char(text, j + m, true);
+            let (c_left, c_right) = md_flanking(c_before, c_after);
+            let can_close = c_right && (!c_left || is_md_punctuation(c_after));
+            let three_ok = ((n + m) % 3 != 0) || (n % 3 == 0);
+            if can_close && three_ok && j > open_at + n {
+                return Some(j + m);
+            }
+            j += m;
+            continue;
+        }
+        j += ch.len_utf8();
+    }
+    None
+}
+
+/// GFM strikethrough: a run of exactly two `~` that is not followed by
+/// whitespace, closed by the next exact `~~` that is not preceded by
+/// whitespace.
+fn find_md_strike_span(text: &str, open_at: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if bytes.get(open_at) != Some(&b'~') || bytes.get(open_at + 1) != Some(&b'~') {
+        return None;
+    }
+    if bytes.get(open_at + 2) == Some(&b'~') {
+        return None;
+    }
+    let after_open = open_at + 2;
+    if after_open >= text.len() {
+        return None;
+    }
+    let first = text[after_open..].chars().next()?;
+    if first.is_whitespace() {
+        return None;
+    }
+    let mut j = after_open;
+    while j < text.len() {
+        let ch = text[j..].chars().next()?;
+        if ch == '~'
+            && bytes.get(j + 1) == Some(&b'~')
+            && bytes.get(j + 2) != Some(&b'~')
+            && j > after_open
+        {
+            let prev = text[..j].chars().next_back()?;
+            if !prev.is_whitespace() {
+                return Some(j + 2);
+            }
+        }
+        j += ch.len_utf8();
+    }
+    None
+}
+
+fn count_ascii_run(bytes: &[u8], start: usize, marker: u8) -> usize {
+    let mut n = 0;
+    while start + n < bytes.len() && bytes[start + n] == marker {
+        n += 1;
+    }
+    n
+}
+
+fn md_edge_char(text: &str, byte: usize, after: bool) -> char {
+    if after {
+        if byte >= text.len() {
+            '\n'
+        } else {
+            text[byte..].chars().next().unwrap_or('\n')
+        }
+    } else if byte == 0 {
+        '\n'
+    } else {
+        text[..byte].chars().next_back().unwrap_or('\n')
+    }
+}
+
+fn is_md_punctuation(c: char) -> bool {
+    if c.is_ascii() {
+        c.is_ascii_punctuation()
+    } else {
+        !c.is_alphanumeric() && !c.is_whitespace()
+    }
+}
+
+fn md_flanking(before: char, after: char) -> (bool, bool) {
+    let after_ws = after.is_whitespace();
+    let before_ws = before.is_whitespace();
+    let after_p = is_md_punctuation(after);
+    let before_p = is_md_punctuation(before);
+    let left = !after_ws && (!after_p || before_ws || before_p);
+    let right = !before_ws && (!before_p || after_ws || after_p);
+    (left, right)
 }
 
 fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
@@ -1175,7 +1318,10 @@ mod tests {
     fn markdown_strong_may_split_after_closer() {
         assert_eq!(
             split("It is **complex**. Equity is hard."),
-            vec!["It is **complex**.".to_string(), "Equity is hard.".to_string()]
+            vec![
+                "It is **complex**.".to_string(),
+                "Equity is hard.".to_string()
+            ]
         );
     }
 
@@ -1195,7 +1341,9 @@ mod tests {
         let text = "This is ~~the end. Still strike~~ after.";
         let (_, placeholders) = protect_inline_tokens(text);
         assert!(
-            placeholders.iter().any(|p| p == "~~the end. Still strike~~"),
+            placeholders
+                .iter()
+                .any(|p| p == "~~the end. Still strike~~"),
             "strike span must be one token, got {placeholders:?}"
         );
         assert_eq!(split(text), vec![text.to_string()]);


### PR DESCRIPTION
CommonMark `*` / `**` and GFM `~~` stay atomic, so a period inside `**the end. Still bold**` does not split the span. A period after the closer may still split.

Blockquotes keep `>` on each content line, including under `max_width`. Two-space and `\\` hard breaks stay hard. Multiline HTML comments pass through; `snapper:off` still works.

Rebased onto #16 (hanging indent).