### PR TITLE
feat: splice reflow with fail-closed backstops

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,11 @@ editors/word/dist/
 editors/word/node_modules/
 packages/snapper-wasm/node_modules/
 
+# cargo-fuzz
+fuzz/target/
+fuzz/artifacts/
+fuzz/coverage/
+
 # Haskell foreign-library build outputs
 native/snapper-pandoc/dist-newstyle/
 native/snapper-pandoc/lib/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. See [conven
 - - -
 ## Unreleased (main)
 
+#### Features
+- (**safety**) native parsers record source byte ranges and splice reflowed prose into the original document; Structure/Code/Blank are input slices
+- (**safety**) `format_text` runs to a byte fixpoint (cap 4) or returns the original; a format-local oracle mismatch (Markdown HTML, or native prose word sequence) also returns the original
+- (**safety**) `format_bytes` refuses invalid UTF-8 with `InvalidUtf8Error`; property tests and a `cargo fuzz` target drive `format_text` per format with the backstops off
 #### Bug Fixes
 - (**reflow**) list continuation sentences hang at the marker width so Org rejoins the item on reparse; Markdown quotes repeat the `>` prefix (`> One.` / `> Two.`, nested `> >`)
 - (**latex**) a trailing `%` eats the newline (TeX nospace join), so `foo%\\nbar` is no longer emitted as `foo% bar` (which comments out `bar`); mid-line `%` comments leave prose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ All notable changes to this project will be documented in this file. See [conven
 
 #### Features
 - (**safety**) native parsers record source byte ranges and splice reflowed prose into the original document; Structure/Code/Blank are input slices
-- (**safety**) `format_text` runs to a byte fixpoint (cap 4) or returns the original; a format-local oracle mismatch (Markdown HTML, or native prose word sequence) also returns the original
-- (**safety**) `format_bytes` refuses invalid UTF-8 with `InvalidUtf8Error`; property tests and a `cargo fuzz` target drive `format_text` per format with the backstops off
+- (**safety**) `format_text` runs to a byte fixpoint (cap 4, including A/B cycles) or returns the original; a format-local oracle (region-kind + slice tree; Markdown HTML plus a code-byte check) mismatch also returns the original
+- (**safety**) `format_bytes` refuses invalid UTF-8 with `InvalidUtf8Error`; `--use-pandoc` refuses (`PandocCannotSplice`) because the AST has no source offsets
+- (**safety**) property tests and a `cargo fuzz` target (fixture corpus) drive `format_text` per format with the backstops off
+- (**code-block**) comment reflow copies non-comment lines as original slices; only comment spans are rewritten
 #### Bug Fixes
 - (**reflow**) list continuation sentences hang at the marker width so Org rejoins the item on reparse; Markdown quotes repeat the `>` prefix (`> One.` / `> Two.`, nested `> >`)
 - (**latex**) a trailing `%` eats the newline (TeX nospace join), so `foo%\\nbar` is no longer emitted as `foo% bar` (which comments out `bar`); mid-line `%` comments leave prose

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1749,6 +1749,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.13.1",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,6 +2237,7 @@ dependencies = [
  "pandoc_ast",
  "pretty_assertions",
  "proptest",
+ "pulldown-cmark",
  "rayon",
  "regex",
  "rmcp",
@@ -2827,6 +2846,12 @@ name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,7 @@ regex = "1"
 textwrap = "0.16"
 thiserror = "2"
 anyhow = "1"
+pulldown-cmark = { version = "0.13", default-features = false, features = ["html"] }
 imara-diff = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "snapper-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2024"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+snapper-fmt = { path = ".." }
+
+[workspace]
+
+[[bin]]
+name = "format_text"
+path = "fuzz_targets/format_text.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/corpus/format_text/edge_cases.org
+++ b/fuzz/corpus/format_text/edge_cases.org
@@ -1,0 +1,66 @@
+#+TITLE: Edge Case Tests
+
+* Quoted and Parenthesized Punctuation
+
+He said "wow!" and then left. She agreed with him.
+
+The answer (really?) surprised everyone. They had not expected it.
+
+She asked "is it done?" before leaving. He nodded silently.
+
+The value (see Fig. 2!) is important. We discuss it below.
+
+* LaTeX Environments in Org
+
+The equation below shows the relationship.
+
+\begin{equation}
+E = mc^2
+\end{equation}
+
+This was proposed by Einstein. It changed physics forever.
+
+\begin{align}
+a &= b + c \\
+d &= e + f
+\end{align}
+
+The alignment above shows two equations. Both are important.
+
+* Display Math
+
+Consider the following expression.
+
+\[
+x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+\]
+
+This is the quadratic formula. It solves second-degree polynomials.
+
+* Export Snippets
+
+Some text before the page break.
+
+@@latex:\newpage@@
+
+Text after the page break. It continues here.
+
+Inline snippet @@html:<br>@@ in prose. More text follows.
+
+* URLs with Trailing Punctuation
+
+Visit https://example.com/page for details. Then read the docs.
+
+The API is at https://api.example.com/v2/endpoint. It supports JSON.
+
+See https://example.com/path?q=search&lang=en. The results are paginated.
+
+* Mixed Edge Cases
+
+Dr. Smith said "excellent!" and published the paper. The results (as shown in Fig. 3) were significant.
+
+Use `std::io::Read` for input. Then call `process()` to handle it.
+
+The value $x = 3.14$ is approximate. We use it throughout.
+
+See [[https://example.com][the example site]] for more. It has documentation.

--- a/fuzz/corpus/format_text/edge_cases.txt
+++ b/fuzz/corpus/format_text/edge_cases.txt
@@ -1,0 +1,19 @@
+He said "wow!" and then left. She agreed with him.
+
+The answer (really?) surprised everyone. They had not expected it.
+
+She asked "is it done?" before leaving. He nodded silently.
+
+Visit https://example.com/page for details. Then read the docs.
+
+The API is at https://api.example.com/v2/endpoint. It supports JSON.
+
+See https://example.com/path?q=search&lang=en. The results are paginated.
+
+Dr. Smith said "excellent!" and published the paper. The results (as shown in Fig. 3) were significant.
+
+Use `std::io::Read` for input. Then call `process()` to handle it.
+
+The value $x = 3.14$ is approximate. We use it throughout.
+
+Sentence one... Sentence two. Sentence three.

--- a/fuzz/corpus/format_text/expected.md
+++ b/fuzz/corpus/format_text/expected.md
@@ -1,0 +1,37 @@
+---
+title: Sample Document
+author: Dr. Smith
+---
+
+# Introduction
+
+This is the first paragraph of the introduction.
+It has multiple sentences that are wrapped across lines.
+See Fig. 3 for details.
+
+The second paragraph discusses related work.
+Previous studies have shown promising results.
+We build on this foundation.
+
+## Background
+
+Some background information here.
+The field has evolved rapidly.
+New methods, e.g. deep learning, have changed everything.
+
+```python
+import numpy as np
+x = np.array([1, 2, 3])
+```
+
+After the code, we discuss implications.
+These results are significant.
+
+- First item in a list
+- Second item with more text here
+- Third item discusses Dr. Johnson's findings
+
+| Feature           | Description                    | Status  |
+|-------------------|--------------------------------|---------|
+| `table_support`   | Preserve pipe-delimited tables | Done    |
+| `code_blocks`     | Fenced code block handling     | Done    |

--- a/fuzz/corpus/format_text/sample.md
+++ b/fuzz/corpus/format_text/sample.md
@@ -1,0 +1,30 @@
+---
+title: Sample Document
+author: Dr. Smith
+---
+
+# Introduction
+
+This is the first paragraph of the introduction. It has multiple sentences that are wrapped across lines. See Fig. 3 for details.
+
+The second paragraph discusses related work. Previous studies have shown promising results. We build on this foundation.
+
+## Background
+
+Some background information here. The field has evolved rapidly. New methods, e.g. deep learning, have changed everything.
+
+```python
+import numpy as np
+x = np.array([1, 2, 3])
+```
+
+After the code, we discuss implications. These results are significant.
+
+- First item in a list
+- Second item with more text here
+- Third item discusses Dr. Johnson's findings
+
+| Feature           | Description                    | Status  |
+|-------------------|--------------------------------|---------|
+| `table_support`   | Preserve pipe-delimited tables | Done    |
+| `code_blocks`     | Fenced code block handling     | Done    |

--- a/fuzz/corpus/format_text/sample.org
+++ b/fuzz/corpus/format_text/sample.org
@@ -1,0 +1,36 @@
+#+TITLE: Sample Paper
+#+AUTHOR: Dr. Smith
+
+* TODO Introduction
+
+This is the first paragraph of the introduction. It has multiple sentences that are wrapped across lines. See Fig. 3 for details.
+
+The second paragraph discusses related work. Previous studies by et al. have shown promising results. We build on this foundation.
+
+** Background
+
+:PROPERTIES:
+:ID: bg-section
+:END:
+
+Some background information here. The field has evolved rapidly over the past decade. New methods, e.g. deep learning, have transformed the landscape.
+
+#+BEGIN_SRC python
+import numpy as np
+x = np.array([1, 2, 3])
+#+END_SRC
+
+After the code, we discuss the implications. These results are significant.
+
+- First item in a list
+- Second item with more text here
+- Third item discusses Dr. Johnson's findings
+
+| Name  | Score |
+|-------+-------|
+| Alice |    95 |
+| Bob   |    87 |
+
+* Results
+
+The results show clear improvement. Fig. 1 illustrates the trend. We observe a 15% increase in performance vs. the baseline.

--- a/fuzz/corpus/format_text/sample.tex
+++ b/fuzz/corpus/format_text/sample.tex
@@ -1,0 +1,28 @@
+\documentclass{article}
+\usepackage{amsmath}
+\usepackage{graphicx}
+
+\title{Sample Paper}
+\author{Dr. Smith}
+
+\begin{document}
+\maketitle
+
+\section{Introduction}
+
+This is the first paragraph of the introduction. It has multiple sentences that span across lines. See Fig. 3 for the experimental setup.
+
+The second paragraph discusses methods. Previous work by et al. showed promising results. We extend these findings in several ways.
+
+\begin{equation}
+E = mc^2
+\end{equation}
+
+After the equation, we continue discussing. The energy-mass equivalence is fundamental.
+
+% This is a comment
+\section{Results}
+
+The results demonstrate clear improvement. We observe a 15\% increase in performance vs. the baseline. Table 1 summarizes the findings.
+
+\end{document}

--- a/fuzz/corpus/format_text/sample.txt
+++ b/fuzz/corpus/format_text/sample.txt
@@ -1,0 +1,5 @@
+This is a simple plaintext document. It contains multiple sentences that should be broken at sentence boundaries. The formatter should handle this correctly.
+
+Here is a second paragraph. Dr. Smith published his findings in 2024. The results were promising, e.g. a 20% improvement over baseline methods.
+
+A third paragraph with questions. Does this work? Yes! It handles various punctuation marks correctly.

--- a/fuzz/fuzz_targets/format_text.rs
+++ b/fuzz/fuzz_targets/format_text.rs
@@ -1,0 +1,58 @@
+//! libfuzzer target for `format_bytes` across every [`Format`].
+//!
+//! Run: `cargo fuzz run format_text` from the repository root (requires
+//! `cargo-fuzz`). The always-on `tests/safety_props.rs` suite covers the
+//! same oracles under proptest.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use snapper_fmt::format::Format;
+use snapper_fmt::oracle;
+use snapper_fmt::{format_bytes, FormatConfig, InvalidUtf8Error};
+
+fn cfg(format: Format) -> FormatConfig {
+    FormatConfig {
+        format,
+        fixpoint_backstop: false,
+        render_backstop: false,
+        ..Default::default()
+    }
+}
+
+fn format_of(b: u8) -> Format {
+    match b % 5 {
+        0 => Format::Plaintext,
+        1 => Format::Markdown,
+        2 => Format::Org,
+        3 => Format::Latex,
+        _ => Format::Rst,
+    }
+}
+
+fuzz_target!(|data: &[u8]| {
+    if data.is_empty() {
+        return;
+    }
+    let format = format_of(data[0]);
+    let src = &data[1..];
+    let c = cfg(format);
+    match format_bytes(src, &c) {
+        Err(e) => {
+            assert!(
+                e.downcast_ref::<InvalidUtf8Error>().is_some(),
+                "only InvalidUtf8Error is allowed, got {e}"
+            );
+        }
+        Ok(out) => {
+            let twice = format_bytes(&out, &c).expect("second pass on valid UTF-8");
+            assert_eq!(out, twice, "not idempotent");
+            let s = std::str::from_utf8(src).unwrap();
+            let o = std::str::from_utf8(&out).unwrap();
+            assert!(
+                oracle::matches(format, s, o),
+                "oracle mismatch\n in={s:?}\n out={o:?}"
+            );
+        }
+    }
+});

--- a/fuzz/fuzz_targets/format_text.rs
+++ b/fuzz/fuzz_targets/format_text.rs
@@ -31,28 +31,27 @@ fn format_of(b: u8) -> Format {
 }
 
 fuzz_target!(|data: &[u8]| {
-    if data.is_empty() {
-        return;
-    }
-    let format = format_of(data[0]);
-    let src = &data[1..];
-    let c = cfg(format);
-    match format_bytes(src, &c) {
-        Err(e) => {
-            assert!(
-                e.downcast_ref::<InvalidUtf8Error>().is_some(),
-                "only InvalidUtf8Error is allowed, got {e}"
-            );
-        }
-        Ok(out) => {
-            let twice = format_bytes(&out, &c).expect("second pass on valid UTF-8");
-            assert_eq!(out, twice, "not idempotent");
-            let s = std::str::from_utf8(src).unwrap();
-            let o = std::str::from_utf8(&out).unwrap();
-            assert!(
-                oracle::matches(format, s, o),
-                "oracle mismatch\n in={s:?}\n out={o:?}"
-            );
+    // Fixture corpus files are raw document bytes. Drive every Format.
+    for tag in 0u8..5 {
+        let format = format_of(tag);
+        let c = cfg(format);
+        match format_bytes(data, &c) {
+            Err(e) => {
+                assert!(
+                    e.downcast_ref::<InvalidUtf8Error>().is_some(),
+                    "only InvalidUtf8Error is allowed, got {e}"
+                );
+            }
+            Ok(out) => {
+                let twice = format_bytes(&out, &c).expect("second pass on valid UTF-8");
+                assert_eq!(out, twice, "not idempotent");
+                if let (Ok(s), Ok(o)) = (std::str::from_utf8(data), std::str::from_utf8(&out)) {
+                    assert!(
+                        oracle::matches(format, s, o),
+                        "oracle mismatch format={format:?}\n in={s:?}\n out={o:?}"
+                    );
+                }
+            }
         }
     }
 });

--- a/src/code_block.rs
+++ b/src/code_block.rs
@@ -77,55 +77,49 @@ pub fn reflow_code_body(
     after_comment_reflow
 }
 
-/// Run the comment-reflow pass. Pure function; no I/O.
+/// Run the comment-reflow pass. Non-comment lines stay original slices;
+/// only comment spans are rewritten.
 fn reflow_comments(body: &str, cfg: &CodeLang, splitter: &dyn SentenceSplitter) -> String {
+    let lines = crate::parser::iter_lines(body);
     let mut out = String::with_capacity(body.len());
-    let mut iter = body.lines().peekable();
+    let mut i = 0;
     let mut pragma_off = false;
-    // Track whether the original body ended with a trailing newline so we
-    // can reproduce it byte-identically.
-    let trailing_newline = body.ends_with('\n');
 
-    while let Some(line) = iter.next() {
-        // Pragma check first; lines between off/on are verbatim.
-        if let Some(on) = check_pragma_for(line, cfg) {
+    while i < lines.len() {
+        let line = lines[i];
+        let slice = &body[line.start..line.end];
+
+        if let Some(on) = check_pragma_for(line.text, cfg) {
             pragma_off = !on;
-            out.push_str(line);
-            out.push('\n');
+            out.push_str(slice);
+            i += 1;
             continue;
         }
         if pragma_off {
-            out.push_str(line);
-            out.push('\n');
+            out.push_str(slice);
+            i += 1;
             continue;
         }
 
-        // Try block-comment open. If matched, accumulate to the close marker
-        // and reflow the interior as plaintext.
         if let Some(ref pair) = cfg.block_comment {
             let [open, close] = [pair[0].as_str(), pair[1].as_str()];
             if !open.is_empty() {
-                if let Some((indent, after_open)) = split_at_marker(line, open) {
-                    // Same-line open + close (e.g. `/* one sentence. */`)?
+                if let Some((indent, after_open)) = split_at_marker(line.text, open) {
                     let trimmed_after = after_open.trim_start();
                     if !close.is_empty() {
                         if let Some(idx) = find_close(trimmed_after, close, cfg) {
                             let interior = &trimmed_after[..idx];
-                            // Emit: indent + open\n + reflowed interior\n + indent + close\n
                             emit_block_comment(&mut out, indent, open, close, interior, splitter);
+                            i += 1;
                             continue;
                         }
                     }
-                    // Multi-line block comment: gather body until close marker.
                     let mut interior = after_open.to_string();
                     let mut close_indent: Option<String> = None;
-                    let mut closed = false;
-                    for next in iter.by_ref() {
-                        if let Some(idx) = find_close(next, close, cfg) {
-                            // Found close. Anything before it (on this line)
-                            // joins the interior; the close marker stays on
-                            // its own emitted line at its original indent.
-                            let pre = &next[..idx];
+                    let mut closed_at = None;
+                    for (j, next) in lines.iter().enumerate().skip(i + 1) {
+                        if let Some(idx) = find_close(next.text, close, cfg) {
+                            let pre = &next.text[..idx];
                             let pre_trim = pre.trim();
                             if !pre_trim.is_empty() {
                                 if !interior.is_empty() && !interior.ends_with(' ') {
@@ -133,14 +127,14 @@ fn reflow_comments(body: &str, cfg: &CodeLang, splitter: &dyn SentenceSplitter) 
                                 }
                                 interior.push_str(pre_trim);
                             }
-                            close_indent =
-                                Some(next[..next.len() - next.trim_start().len()].to_string());
-                            closed = true;
+                            close_indent = Some(
+                                next.text[..next.text.len() - next.text.trim_start().len()]
+                                    .to_string(),
+                            );
+                            closed_at = Some(j);
                             break;
                         }
-                        let stripped = next.trim_start();
-                        // Strip a leading `*` decoration commonly used in
-                        // C/Java/JS doc comments, plus one optional space.
+                        let stripped = next.text.trim_start();
                         let stripped = stripped
                             .strip_prefix("* ")
                             .or_else(|| stripped.strip_prefix('*'))
@@ -150,7 +144,7 @@ fn reflow_comments(body: &str, cfg: &CodeLang, splitter: &dyn SentenceSplitter) 
                         }
                         interior.push_str(stripped.trim());
                     }
-                    if closed {
+                    if let Some(j) = closed_at {
                         let ci = close_indent.unwrap_or_else(|| indent.to_string());
                         emit_block_comment_multi(
                             &mut out,
@@ -161,70 +155,63 @@ fn reflow_comments(body: &str, cfg: &CodeLang, splitter: &dyn SentenceSplitter) 
                             interior.trim(),
                             splitter,
                         );
+                        i = j + 1;
                         continue;
                     }
-                    // Unterminated block comment: emit interior we accumulated
-                    // and bail out (best-effort; keep input shape).
-                    out.push_str(line);
-                    out.push('\n');
-                    if !interior.is_empty() {
-                        out.push_str(interior.trim_end());
-                        out.push('\n');
+                    // Unterminated: copy original slices through EOF.
+                    for keep in &lines[i..] {
+                        out.push_str(&body[keep.start..keep.end]);
                     }
-                    continue;
+                    break;
                 }
             }
         }
 
-        // Line-comment reflow.
         if let Some(ref marker) = cfg.line_comment {
-            if let Some((indent, marker, rest)) = strip_line_comment(line, marker) {
+            if let Some((indent, marker, rest)) = strip_line_comment(line.text, marker) {
                 let prose = rest.trim();
                 if prose.is_empty() {
-                    out.push_str(line);
-                    out.push('\n');
+                    out.push_str(slice);
+                    i += 1;
                     continue;
                 }
-                // If this comment line is the pragma itself we already handled
-                // it above. Reflow as plaintext.
                 let sentences = splitter.split(prose);
-                if sentences.is_empty() {
-                    out.push_str(line);
-                    out.push('\n');
+                if sentences.len() <= 1 {
+                    out.push_str(slice);
+                    i += 1;
                     continue;
                 }
-                for s in &sentences {
+                for (k, s) in sentences.iter().enumerate() {
                     out.push_str(indent);
                     out.push_str(marker);
                     out.push(' ');
                     out.push_str(s);
-                    out.push('\n');
+                    if k + 1 < sentences.len() {
+                        out.push('\n');
+                    } else {
+                        out.push_str(
+                            &body[line.terminator_span().start..line.terminator_span().end],
+                        );
+                    }
                 }
+                i += 1;
                 continue;
             }
         }
 
-        // A comment trailing real code. Without a grammar the only way to
-        // tell this marker from the same characters inside a literal is to
-        // track quoting, so that is what `trailing_comment_at` does.
         if let Some(ref marker) = cfg.line_comment {
-            if let Some(at) = trailing_comment_at(line, marker, cfg) {
-                if let Some(rewritten) = rewrite_trailing(line, at, marker, splitter) {
+            if let Some(at) = trailing_comment_at(line.text, marker, cfg) {
+                if let Some(rewritten) = rewrite_trailing(line.text, at, marker, splitter) {
                     out.push_str(&rewritten);
-                    out.push('\n');
+                    out.push_str(&body[line.terminator_span().start..line.terminator_span().end]);
+                    i += 1;
                     continue;
                 }
             }
         }
 
-        // Non-comment line: passthrough.
-        out.push_str(line);
-        out.push('\n');
-    }
-
-    // Reproduce trailing-newline shape of the input.
-    if !trailing_newline && out.ends_with('\n') {
-        out.pop();
+        out.push_str(slice);
+        i += 1;
     }
     out
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ use anyhow::Result;
 
 use crate::config::CodeLang;
 use crate::format::Format;
-use crate::reflow::{ReflowConfig, reflow};
+use crate::reflow::ReflowConfig;
 use crate::sentence::SentenceSplitter;
 use crate::sentence::unicode::UnicodeSentenceSplitter;
 
@@ -136,9 +136,54 @@ impl Default for FormatConfig {
 #[error("input is not valid UTF-8")]
 pub struct InvalidUtf8Error;
 
+/// Pandoc's AST has no source offsets, so it cannot splice into original
+/// bytes. `format_text` refuses rather than reconstruct.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("pandoc backend cannot splice original source bytes")]
+pub struct PandocCannotSplice;
+
 /// Maximum pipeline passes including the first. Cap hit (or an A/B cycle)
 /// returns the original document unchanged.
 const MAX_FORMAT_PASSES: usize = 4;
+
+impl FormatConfig {
+    /// Tests that assert planner properties (idempotence, oracle, splice)
+    /// must disable both backstops so a planner that needs them fails.
+    pub fn without_safety_backstops(mut self) -> Self {
+        self.fixpoint_backstop = false;
+        self.render_backstop = false;
+        self
+    }
+}
+
+/// Run `step` until the output is a byte fixpoint or the cap is hit.
+///
+/// A cycle (including A/B) or a cap miss returns `original`. `enabled`
+/// false runs `step` once. Public so tests can inject a cycling step.
+pub fn run_fixpoint<F>(original: &str, enabled: bool, mut step: F) -> Result<String>
+where
+    F: FnMut(&str) -> Result<String>,
+{
+    let once = step(original)?;
+    if !enabled {
+        return Ok(once);
+    }
+    let mut cur = once;
+    let mut seen = std::collections::HashSet::new();
+    seen.insert(original.to_string());
+    seen.insert(cur.clone());
+    for _ in 1..MAX_FORMAT_PASSES {
+        let next = step(&cur)?;
+        if next == cur {
+            return Ok(cur);
+        }
+        if !seen.insert(next.clone()) {
+            return Ok(original.to_string());
+        }
+        cur = next;
+    }
+    Ok(original.to_string())
+}
 
 /// Build the appropriate sentence splitter from config.
 pub fn build_splitter(config: &FormatConfig) -> Result<Box<dyn SentenceSplitter>> {
@@ -204,37 +249,20 @@ pub fn format_text_with_splitter(
     };
 
     let once = format_once(work_input, config, splitter, config.format_code)?;
-    let candidate = if config.fixpoint_backstop && !config.use_pandoc {
-        let mut cur = once;
-        let mut converged = false;
-        // Later passes prove prose stability. External code formatters
-        // already ran on the first pass; re-invoking them multiplies
-        // timeout budgets and is not part of the planner fixpoint.
-        for _ in 1..MAX_FORMAT_PASSES {
-            let next = format_once(&cur, config, splitter, false)?;
-            if next == cur {
-                converged = true;
-                break;
-            }
-            cur = next;
-        }
-        if converged {
-            cur
+    // Later passes prove prose stability. External code formatters
+    // already ran on the first pass; re-invoking them multiplies
+    // timeout budgets and is not part of the planner fixpoint.
+    let candidate = run_fixpoint(work_input, config.fixpoint_backstop, |cur| {
+        if cur == work_input {
+            Ok(once.clone())
         } else {
-            work_input.to_string()
+            format_once(cur, config, splitter, false)
         }
-    } else {
-        once
-    };
+    })?;
 
-    // The render backstop is for the splice path: output is original
-    // bytes plus reflowed prose. Pandoc reconstructs from an AST, so
-    // goldmark/pulldown HTML of that reconstruction is not comparable
-    // to the source and must not veto a successful reflow.
     let candidate = if config.render_backstop
-        && !config.use_pandoc
         && candidate != work_input
-        && !oracle::matches(config.format, work_input, &candidate)
+        && !oracle::matches_ex(config.format, work_input, &candidate, config.format_code)
     {
         work_input.to_string()
     } else {
@@ -296,11 +324,12 @@ fn format_once(
                 });
             let parser =
                 parser::pandoc::PandocParser::with_backend(pandoc_fmt, config.pandoc_backend);
-            // Pandoc path: fail closed (no silent all-prose, no native re-parse).
-            let regions = parser
+            // Surface parse errors (no silent all-prose). Splice still
+            // requires source offsets the AST does not carry.
+            parser
                 .try_parse(work_input)
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
-            return Ok(reflow(&regions, splitter, &reflow_config));
+            return Err(anyhow::Error::new(PandocCannotSplice));
         }
         #[cfg(not(feature = "pandoc"))]
         {
@@ -312,12 +341,10 @@ fn format_once(
 
     let spanned: Vec<SpannedRegion> =
         parser::parser_for_format(config.format).parse_full(work_input);
-    Ok(reflow_spanned(
-        work_input,
-        &spanned,
-        splitter,
-        &reflow_config,
-    ))
+    match reflow_spanned(work_input, &spanned, splitter, &reflow_config) {
+        Ok(out) => Ok(out),
+        Err(_) => Ok(work_input.to_string()),
+    }
 }
 
 /// Format only lines within a range (1-indexed, inclusive).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ pub mod init;
 pub mod lsp;
 #[cfg(feature = "mcp")]
 pub mod mcp;
+pub mod oracle;
 pub mod output;
 pub mod parser;
 pub mod reflow;
@@ -99,6 +100,13 @@ pub struct FormatConfig {
     /// under `max_width` (sembr rule 5). Default `false` keeps plain
     /// `textwrap::fill` behaviour.
     pub clause_breaks: bool,
+    /// Run `format_text` to a byte fixpoint (cap 4). Production default
+    /// `true`; tests set `false` so a planner that needs the backstop fails.
+    pub fixpoint_backstop: bool,
+    /// After the fixpoint, a format-local oracle mismatch returns the
+    /// original document. Production default `true`; tests set `false`
+    /// and assert the oracle themselves.
+    pub render_backstop: bool,
 }
 
 impl Default for FormatConfig {
@@ -117,9 +125,20 @@ impl Default for FormatConfig {
             code: HashMap::new(),
             format_code: false,
             clause_breaks: false,
+            fixpoint_backstop: true,
+            render_backstop: true,
         }
     }
 }
+
+/// Typed error for invalid UTF-8 input. Branch with `error.downcast_ref`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("input is not valid UTF-8")]
+pub struct InvalidUtf8Error;
+
+/// Maximum pipeline passes including the first. Cap hit (or an A/B cycle)
+/// returns the original document unchanged.
+const MAX_FORMAT_PASSES: usize = 4;
 
 /// Build the appropriate sentence splitter from config.
 pub fn build_splitter(config: &FormatConfig) -> Result<Box<dyn SentenceSplitter>> {
@@ -160,6 +179,12 @@ pub fn format_text(input: &str, config: &FormatConfig) -> Result<String> {
     format_text_with_splitter(input, config, splitter.as_ref())
 }
 
+/// Format raw bytes. Invalid UTF-8 is a hard error ([`InvalidUtf8Error`]).
+pub fn format_bytes(input: &[u8], config: &FormatConfig) -> Result<Vec<u8>> {
+    let s = std::str::from_utf8(input).map_err(|_| anyhow::Error::new(InvalidUtf8Error))?;
+    format_text(s, config).map(|s| s.into_bytes())
+}
+
 /// Format text using a pre-constructed splitter (avoids reloading models per file).
 pub fn format_text_with_splitter(
     input: &str,
@@ -178,47 +203,45 @@ pub fn format_text_with_splitter(
         input
     };
 
-    // Two pipelines:
-    // - use_pandoc: pandoc parses source → AST → regions by node kind → reflow prose only.
-    // - else: native line parsers (markdown/org/…) then reflow. Never mixed after success.
-    let regions = if config.use_pandoc {
-        #[cfg(feature = "pandoc")]
-        {
-            let pandoc_fmt = config
-                .pandoc_format
-                .as_deref()
-                .unwrap_or(match config.format {
-                    Format::Org => "org",
-                    Format::Latex => "latex",
-                    Format::Markdown => "markdown",
-                    Format::Rst => "rst",
-                    Format::Plaintext => "markdown",
-                });
-            let parser =
-                parser::pandoc::PandocParser::with_backend(pandoc_fmt, config.pandoc_backend);
-            // Pandoc path: fail closed (no silent all-prose, no native re-parse).
-            parser
-                .try_parse(work_input)
-                .map_err(|e| anyhow::anyhow!("{e}"))?
+    let once = format_once(work_input, config, splitter, config.format_code)?;
+    let candidate = if config.fixpoint_backstop && !config.use_pandoc {
+        let mut cur = once;
+        let mut converged = false;
+        // Later passes prove prose stability. External code formatters
+        // already ran on the first pass; re-invoking them multiplies
+        // timeout budgets and is not part of the planner fixpoint.
+        for _ in 1..MAX_FORMAT_PASSES {
+            let next = format_once(&cur, config, splitter, false)?;
+            if next == cur {
+                converged = true;
+                break;
+            }
+            cur = next;
         }
-        #[cfg(not(feature = "pandoc"))]
-        {
-            return Err(anyhow::anyhow!(
-                "pandoc backend requires the 'pandoc' feature"
-            ));
+        if converged {
+            cur
+        } else {
+            work_input.to_string()
         }
     } else {
-        parser::parser_for_format(config.format).parse(work_input)
+        once
     };
 
-    let reflow_config = ReflowConfig {
-        max_width: config.max_width,
-        code: Some(&config.code),
-        format_code: config.format_code,
-        clause_breaks: config.clause_breaks,
+    // The render backstop is for the splice path: output is original
+    // bytes plus reflowed prose. Pandoc reconstructs from an AST, so
+    // goldmark/pulldown HTML of that reconstruction is not comparable
+    // to the source and must not veto a successful reflow.
+    let candidate = if config.render_backstop
+        && !config.use_pandoc
+        && candidate != work_input
+        && !oracle::matches(config.format, work_input, &candidate)
+    {
+        work_input.to_string()
+    } else {
+        candidate
     };
 
-    let mut output = reflow(&regions, splitter, &reflow_config);
+    let mut output = candidate;
 
     // Preserve the original file's trailing newline convention.
     if had_trailing_newline && !output.ends_with('\n') {
@@ -235,6 +258,66 @@ pub fn format_text_with_splitter(
     }
 
     Ok(output)
+}
+
+/// One parse+reflow pass. Native parsers splice into original bytes;
+/// pandoc concatenates reconstructed regions.
+fn format_once(
+    work_input: &str,
+    config: &FormatConfig,
+    splitter: &dyn SentenceSplitter,
+    format_code: bool,
+) -> Result<String> {
+    use crate::parser::SpannedRegion;
+    use crate::reflow::reflow_spanned;
+
+    let reflow_config = ReflowConfig {
+        max_width: config.max_width,
+        code: Some(&config.code),
+        format_code,
+        clause_breaks: config.clause_breaks,
+    };
+
+    // Two pipelines:
+    // - use_pandoc: pandoc parses source → AST → regions by node kind → reflow prose only.
+    // - else: native line parsers (markdown/org/…) then splice. Never mixed after success.
+    if config.use_pandoc {
+        #[cfg(feature = "pandoc")]
+        {
+            let pandoc_fmt = config
+                .pandoc_format
+                .as_deref()
+                .unwrap_or(match config.format {
+                    Format::Org => "org",
+                    Format::Latex => "latex",
+                    Format::Markdown => "markdown",
+                    Format::Rst => "rst",
+                    Format::Plaintext => "markdown",
+                });
+            let parser =
+                parser::pandoc::PandocParser::with_backend(pandoc_fmt, config.pandoc_backend);
+            // Pandoc path: fail closed (no silent all-prose, no native re-parse).
+            let regions = parser
+                .try_parse(work_input)
+                .map_err(|e| anyhow::anyhow!("{e}"))?;
+            return Ok(reflow(&regions, splitter, &reflow_config));
+        }
+        #[cfg(not(feature = "pandoc"))]
+        {
+            return Err(anyhow::anyhow!(
+                "pandoc backend requires the 'pandoc' feature"
+            ));
+        }
+    }
+
+    let spanned: Vec<SpannedRegion> =
+        parser::parser_for_format(config.format).parse_full(work_input);
+    Ok(reflow_spanned(
+        work_input,
+        &spanned,
+        splitter,
+        &reflow_config,
+    ))
 }
 
 /// Format only lines within a range (1-indexed, inclusive).

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -45,8 +45,11 @@ fn structure_tree_ok(
     output: &str,
     allow_code_body_rewrite: bool,
 ) -> bool {
-    let a = parser_for_format(format).parse(original);
-    let b = parser_for_format(format).parse(output);
+    // Hang list/quote continuations (`> One.` / `> Two.`) reparse as more
+    // regions than the source. Coalesce adjacent same-marker items so the
+    // tree compares as one item with the same prose words.
+    let a = coalesce_hang_items(&parser_for_format(format).parse(original));
+    let b = coalesce_hang_items(&parser_for_format(format).parse(output));
     if a.len() != b.len() {
         return false;
     }
@@ -92,6 +95,67 @@ fn structure_tree_ok(
 
 fn words(s: &str) -> Vec<&str> {
     s.split_whitespace().collect()
+}
+
+/// Join adjacent list/quote items that share a marker.
+///
+/// `> One.\n> Two.` parses as two Structure+Prose pairs; hanging indent
+/// emitted that from one source item. Folding them keeps the oracle from
+/// vetoing a render-preserving hang.
+fn coalesce_hang_items(regions: &[Region]) -> Vec<Region> {
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < regions.len() {
+        let Region::Structure(marker) = &regions[i] else {
+            out.push(regions[i].clone());
+            i += 1;
+            continue;
+        };
+        if !crate::reflow::is_hanging_marker(marker) {
+            out.push(regions[i].clone());
+            i += 1;
+            continue;
+        }
+        let marker = marker.clone();
+        let mut prose = String::new();
+        i += 1;
+        loop {
+            match regions.get(i) {
+                Some(Region::Prose(p)) => {
+                    if !prose.is_empty() {
+                        prose.push(' ');
+                    }
+                    prose.push_str(p);
+                    i += 1;
+                }
+                Some(Region::Structure(nl)) if nl == "\n" => {
+                    let same_marker = matches!(
+                        regions.get(i + 1),
+                        Some(Region::Structure(m2)) if *m2 == marker
+                    );
+                    if same_marker {
+                        i += 2;
+                        continue;
+                    }
+                    out.push(Region::Structure(marker));
+                    if !prose.is_empty() {
+                        out.push(Region::Prose(prose));
+                    }
+                    out.push(Region::Structure(nl.clone()));
+                    i += 1;
+                    break;
+                }
+                _ => {
+                    out.push(Region::Structure(marker));
+                    if !prose.is_empty() {
+                        out.push(Region::Prose(prose));
+                    }
+                    break;
+                }
+            }
+        }
+    }
+    out
 }
 
 /// Code bodies stay slices except rewritten comment lines.
@@ -221,5 +285,29 @@ mod tests {
     fn structure_tree_sees_invented_newline() {
         assert!(!matches(Format::Markdown, "## Title", "## Title\n"));
         assert!(!matches(Format::Org, "* TODO a", "* TODO a\n"));
+    }
+
+    #[test]
+    fn hung_quote_matches_source_item() {
+        assert!(matches(
+            Format::Markdown,
+            "> One. Two.\n",
+            "> One.\n> Two.\n"
+        ));
+        assert!(matches(
+            Format::Markdown,
+            "> Quoted one. Quoted two.\n> > Nested one. Nested two.\n",
+            "> Quoted one.\n> Quoted two.\n> > Nested one.\n> > Nested two.\n"
+        ));
+    }
+
+    #[test]
+    fn hung_list_matches_source_item() {
+        assert!(matches(
+            Format::Markdown,
+            "- One. Two.\n",
+            "- One.\n  Two.\n"
+        ));
+        assert!(matches(Format::Org, "- One. Two.\n", "- One.\n  Two.\n"));
     }
 }

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -3,24 +3,133 @@
 //! After a fixpoint, `format_text` compares input and output under a
 //! format-specific check. A mismatch returns the original document.
 //! Tests disable the backstop and assert the oracle themselves.
+//!
+//! The oracle is a native region-kind + slice tree for every format:
+//! Structure/Blank must be byte-identical, Code headers/footers must be
+//! identical, Code bodies may change only in comment lines, and Prose may
+//! only move inter-word whitespace. Markdown also compares pulldown-cmark
+//! HTML (including `<pre>` contents unless the only delta is a comment
+//! reflow already allowed by the code-byte check).
 
 use crate::format::Format;
-use crate::parser::Region;
+use crate::parser::{Region, parser_for_format};
 
 /// True when `output` is a render-safe reflow of `original`.
 pub fn matches(format: Format, original: &str, output: &str) -> bool {
+    matches_ex(format, original, output, false)
+}
+
+/// `allow_code_body_rewrite` is set when an opt-in external formatter may
+/// replace a code body. Comment-only reflow does not need it.
+pub fn matches_ex(
+    format: Format,
+    original: &str,
+    output: &str,
+    allow_code_body_rewrite: bool,
+) -> bool {
     if original == output {
         return true;
     }
-    match format {
-        Format::Markdown => md_html_normalized(original) == md_html_normalized(output),
-        Format::Org | Format::Latex | Format::Rst | Format::Plaintext => {
-            prose_words(format, original) == prose_words(format, output)
-        }
+    if !structure_tree_ok(format, original, output, allow_code_body_rewrite) {
+        return false;
     }
+    if format == Format::Markdown {
+        return md_html_ok(original, output);
+    }
+    true
 }
 
-fn md_html_normalized(src: &str) -> String {
+fn structure_tree_ok(
+    format: Format,
+    original: &str,
+    output: &str,
+    allow_code_body_rewrite: bool,
+) -> bool {
+    let a = parser_for_format(format).parse(original);
+    let b = parser_for_format(format).parse(output);
+    if a.len() != b.len() {
+        return false;
+    }
+    for (ra, rb) in a.iter().zip(&b) {
+        match (ra, rb) {
+            (Region::Prose(x), Region::Prose(y)) => {
+                if words(x) != words(y) {
+                    return false;
+                }
+            }
+            (Region::Structure(x), Region::Structure(y))
+            | (Region::BlankLines(x), Region::BlankLines(y)) => {
+                if x != y {
+                    return false;
+                }
+            }
+            (
+                Region::Code {
+                    lang: la,
+                    header: ha,
+                    body: ba,
+                    footer: fa,
+                },
+                Region::Code {
+                    lang: lb,
+                    header: hb,
+                    body: bb,
+                    footer: fb,
+                },
+            ) => {
+                if la != lb || ha != hb || fa != fb {
+                    return false;
+                }
+                if !allow_code_body_rewrite && !code_body_ok(ba, bb) {
+                    return false;
+                }
+            }
+            _ => return false,
+        }
+    }
+    true
+}
+
+fn words(s: &str) -> Vec<&str> {
+    s.split_whitespace().collect()
+}
+
+/// Code bodies stay slices except rewritten comment lines.
+fn code_body_ok(original: &str, output: &str) -> bool {
+    if original == output {
+        return true;
+    }
+    non_comment_lines(original) == non_comment_lines(output)
+}
+
+fn non_comment_lines(body: &str) -> Vec<&str> {
+    body.lines().filter(|l| !looks_like_comment(l)).collect()
+}
+
+fn looks_like_comment(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with("//")
+        || t.starts_with('#')
+        || t.starts_with("--")
+        || t.starts_with(';')
+        || t.starts_with("/*")
+        || t.starts_with('*')
+        || t.starts_with("*/")
+}
+
+fn md_html_ok(original: &str, output: &str) -> bool {
+    let ha = md_html(original);
+    let hb = md_html(output);
+    if normalize_ws(&ha) == normalize_ws(&hb) {
+        return true;
+    }
+    // Full HTML (including `<pre>`) differed. Allow only when the
+    // non-pre document matches and the code-byte check already passed
+    // via the structure tree.
+    normalize_ws(&html_without_pre_inner(&ha)) == normalize_ws(&html_without_pre_inner(&hb))
+}
+
+fn md_html(src: &str) -> String {
     use pulldown_cmark::{Options, Parser, html};
     let mut opts = Options::empty();
     opts.insert(Options::ENABLE_TABLES);
@@ -30,27 +139,29 @@ fn md_html_normalized(src: &str) -> String {
     let parser = Parser::new_ext(src, opts);
     let mut html_output = String::new();
     html::push_html(&mut html_output, parser);
-    // Fenced/indented code may have comment reflow (`// a. b.` → two
-    // `//` lines). That is an intentional rewrite; the oracle still
-    // guards prose render around the blocks.
-    let without_pre = strip_pre(&html_output);
-    normalize_ws(&without_pre)
+    html_output
 }
 
-fn strip_pre(html: &str) -> String {
+/// Keep `<pre></pre>` tags so a missing/extra fence still fails, but drop
+/// inner text that the code-byte check already judged.
+fn html_without_pre_inner(html: &str) -> String {
     let mut out = String::with_capacity(html.len());
     let mut rest = html;
     while let Some(start) = rest.find("<pre") {
         out.push_str(&rest[..start]);
         let after = &rest[start..];
-        if let Some(end) = after.find("</pre>") {
-            out.push_str("<pre></pre>");
-            rest = &after[end + 6..];
-        } else {
-            out.push_str(after);
-            rest = "";
-            break;
+        if let Some(gt) = after.find('>') {
+            out.push_str(&after[..=gt]);
+            let inner = &after[gt + 1..];
+            if let Some(end) = inner.find("</pre>") {
+                out.push_str("</pre>");
+                rest = &inner[end + 6..];
+                continue;
+            }
         }
+        out.push_str(after);
+        rest = "";
+        break;
     }
     out.push_str(rest);
     out
@@ -73,9 +184,9 @@ fn normalize_ws(s: &str) -> String {
     out.trim().to_string()
 }
 
-/// Word sequence of prose regions only (structure/code/blank ignored).
+/// Word sequence of prose regions only.
 pub fn prose_words(format: Format, text: &str) -> Vec<String> {
-    let regions = crate::parser::parser_for_format(format).parse(text);
+    let regions = parser_for_format(format).parse(text);
     let mut words = Vec::new();
     for r in regions {
         if let Region::Prose(p) = r {
@@ -93,7 +204,7 @@ mod tests {
     fn md_html_ignores_soft_breaks() {
         let a = "Hello world. Next sentence.";
         let b = "Hello world.\nNext sentence.";
-        assert_eq!(md_html_normalized(a), md_html_normalized(b));
+        assert!(matches(Format::Markdown, a, b));
     }
 
     #[test]
@@ -104,5 +215,11 @@ mod tests {
             prose_words(Format::Plaintext, a),
             prose_words(Format::Plaintext, b)
         );
+    }
+
+    #[test]
+    fn structure_tree_sees_invented_newline() {
+        assert!(!matches(Format::Markdown, "## Title", "## Title\n"));
+        assert!(!matches(Format::Org, "* TODO a", "* TODO a\n"));
     }
 }

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -1,0 +1,108 @@
+//! Format-local render oracle used as a fail-closed backstop.
+//!
+//! After a fixpoint, `format_text` compares input and output under a
+//! format-specific check. A mismatch returns the original document.
+//! Tests disable the backstop and assert the oracle themselves.
+
+use crate::format::Format;
+use crate::parser::Region;
+
+/// True when `output` is a render-safe reflow of `original`.
+pub fn matches(format: Format, original: &str, output: &str) -> bool {
+    if original == output {
+        return true;
+    }
+    match format {
+        Format::Markdown => md_html_normalized(original) == md_html_normalized(output),
+        Format::Org | Format::Latex | Format::Rst | Format::Plaintext => {
+            prose_words(format, original) == prose_words(format, output)
+        }
+    }
+}
+
+fn md_html_normalized(src: &str) -> String {
+    use pulldown_cmark::{Options, Parser, html};
+    let mut opts = Options::empty();
+    opts.insert(Options::ENABLE_TABLES);
+    opts.insert(Options::ENABLE_FOOTNOTES);
+    opts.insert(Options::ENABLE_STRIKETHROUGH);
+    opts.insert(Options::ENABLE_TASKLISTS);
+    let parser = Parser::new_ext(src, opts);
+    let mut html_output = String::new();
+    html::push_html(&mut html_output, parser);
+    // Fenced/indented code may have comment reflow (`// a. b.` → two
+    // `//` lines). That is an intentional rewrite; the oracle still
+    // guards prose render around the blocks.
+    let without_pre = strip_pre(&html_output);
+    normalize_ws(&without_pre)
+}
+
+fn strip_pre(html: &str) -> String {
+    let mut out = String::with_capacity(html.len());
+    let mut rest = html;
+    while let Some(start) = rest.find("<pre") {
+        out.push_str(&rest[..start]);
+        let after = &rest[start..];
+        if let Some(end) = after.find("</pre>") {
+            out.push_str("<pre></pre>");
+            rest = &after[end + 6..];
+        } else {
+            out.push_str(after);
+            rest = "";
+            break;
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+fn normalize_ws(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut prev_space = false;
+    for c in s.chars() {
+        if c.is_whitespace() {
+            if !prev_space {
+                out.push(' ');
+                prev_space = true;
+            }
+        } else {
+            out.push(c);
+            prev_space = false;
+        }
+    }
+    out.trim().to_string()
+}
+
+/// Word sequence of prose regions only (structure/code/blank ignored).
+pub fn prose_words(format: Format, text: &str) -> Vec<String> {
+    let regions = crate::parser::parser_for_format(format).parse(text);
+    let mut words = Vec::new();
+    for r in regions {
+        if let Region::Prose(p) = r {
+            words.extend(p.split_whitespace().map(str::to_string));
+        }
+    }
+    words
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn md_html_ignores_soft_breaks() {
+        let a = "Hello world. Next sentence.";
+        let b = "Hello world.\nNext sentence.";
+        assert_eq!(md_html_normalized(a), md_html_normalized(b));
+    }
+
+    #[test]
+    fn prose_words_stable_across_reflow() {
+        let a = "Hello world. Next sentence.";
+        let b = "Hello world.\nNext sentence.\n";
+        assert_eq!(
+            prose_words(Format::Plaintext, a),
+            prose_words(Format::Plaintext, b)
+        );
+    }
+}

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -376,7 +376,8 @@ mod tests {
         let cfg = FormatConfig {
             format: Format::Latex,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             out.contains("\\section{A long title. With two sentences.}"),
@@ -450,7 +451,8 @@ Some text.
         let cfg = FormatConfig {
             format: Format::Latex,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             !out.contains("foo% bar"),
@@ -473,7 +475,8 @@ Some text.
         let cfg = FormatConfig {
             format: Format::Latex,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             out.contains("50\\% of cases."),
@@ -491,7 +494,8 @@ Some text.
         let cfg = FormatConfig {
             format: Format::Latex,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             out.contains("% TODO cite"),

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-use crate::parser::{FormatParser, Region, flush_prose};
+use crate::parser::{ByteSpan, FormatParser, SpannedRegion, flush_prose_spanned, iter_lines};
 
 // Environments whose content is NOT prose (math, code, figures, tables)
 static NON_PROSE_ENVS: &[&str] = &[
@@ -93,155 +93,168 @@ impl LatexParser {
 }
 
 impl FormatParser for LatexParser {
-    fn parse(&self, input: &str) -> Vec<Region> {
-        let mut regions: Vec<Region> = Vec::new();
+    fn parse_full(&self, input: &str) -> Vec<SpannedRegion> {
+        let mut regions: Vec<SpannedRegion> = Vec::new();
         let mut current_prose = String::new();
+        let mut prose_span: Option<ByteSpan> = None;
         let mut in_preamble = true;
         let mut in_non_prose_env: Option<String> = None;
         // Code environment bookkeeping.
         let mut in_code_env: Option<String> = None;
         let mut code_lang: Option<String> = None;
-        let mut code_header = String::new();
-        let mut code_body = String::new();
+        let mut code_header = ByteSpan::default();
+        let mut code_body_start = 0usize;
         let mut in_display_math = false;
         let mut pragma_off = false;
         // A `%` comment eats the newline, so the next physical line joins
         // this prose with no inserted space (`foo%\nbar` is TeX `foobar`).
         let mut nospace_join = false;
 
-        for line in input.lines() {
+        for line in iter_lines(input) {
+            let line_text = line.text;
             // Check for snapper:off/on pragmas; inside a code environment
             // the per-language reflow path handles pragmas instead.
             if in_code_env.is_none() {
-                if let Some(on) = super::check_pragma(line) {
-                    flush_prose(&mut current_prose, &mut regions);
+                if let Some(on) = super::check_pragma(line_text) {
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                     pragma_off = !on;
-                    regions.push(Region::Structure(format!("{line}\n")));
+                    regions.push(SpannedRegion::structure(input, line.span()));
                     continue;
                 }
 
                 if pragma_off {
-                    flush_prose(&mut current_prose, &mut regions);
-                    regions.push(Region::Structure(format!("{line}\n")));
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                    regions.push(SpannedRegion::structure(input, line.span()));
                     continue;
                 }
             }
 
             // Preamble: everything before \begin{document} is structure
             if in_preamble {
-                if line.contains(r"\begin{document}") {
+                if line_text.contains(r"\begin{document}") {
                     in_preamble = false;
                 }
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Inside code environment -- buffer body
             if let Some(env_name) = in_code_env.clone() {
-                flush_prose(&mut current_prose, &mut regions);
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 let ends = END_ENV_RE
-                    .captures(line)
+                    .captures(line_text)
                     .map(|c| c.get(1).unwrap().as_str() == env_name)
                     .unwrap_or(false);
                 if ends {
                     in_code_env = None;
-                    regions.push(Region::Code {
-                        lang: code_lang.take(),
-                        header: std::mem::take(&mut code_header),
-                        body: std::mem::take(&mut code_body),
-                        footer: format!("{line}\n"),
-                    });
-                } else {
-                    code_body.push_str(line);
-                    code_body.push('\n');
+                    regions.push(SpannedRegion::code(
+                        input,
+                        code_lang.take(),
+                        code_header,
+                        ByteSpan::new(code_body_start, line.start),
+                        line.span(),
+                    ));
                 }
                 continue;
             }
 
             // Inside non-prose environment
             if let Some(ref env_name) = in_non_prose_env {
-                flush_prose(&mut current_prose, &mut regions);
-                if let Some(caps) = END_ENV_RE.captures(line) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                if let Some(caps) = END_ENV_RE.captures(line_text) {
                     if caps.get(1).unwrap().as_str() == env_name {
                         in_non_prose_env = None;
                     }
                 }
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Inside display math \[...\]
             if in_display_math {
-                flush_prose(&mut current_prose, &mut regions);
-                if DISPLAY_MATH_CLOSE.is_match(line) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                if DISPLAY_MATH_CLOSE.is_match(line_text) {
                     in_display_math = false;
                 }
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Blank line
-            if line.trim().is_empty() {
-                flush_prose(&mut current_prose, &mut regions);
+            if line_text.trim().is_empty() {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 nospace_join = false;
-                regions.push(Region::BlankLines(format!("{line}\n")));
+                regions.push(SpannedRegion::blank(input, line.span()));
                 continue;
             }
 
             // Comment
-            if Self::is_comment(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if Self::is_comment(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 nospace_join = false;
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Mid-line `%`: prefix is prose; `%` eats the newline (nospace
             // join). A comment with text is Structure after the prefix.
-            if let Some(idx) = Self::unescaped_percent(line) {
-                let code = &line[..idx];
-                let comment = &line[idx..];
+            if let Some(idx) = Self::unescaped_percent(line_text) {
+                let code = &line_text[..idx];
+                let comment = &line_text[idx..];
                 if !code.trim().is_empty() {
                     if !current_prose.is_empty() && !nospace_join {
                         current_prose.push(' ');
                     }
                     current_prose.push_str(code.trim_start());
+                    let start = line.start + (line_text.len() - line_text.trim_start().len());
+                    let content_end = line.start + idx;
+                    match &mut prose_span {
+                        None => prose_span = Some(ByteSpan::new(start, content_end)),
+                        Some(s) => s.end = content_end,
+                    }
                 }
                 nospace_join = true;
                 if comment.trim() != "%" {
-                    flush_prose(&mut current_prose, &mut regions);
-                    regions.push(Region::Structure(format!("{comment}\n")));
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                    let comment_span = ByteSpan::new(line.start + idx, line.end);
+                    regions.push(SpannedRegion::structure(input, comment_span));
+                } else if let Some(s) = &mut prose_span {
+                    // Lone `%` plus the newline stay inside the prose span so
+                    // the rewrite covers `foo%\nbar` as one TeX word.
+                    s.end = line.end;
                 }
                 continue;
             }
 
             // \end{document}
-            if line.contains(r"\end{document}") {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if line_text.contains(r"\end{document}") {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Begin non-prose environment
-            if let Some(caps) = BEGIN_ENV_RE.captures(line) {
+            if let Some(caps) = BEGIN_ENV_RE.captures(line_text) {
                 let env_name = caps.get(1).unwrap().as_str().to_string();
                 if Self::is_non_prose_env(&env_name) {
-                    flush_prose(&mut current_prose, &mut regions);
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                     // Single-line \begin{...}...\end{...}: emit as Structure
                     // (or as an empty-body Code region for code envs) -- the
                     // common case is multi-line, so keep this path simple.
-                    if let Some(end_caps) = END_ENV_RE.captures(line) {
+                    if let Some(end_caps) = END_ENV_RE.captures(line_text) {
                         if end_caps.get(1).unwrap().as_str() == env_name {
                             if is_code_env(&env_name) {
-                                regions.push(Region::Code {
-                                    lang: None,
-                                    header: format!("{line}\n"),
-                                    body: String::new(),
-                                    footer: String::new(),
-                                });
+                                let empty = ByteSpan::new(line.end, line.end);
+                                regions.push(SpannedRegion::code(
+                                    input,
+                                    None,
+                                    line.span(),
+                                    empty,
+                                    empty,
+                                ));
                             } else {
-                                regions.push(Region::Structure(format!("{line}\n")));
+                                regions.push(SpannedRegion::structure(input, line.span()));
                             }
                             continue;
                         }
@@ -249,21 +262,21 @@ impl FormatParser for LatexParser {
                     if is_code_env(&env_name) {
                         code_lang = if env_name == "minted" {
                             MINTED_LANG_RE
-                                .captures(line)
+                                .captures(line_text)
                                 .map(|c| c.get(1).unwrap().as_str().to_string())
                         } else if env_name == "lstlisting" {
                             LSTLISTING_LANG_RE
-                                .captures(line)
+                                .captures(line_text)
                                 .map(|c| c.get(1).unwrap().as_str().to_string())
                         } else {
                             None
                         };
-                        code_header = format!("{line}\n");
-                        code_body.clear();
+                        code_header = line.span();
+                        code_body_start = line.end;
                         in_code_env = Some(env_name);
                     } else {
                         in_non_prose_env = Some(env_name);
-                        regions.push(Region::Structure(format!("{line}\n")));
+                        regions.push(SpannedRegion::structure(input, line.span()));
                     }
                     continue;
                 }
@@ -273,24 +286,24 @@ impl FormatParser for LatexParser {
             // Splitting Structure(\section{)+Prose(title)+Structure(}) reflowed
             // multi-sentence titles mid-brace. Single-line sectioning is not
             // prose; do not reflow titles.
-            if SECTION_CMD_RE.is_match(line) {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if SECTION_CMD_RE.is_match(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Display math \[
-            if DISPLAY_MATH_OPEN.is_match(line) && !DISPLAY_MATH_CLOSE.is_match(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if DISPLAY_MATH_OPEN.is_match(line_text) && !DISPLAY_MATH_CLOSE.is_match(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 in_display_math = true;
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Single-line display math \[...\]
-            if DISPLAY_MATH_OPEN.is_match(line) && DISPLAY_MATH_CLOSE.is_match(line) {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if DISPLAY_MATH_OPEN.is_match(line_text) && DISPLAY_MATH_CLOSE.is_match(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
@@ -298,18 +311,25 @@ impl FormatParser for LatexParser {
             if !current_prose.is_empty() && !nospace_join {
                 current_prose.push(' ');
             }
-            current_prose.push_str(line.trim());
+            current_prose.push_str(line_text.trim());
+            let end = line.end;
+            match &mut prose_span {
+                None => prose_span = Some(ByteSpan::new(line.start, end)),
+                Some(s) => s.end = end,
+            }
             nospace_join = false;
         }
 
-        flush_prose(&mut current_prose, &mut regions);
+        flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
         if in_code_env.is_some() {
-            regions.push(Region::Code {
-                lang: code_lang.take(),
-                header: std::mem::take(&mut code_header),
-                body: std::mem::take(&mut code_body),
-                footer: String::new(),
-            });
+            let eof = ByteSpan::new(input.len(), input.len());
+            regions.push(SpannedRegion::code(
+                input,
+                code_lang.take(),
+                code_header,
+                ByteSpan::new(code_body_start, input.len()),
+                eof,
+            ));
         }
         regions
     }
@@ -318,6 +338,7 @@ impl FormatParser for LatexParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::Region;
 
     #[test]
     fn section_command_title_is_structure_not_prose() {

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -633,7 +633,8 @@ mod tests {
         let cfg = FormatConfig {
             format: Format::Markdown,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             out.starts_with(

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -1,7 +1,9 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-use crate::parser::{FormatParser, Region, flush_prose};
+use crate::parser::{
+    ByteSpan, FormatParser, Line, SpannedRegion, flush_prose_spanned, iter_lines, push_prose_line,
+};
 
 static HEADING_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(#{1,6}\s+)(.*)$").unwrap());
 
@@ -31,10 +33,21 @@ static SETEXT_UNDERLINE_RE: LazyLock<Regex> =
 pub struct MarkdownParser;
 
 /// Close an open list item: flush accumulated prose and emit the trailing newline.
-fn close_list_item(in_list_item: &mut bool, current_prose: &mut String, regions: &mut Vec<Region>) {
+fn close_list_item(
+    in_list_item: &mut bool,
+    current_prose: &mut String,
+    prose_span: &mut Option<ByteSpan>,
+    list_term: &mut Option<ByteSpan>,
+    input: &str,
+    regions: &mut Vec<SpannedRegion>,
+) {
     if *in_list_item {
-        flush_prose(current_prose, regions);
-        regions.push(Region::Structure("\n".to_string()));
+        flush_prose_spanned(current_prose, prose_span, regions);
+        if let Some(span) = list_term.take() {
+            if !span.is_empty() {
+                regions.push(SpannedRegion::structure(input, span));
+            }
+        }
         *in_list_item = false;
     }
 }
@@ -71,26 +84,28 @@ fn is_setext_title_line(line: &str) -> bool {
 }
 
 impl FormatParser for MarkdownParser {
-    fn parse(&self, input: &str) -> Vec<Region> {
-        let mut regions: Vec<Region> = Vec::new();
+    fn parse_full(&self, input: &str) -> Vec<SpannedRegion> {
+        let mut regions: Vec<SpannedRegion> = Vec::new();
         let mut current_prose = String::new();
+        let mut prose_span: Option<ByteSpan> = None;
         let mut in_fenced_code = false;
         let mut fence_marker = String::new();
-        // Buffer for the running code block: header line, body lines, lang
-        let mut code_header = String::new();
-        let mut code_body = String::new();
+        let mut code_header = ByteSpan::default();
+        let mut code_body_start = 0usize;
         let mut code_lang: Option<String> = None;
         let mut in_frontmatter = false;
         let mut frontmatter_fence = String::new();
         let mut in_list_item = false;
+        let mut list_term: Option<ByteSpan> = None;
         let mut pragma_off = false;
 
-        let lines: Vec<&str> = input.lines().collect();
+        let lines = iter_lines(input);
         let total = lines.len();
         let mut i = 0;
 
         while i < total {
-            let line = lines[i];
+            let line: &Line<'_> = &lines[i];
+            let line_text = line.text;
             let line_number = i + 1;
 
             // Check for snapper:off/on pragmas. Inside a fenced code block,
@@ -99,48 +114,69 @@ impl FormatParser for MarkdownParser {
             // `#`, `//`, `--`, `;` are all valid pragma prefixes inside
             // their respective languages).
             if !in_fenced_code {
-                if let Some(on) = super::check_pragma(line) {
-                    close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                    flush_prose(&mut current_prose, &mut regions);
+                if let Some(on) = super::check_pragma(line_text) {
+                    close_list_item(
+                        &mut in_list_item,
+                        &mut current_prose,
+                        &mut prose_span,
+                        &mut list_term,
+                        input,
+                        &mut regions,
+                    );
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                     pragma_off = !on;
-                    regions.push(Region::Structure(format!("{line}\n")));
+                    regions.push(SpannedRegion::structure(input, line.span()));
                     i += 1;
                     continue;
                 }
 
                 if pragma_off {
-                    close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                    flush_prose(&mut current_prose, &mut regions);
-                    regions.push(Region::Structure(format!("{line}\n")));
+                    close_list_item(
+                        &mut in_list_item,
+                        &mut current_prose,
+                        &mut prose_span,
+                        &mut list_term,
+                        input,
+                        &mut regions,
+                    );
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                    regions.push(SpannedRegion::structure(input, line.span()));
                     i += 1;
                     continue;
                 }
             }
 
             // Front matter detection (only at start of file)
-            if line_number == 1 && (line.trim() == "---" || line.trim() == "+++") {
+            if line_number == 1 && (line_text.trim() == "---" || line_text.trim() == "+++") {
                 in_frontmatter = true;
-                frontmatter_fence = line.trim().to_string();
-                regions.push(Region::Structure(format!("{line}\n")));
+                frontmatter_fence = line_text.trim().to_string();
+                regions.push(SpannedRegion::structure(input, line.span()));
                 i += 1;
                 continue;
             }
 
             if in_frontmatter {
-                if line.trim() == frontmatter_fence {
+                if line_text.trim() == frontmatter_fence {
                     in_frontmatter = false;
                 }
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 i += 1;
                 continue;
             }
 
             // Inside fenced code block
             if in_fenced_code {
-                close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                flush_prose(&mut current_prose, &mut regions);
+                close_list_item(
+                    &mut in_list_item,
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    input,
+                    &mut regions,
+                );
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 let mut closed = false;
-                if let Some(caps) = FENCED_CODE_RE.captures(line.trim_start()) {
+                if let Some(caps) = FENCED_CODE_RE.captures(line_text.trim_start()) {
                     let marker = caps.get(1).unwrap().as_str();
                     if marker.chars().next() == fence_marker.chars().next()
                         && marker.len() >= fence_marker.len()
@@ -150,40 +186,52 @@ impl FormatParser for MarkdownParser {
                 }
                 if closed {
                     in_fenced_code = false;
-                    regions.push(Region::Code {
-                        lang: code_lang.take(),
-                        header: std::mem::take(&mut code_header),
-                        body: std::mem::take(&mut code_body),
-                        footer: format!("{line}\n"),
-                    });
-                } else {
-                    code_body.push_str(line);
-                    code_body.push('\n');
+                    regions.push(SpannedRegion::code(
+                        input,
+                        code_lang.take(),
+                        code_header,
+                        ByteSpan::new(code_body_start, line.start),
+                        line.span(),
+                    ));
                 }
                 i += 1;
                 continue;
             }
 
             // Fenced code block start
-            if let Some(caps) = FENCED_CODE_RE.captures(line.trim_start()) {
-                close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                flush_prose(&mut current_prose, &mut regions);
+            if let Some(caps) = FENCED_CODE_RE.captures(line_text.trim_start()) {
+                close_list_item(
+                    &mut in_list_item,
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    input,
+                    &mut regions,
+                );
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 fence_marker = caps.get(1).unwrap().as_str().to_string();
                 in_fenced_code = true;
                 code_lang = FENCED_LANG_RE
-                    .captures(line.trim_start())
+                    .captures(line_text.trim_start())
                     .map(|c| c.get(1).unwrap().as_str().to_string());
-                code_header = format!("{line}\n");
-                code_body.clear();
+                code_header = line.span();
+                code_body_start = line.end;
                 i += 1;
                 continue;
             }
 
             // Blank line
-            if line.trim().is_empty() {
-                close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::BlankLines(format!("{line}\n")));
+            if line_text.trim().is_empty() {
+                close_list_item(
+                    &mut in_list_item,
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    input,
+                    &mut regions,
+                );
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::blank(input, line.span()));
                 i += 1;
                 continue;
             }
@@ -195,10 +243,17 @@ impl FormatParser for MarkdownParser {
             //   ### 1.
             //   `cargo binstall` (preferred binary install)
             // CommonMark ATX headings are single-line; do not reflow them.
-            if HEADING_RE.is_match(line) {
-                close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if HEADING_RE.is_match(line_text) {
+                close_list_item(
+                    &mut in_list_item,
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    input,
+                    &mut regions,
+                );
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 i += 1;
                 continue;
             }
@@ -206,35 +261,65 @@ impl FormatParser for MarkdownParser {
             // Setext heading: title line + underline of `=` or `-`.
             // Without this, title text is Prose and the underline is glued on
             // (or mid-title periods reflow), collapsing the heading.
-            if i + 1 < total && is_setext_title_line(line) && is_setext_underline(lines[i + 1]) {
-                close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
-                regions.push(Region::Structure(format!("{}\n", lines[i + 1])));
+            if i + 1 < total
+                && is_setext_title_line(line_text)
+                && is_setext_underline(lines[i + 1].text)
+            {
+                close_list_item(
+                    &mut in_list_item,
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    input,
+                    &mut regions,
+                );
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
+                regions.push(SpannedRegion::structure(input, lines[i + 1].span()));
                 i += 2;
                 continue;
             }
 
             // Table row (pipe-delimited)
-            if TABLE_ROW_RE.is_match(line) {
-                close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if TABLE_ROW_RE.is_match(line_text) {
+                close_list_item(
+                    &mut in_list_item,
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    input,
+                    &mut regions,
+                );
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 i += 1;
                 continue;
             }
 
             // Blockquote: emit the full `> ` / `> > ` prefix as Structure.
             // Checked before list items so nested `> >` is not flattened.
-            if let Some(caps) = QUOTE_RE.captures(line) {
-                close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                flush_prose(&mut current_prose, &mut regions);
+            if let Some(caps) = QUOTE_RE.captures(line_text) {
+                close_list_item(
+                    &mut in_list_item,
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    input,
+                    &mut regions,
+                );
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 let marker = caps.get(1).unwrap().as_str();
                 let text = caps.get(2).unwrap().as_str();
-                regions.push(Region::Structure(marker.to_string()));
+                let marker_span = ByteSpan::new(line.start, line.start + marker.len());
+                regions.push(SpannedRegion::structure(input, marker_span));
                 in_list_item = true;
+                list_term = Some(line.terminator_span());
                 if !text.is_empty() {
                     current_prose.push_str(text);
+                    prose_span = Some(ByteSpan::new(
+                        line.start + marker.len(),
+                        line.start + line_text.len(),
+                    ));
                 }
                 i += 1;
                 continue;
@@ -242,38 +327,62 @@ impl FormatParser for MarkdownParser {
 
             // List item: emit marker as Structure, start accumulating text as prose.
             // Continuation lines are appended until a block boundary.
-            if let Some(caps) = LIST_ITEM_RE.captures(line) {
-                close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-                flush_prose(&mut current_prose, &mut regions);
+            if let Some(caps) = LIST_ITEM_RE.captures(line_text) {
+                close_list_item(
+                    &mut in_list_item,
+                    &mut current_prose,
+                    &mut prose_span,
+                    &mut list_term,
+                    input,
+                    &mut regions,
+                );
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 let marker = caps.get(1).unwrap().as_str();
                 let text = caps.get(2).unwrap().as_str();
-                regions.push(Region::Structure(marker.to_string()));
+                let marker_span = ByteSpan::new(line.start, line.start + marker.len());
+                regions.push(SpannedRegion::structure(input, marker_span));
                 in_list_item = true;
+                list_term = Some(line.terminator_span());
                 if !text.is_empty() {
                     current_prose.push_str(text);
+                    prose_span = Some(ByteSpan::new(
+                        line.start + marker.len(),
+                        line.start + line_text.len(),
+                    ));
                 }
                 i += 1;
                 continue;
             }
 
             // Regular prose (also serves as list-item continuation when in_list_item)
-            if !current_prose.is_empty() {
-                current_prose.push(' ');
+            if in_list_item {
+                push_prose_line(&mut current_prose, &mut prose_span, line, true, false);
+                list_term = Some(line.terminator_span());
+            } else {
+                push_prose_line(&mut current_prose, &mut prose_span, line, true, true);
             }
-            current_prose.push_str(line.trim());
             i += 1;
         }
 
-        close_list_item(&mut in_list_item, &mut current_prose, &mut regions);
-        flush_prose(&mut current_prose, &mut regions);
+        close_list_item(
+            &mut in_list_item,
+            &mut current_prose,
+            &mut prose_span,
+            &mut list_term,
+            input,
+            &mut regions,
+        );
+        flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
         // Unclosed fence at EOF: emit a code region with empty footer.
         if in_fenced_code {
-            regions.push(Region::Code {
-                lang: code_lang.take(),
-                header: std::mem::take(&mut code_header),
-                body: std::mem::take(&mut code_body),
-                footer: String::new(),
-            });
+            let eof = ByteSpan::new(input.len(), input.len());
+            regions.push(SpannedRegion::code(
+                input,
+                code_lang.take(),
+                code_header,
+                ByteSpan::new(code_body_start, input.len()),
+                eof,
+            ));
         }
         regions
     }
@@ -282,6 +391,7 @@ impl FormatParser for MarkdownParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::Region;
 
     #[test]
     fn simple_prose() {
@@ -368,7 +478,10 @@ mod tests {
         for r in &regions {
             if let Region::Structure(s) = r {
                 assert!(s.starts_with('|'));
-                assert!(s.ends_with("|\n"));
+                assert!(
+                    s.ends_with('|') || s.ends_with("|\n"),
+                    "table row must be the input slice: {s:?}"
+                );
             }
         }
     }
@@ -385,8 +498,8 @@ mod tests {
                 "First line of item continuation text here. Another sentence.".to_string()
             )
         );
-        assert_eq!(regions[2], Region::Structure("\n".to_string()));
-        assert_eq!(regions.len(), 3);
+        // No trailing newline in the source, so no terminator Structure.
+        assert_eq!(regions.len(), 2);
     }
 
     #[test]
@@ -417,7 +530,7 @@ mod tests {
         // Second item
         assert_eq!(regions[3], Region::Structure("- ".to_string()));
         assert_eq!(regions[4], Region::Prose("Second item".to_string()));
-        assert_eq!(regions[5], Region::Structure("\n".to_string()));
+        assert_eq!(regions.len(), 5);
     }
 
     #[test]
@@ -432,7 +545,7 @@ mod tests {
                 "**Quality gates:** `Thresholds(warning=0.1)` lets you express failure rates. Replaces binary assert.".to_string()
             )
         );
-        assert_eq!(regions[2], Region::Structure("\n".to_string()));
+        assert_eq!(regions.len(), 2);
     }
 
     #[test]
@@ -440,7 +553,7 @@ mod tests {
         let input = "## My Heading";
         let regions = MarkdownParser.parse(input);
         assert_eq!(regions.len(), 1);
-        assert_eq!(regions[0], Region::Structure("## My Heading\n".to_string()));
+        assert_eq!(regions[0], Region::Structure("## My Heading".to_string()));
     }
 
     #[test]
@@ -472,7 +585,7 @@ mod tests {
             let regions = MarkdownParser.parse(&line);
             assert_eq!(
                 regions,
-                vec![Region::Structure(format!("{line}\n"))],
+                vec![Region::Structure(line.clone())],
                 "level {hashes}"
             );
         }
@@ -560,8 +673,8 @@ mod tests {
         let regions = MarkdownParser.parse(input);
         assert_eq!(regions[0], Region::Structure("> ".to_string()));
         assert_eq!(regions[1], Region::Prose("One. Two.".to_string()));
-        assert_eq!(regions[2], Region::Structure("\n".to_string()));
-        assert_eq!(regions.len(), 3);
+        // No trailing newline in the source, so no terminator Structure.
+        assert_eq!(regions.len(), 2);
     }
 
     #[test]
@@ -595,8 +708,7 @@ mod tests {
             regions[1],
             Region::Prose("Nested one. Nested two.".to_string())
         );
-        assert_eq!(regions[2], Region::Structure("\n".to_string()));
-        assert_eq!(regions.len(), 3);
+        assert_eq!(regions.len(), 2);
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,6 +5,12 @@ pub mod org;
 pub mod pandoc;
 pub mod plaintext;
 pub mod rst;
+pub mod span;
+
+pub use span::{
+    ByteSpan, CodeSpans, Line, RegionOrigin, SpannedRegion, flush_prose_spanned, iter_lines,
+    push_prose_line,
+};
 
 /// A region of text classified by a format parser.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -30,7 +36,16 @@ pub enum Region {
 
 /// Trait for format-specific parsers that classify text into regions.
 pub trait FormatParser {
-    fn parse(&self, input: &str) -> Vec<Region>;
+    /// Classify `input` and record source byte ranges where possible.
+    fn parse_full(&self, input: &str) -> Vec<SpannedRegion>;
+
+    /// Classify `input` into regions, dropping recorded spans.
+    fn parse(&self, input: &str) -> Vec<Region> {
+        self.parse_full(input)
+            .into_iter()
+            .map(|s| s.region)
+            .collect()
+    }
 }
 
 /// Create the appropriate parser for a given format.
@@ -46,6 +61,9 @@ pub fn parser_for_format(format: crate::format::Format) -> Box<dyn FormatParser>
 }
 
 /// Flush accumulated prose into the region list, clearing the buffer.
+///
+/// Prefer [`flush_prose_spanned`] in native parsers so the rewrite range
+/// is recorded. This helper remains for tests and the pandoc AST path.
 pub fn flush_prose(prose: &mut String, regions: &mut Vec<Region>) {
     if !prose.is_empty() {
         regions.push(Region::Prose(prose.clone()));

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -1,7 +1,10 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-use crate::parser::{FormatParser, Region, flush_prose};
+use crate::parser::{
+    ByteSpan, FormatParser, Region, RegionOrigin, SpannedRegion, flush_prose_spanned, iter_lines,
+    push_prose_line,
+};
 
 static HEADLINE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\*+\s+(?:TODO\s+|DONE\s+|NEXT\s+|WAIT\s+)?)(.*)$").unwrap());
@@ -120,15 +123,16 @@ impl OrgParser {
 }
 
 impl FormatParser for OrgParser {
-    fn parse(&self, input: &str) -> Vec<Region> {
-        let mut regions: Vec<Region> = Vec::new();
+    fn parse_full(&self, input: &str) -> Vec<SpannedRegion> {
+        let mut regions: Vec<SpannedRegion> = Vec::new();
         let mut current_prose = String::new();
+        let mut prose_span: Option<ByteSpan> = None;
         let mut in_block = false;
         // Source block bookkeeping; `in_src_block` implies `in_block`.
         let mut in_src_block = false;
         let mut src_lang: Option<String> = None;
-        let mut src_header = String::new();
-        let mut src_body = String::new();
+        let mut src_header = ByteSpan::default();
+        let mut src_body_start = 0usize;
         let mut in_drawer = false;
         let mut in_latex_env: Option<String> = None;
         let mut in_display_math = false;
@@ -137,70 +141,69 @@ impl FormatParser for OrgParser {
         // Continuation lines indented at or beyond this level belong to the item.
         let mut list_item_indent: Option<usize> = None;
 
-        for line in input.lines() {
+        for line in iter_lines(input) {
+            let line_text = line.text;
             // Check for snapper:off/on pragmas. Inside a source block we
             // defer pragma handling to the code-block reflow so the
             // language's own comment marker controls the freeze.
             if !in_src_block {
-                if let Some(on) = super::check_pragma(line) {
-                    flush_prose(&mut current_prose, &mut regions);
+                if let Some(on) = super::check_pragma(line_text) {
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                     pragma_off = !on;
-                    regions.push(Region::Structure(format!("{line}\n")));
+                    regions.push(SpannedRegion::structure(input, line.span()));
                     continue;
                 }
 
                 // Inside pragma-off region: pass through unchanged
                 if pragma_off {
-                    flush_prose(&mut current_prose, &mut regions);
-                    regions.push(Region::Structure(format!("{line}\n")));
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                    regions.push(SpannedRegion::structure(input, line.span()));
                     continue;
                 }
             }
 
             // Inside a source block -- buffer body until #+END_SRC
             if in_src_block {
-                flush_prose(&mut current_prose, &mut regions);
-                if Self::is_src_end(line) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                if Self::is_src_end(line_text) {
                     in_src_block = false;
                     in_block = false;
-                    regions.push(Region::Code {
-                        lang: src_lang.take(),
-                        header: std::mem::take(&mut src_header),
-                        body: std::mem::take(&mut src_body),
-                        footer: format!("{line}\n"),
-                    });
-                } else {
-                    src_body.push_str(line);
-                    src_body.push('\n');
+                    regions.push(SpannedRegion::code(
+                        input,
+                        src_lang.take(),
+                        src_header,
+                        ByteSpan::new(src_body_start, line.start),
+                        line.span(),
+                    ));
                 }
                 continue;
             }
 
             // Inside a non-src block -- everything is structure
             if in_block {
-                flush_prose(&mut current_prose, &mut regions);
-                if Self::is_block_end(line) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                if Self::is_block_end(line_text) {
                     in_block = false;
                 }
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Inside a drawer -- everything is structure
             if in_drawer {
-                flush_prose(&mut current_prose, &mut regions);
-                if Self::is_drawer_end(line) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                if Self::is_drawer_end(line_text) {
                     in_drawer = false;
                 }
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Inside a LaTeX environment -- everything is structure
             if let Some(ref env) = in_latex_env {
-                flush_prose(&mut current_prose, &mut regions);
-                let done = Self::is_latex_end(line, env);
-                regions.push(Region::Structure(format!("{line}\n")));
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                let done = Self::is_latex_end(line_text, env);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 if done {
                     in_latex_env = None;
                 }
@@ -209,100 +212,100 @@ impl FormatParser for OrgParser {
 
             // Inside display math \[...\] -- everything is structure
             if in_display_math {
-                flush_prose(&mut current_prose, &mut regions);
-                if Self::is_display_math_close(line) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                if Self::is_display_math_close(line_text) {
                     in_display_math = false;
                 }
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Source block begin (#+BEGIN_SRC LANG ...)
-            if let Some(lang) = Self::is_src_begin(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if let Some(lang) = Self::is_src_begin(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 in_block = true;
                 in_src_block = true;
                 src_lang = lang;
-                src_header = format!("{line}\n");
-                src_body.clear();
+                src_header = line.span();
+                src_body_start = line.end;
                 continue;
             }
 
             // Other #+BEGIN_ block: opaque structure
-            if Self::is_block_begin(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if Self::is_block_begin(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 in_block = true;
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Drawer begin
-            if Self::is_drawer_begin(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if Self::is_drawer_begin(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 in_drawer = true;
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // LaTeX environment begin (\begin{equation} etc.)
-            if let Some(env) = Self::is_latex_begin(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if let Some(env) = Self::is_latex_begin(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 in_latex_env = Some(env);
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Display math open (\[)
-            if Self::is_display_math_open(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if Self::is_display_math_open(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 in_display_math = true;
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Export snippet line (@@latex:...@@)
-            if Self::is_export_snippet_line(line) {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if Self::is_export_snippet_line(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Blank line
-            if line.trim().is_empty() {
-                flush_prose(&mut current_prose, &mut regions);
+            if line_text.trim().is_empty() {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 list_item_indent = None;
-                regions.push(Region::BlankLines(format!("{line}\n")));
+                regions.push(SpannedRegion::blank(input, line.span()));
                 continue;
             }
 
             // Keyword/directive
-            if Self::is_keyword(line) {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if Self::is_keyword(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Comment
-            if Self::is_comment(line) {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if Self::is_comment(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Table row
-            if Self::is_table_row(line) {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if Self::is_table_row(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // Bare file/http links on their own line -- treat as structure
-            if line.trim_start().starts_with("file:")
-                || line.trim_start().starts_with("http://")
-                || line.trim_start().starts_with("https://")
+            if line_text.trim_start().starts_with("file:")
+                || line_text.trim_start().starts_with("http://")
+                || line_text.trim_start().starts_with("https://")
             {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
@@ -310,44 +313,64 @@ impl FormatParser for OrgParser {
             // Splitting Structure(stars)+Prose(title) reflowed multi-sentence
             // titles and left continuation lines without stars (orphan body).
             // Org headlines are single-line; do not reflow them.
-            if HEADLINE_RE.is_match(line) {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+            if HEADLINE_RE.is_match(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             // List item: marker is structure, rest is prose
-            if let Some(caps) = LIST_ITEM_RE.captures(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if let Some(caps) = LIST_ITEM_RE.captures(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 let marker = caps.get(1).unwrap().as_str();
                 let text = caps.get(2).unwrap().as_str();
                 // Track indent for continuation detection: text starts at marker length
                 list_item_indent = Some(marker.len());
-                regions.push(Region::Structure(marker.to_string()));
+                let marker_span = ByteSpan::new(line.start, line.start + marker.len());
+                regions.push(SpannedRegion::structure(input, marker_span));
                 if !text.is_empty() {
-                    regions.push(Region::Prose(text.to_string()));
+                    regions.push(SpannedRegion::prose(
+                        text.to_string(),
+                        ByteSpan::new(line.start + marker.len(), line.start + line_text.len()),
+                    ));
                 }
-                regions.push(Region::Structure("\n".to_string()));
+                let term = line.terminator_span();
+                if !term.is_empty() {
+                    regions.push(SpannedRegion::structure(input, term));
+                }
                 continue;
             }
 
             // List item continuation: indented line following a list item
             if let Some(indent) = list_item_indent {
-                let leading = line.len() - line.trim_start().len();
-                if leading >= indent && !line.trim().is_empty() {
+                let leading = line_text.len() - line_text.trim_start().len();
+                if leading >= indent && !line_text.trim().is_empty() {
                     // Append to the previous Prose region of the list item.
                     // The last three regions are Structure(marker), Prose(text), Structure(\n)
                     // We want to extend the Prose region.
-                    if let Some(Region::Structure(s)) = regions.last() {
-                        if s == "\n" {
-                            regions.pop(); // remove the \n
-                            if let Some(Region::Prose(prose)) = regions.last_mut() {
+                    let is_term = matches!(
+                        regions.last(),
+                        Some(SpannedRegion {
+                            region: Region::Structure(s),
+                            ..
+                        }) if s == "\n"
+                    );
+                    if is_term {
+                        regions.pop();
+                        if let Some(prev) = regions.last_mut() {
+                            if let Region::Prose(prose) = &mut prev.region {
                                 prose.push(' ');
-                                prose.push_str(line.trim());
+                                prose.push_str(line_text.trim());
                             }
-                            regions.push(Region::Structure("\n".to_string()));
-                            continue;
+                            if let Some(RegionOrigin::Whole(span)) = &mut prev.origin {
+                                span.end = line.start + line_text.len();
+                            }
                         }
+                        let term = line.terminator_span();
+                        if !term.is_empty() {
+                            regions.push(SpannedRegion::structure(input, term));
+                        }
+                        continue;
                     }
                 }
                 // Not a continuation: leave list context
@@ -355,22 +378,21 @@ impl FormatParser for OrgParser {
             }
 
             // Regular prose line -- accumulate
-            if !current_prose.is_empty() {
-                current_prose.push(' ');
-            }
-            current_prose.push_str(line.trim());
+            push_prose_line(&mut current_prose, &mut prose_span, &line, true, true);
         }
 
         // Flush remaining
-        flush_prose(&mut current_prose, &mut regions);
+        flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
         // Unclosed source block at EOF: still emit as Code with empty footer.
         if in_src_block {
-            regions.push(Region::Code {
-                lang: src_lang.take(),
-                header: std::mem::take(&mut src_header),
-                body: std::mem::take(&mut src_body),
-                footer: String::new(),
-            });
+            let eof = ByteSpan::new(input.len(), input.len());
+            regions.push(SpannedRegion::code(
+                input,
+                src_lang.take(),
+                src_header,
+                ByteSpan::new(src_body_start, input.len()),
+                eof,
+            ));
         }
 
         regions
@@ -431,7 +453,7 @@ mod tests {
         assert_eq!(regions.len(), 1);
         assert_eq!(
             regions[0],
-            Region::Structure("* TODO This is a headline\n".to_string())
+            Region::Structure("* TODO This is a headline".to_string())
         );
     }
 
@@ -550,7 +572,8 @@ mod tests {
         let input = "- First item text\n- Second item text";
         let regions = OrgParser.parse(input);
         // Each list item: Structure(marker) + Prose(text) + Structure(\n)
-        assert_eq!(regions.len(), 6);
+        // The last item has no trailing newline, so no final Structure(\n).
+        assert_eq!(regions.len(), 5);
         assert_eq!(regions[0], Region::Structure("- ".to_string()));
         assert_eq!(regions[1], Region::Prose("First item text".to_string()));
     }

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -466,7 +466,8 @@ mod tests {
         let cfg = FormatConfig {
             format: Format::Org,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             out.lines()
@@ -489,7 +490,8 @@ mod tests {
         let cfg = FormatConfig {
             format: Format::Org,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             out.contains("Vec[T]"),
@@ -510,7 +512,8 @@ mod tests {
         let cfg = FormatConfig {
             format: Format::Org,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert_eq!(
             out, input,
@@ -532,7 +535,8 @@ mod tests {
         let cfg = FormatConfig {
             format: Format::Org,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         // Emphasis with an internal period must stay on one line; splitting
         // would leave a line starting with `*Bold` and a dangling closer.

--- a/src/parser/pandoc/mod.rs
+++ b/src/parser/pandoc/mod.rs
@@ -175,8 +175,14 @@ impl FormatParser for PandocParser {
     /// Prefer [`PandocParser::try_parse`] / `format_text` (they surface errors).
     /// On failure this returns **empty** regions — never all-prose fallback.
     /// (`format_text` does not use this trait method for the pandoc path.)
-    fn parse(&self, input: &str) -> Vec<Region> {
-        self.try_parse(input).unwrap_or_default()
+    /// Pandoc rebuilds regions from an AST, so origins are unset and reflow
+    /// falls back to concatenating region strings.
+    fn parse_full(&self, input: &str) -> Vec<crate::parser::SpannedRegion> {
+        self.try_parse(input)
+            .unwrap_or_default()
+            .into_iter()
+            .map(crate::parser::SpannedRegion::unspanned)
+            .collect()
     }
 }
 

--- a/src/parser/plaintext.rs
+++ b/src/parser/plaintext.rs
@@ -1,41 +1,41 @@
-use crate::parser::{FormatParser, Region, flush_prose};
+use crate::parser::{
+    ByteSpan, FormatParser, SpannedRegion, flush_prose_spanned, iter_lines, push_prose_line,
+};
 
 /// Trivial parser: everything is prose, blank lines are preserved.
 pub struct PlaintextParser;
 
 impl FormatParser for PlaintextParser {
-    fn parse(&self, input: &str) -> Vec<Region> {
+    fn parse_full(&self, input: &str) -> Vec<SpannedRegion> {
         let mut regions = Vec::new();
         let mut current_prose = String::new();
+        let mut prose_span: Option<ByteSpan> = None;
         let mut pragma_off = false;
 
-        for line in input.lines() {
+        for line in iter_lines(input) {
             // Check for snapper:off/on pragmas
-            if let Some(on) = super::check_pragma(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if let Some(on) = super::check_pragma(line.text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 pragma_off = !on;
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
             if pragma_off {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 
-            if line.trim().is_empty() {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::BlankLines(format!("{line}\n")));
+            if line.text.trim().is_empty() {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::blank(input, line.span()));
             } else {
-                if !current_prose.is_empty() {
-                    current_prose.push(' ');
-                }
-                current_prose.push_str(line.trim());
+                push_prose_line(&mut current_prose, &mut prose_span, &line, true, true);
             }
         }
 
-        flush_prose(&mut current_prose, &mut regions);
+        flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
         regions
     }
 }
@@ -43,6 +43,7 @@ impl FormatParser for PlaintextParser {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::Region;
 
     #[test]
     fn simple_paragraph() {

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -1,7 +1,9 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-use crate::parser::{FormatParser, Region, flush_prose};
+use crate::parser::{
+    ByteSpan, FormatParser, SpannedRegion, flush_prose_spanned, iter_lines, push_prose_line,
+};
 
 /// Match `.. code-block:: LANG` or `.. sourcecode:: LANG` (or `.. code:: LANG`).
 static CODE_DIRECTIVE_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -11,16 +13,17 @@ static CODE_DIRECTIVE_RE: LazyLock<Regex> = LazyLock::new(|| {
 pub struct RstParser;
 
 impl FormatParser for RstParser {
-    fn parse(&self, input: &str) -> Vec<Region> {
+    fn parse_full(&self, input: &str) -> Vec<SpannedRegion> {
         parse_line_based(input)
     }
 }
 
 /// Line-based RST parser. Handles directives, literal blocks, sections,
 /// field lists, comments, and tables as structure regions.
-fn parse_line_based(input: &str) -> Vec<Region> {
+fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut regions = Vec::new();
     let mut current_prose = String::new();
+    let mut prose_span: Option<ByteSpan> = None;
     let mut in_literal_block = false;
     let mut literal_indent: usize = 0;
     let mut in_directive = false;
@@ -31,31 +34,33 @@ fn parse_line_based(input: &str) -> Vec<Region> {
     let mut in_code_block = false;
     let mut code_indent: usize = 0;
     let mut code_lang: Option<String> = None;
-    let mut code_header = String::new();
-    let mut code_body = String::new();
-    let mut code_footer_blanks = String::new();
+    let mut code_header = ByteSpan::default();
+    let mut code_body_start = 0usize;
+    let mut code_body_end = 0usize;
+    let mut code_footer_start: Option<usize> = None;
 
-    let lines: Vec<&str> = input.lines().collect();
+    let lines = iter_lines(input);
     let total = lines.len();
     let mut i = 0;
 
     while i < total {
-        let line = lines[i];
+        let line = &lines[i];
+        let line_text = line.text;
 
         // Pragma check; inside a code-block directive the per-language
         // reflow path handles pragmas instead.
         if !in_code_block {
-            if let Some(on) = super::check_pragma(line) {
-                flush_prose(&mut current_prose, &mut regions);
+            if let Some(on) = super::check_pragma(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 pragma_off = !on;
-                regions.push(Region::Structure(format!("{line}\n")));
+                regions.push(SpannedRegion::structure(input, line.span()));
                 i += 1;
                 continue;
             }
 
             if pragma_off {
-                flush_prose(&mut current_prose, &mut regions);
-                regions.push(Region::Structure(format!("{line}\n")));
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
                 i += 1;
                 continue;
             }
@@ -66,45 +71,48 @@ fn parse_line_based(input: &str) -> Vec<Region> {
         // interior blank lines. The block ends at a non-blank line whose
         // indent drops below `code_indent`.
         if in_code_block {
-            let leading = line.len() - line.trim_start().len();
-            if line.trim().is_empty() {
+            let leading = line_text.len() - line_text.trim_start().len();
+            if line_text.trim().is_empty() {
                 // Could be interior blank or end-of-block; buffer and look ahead.
-                code_footer_blanks.push_str(line);
-                code_footer_blanks.push('\n');
+                if code_footer_start.is_none() {
+                    code_footer_start = Some(line.start);
+                }
                 i += 1;
                 continue;
             }
             if leading >= code_indent {
-                // Promote any buffered interior blanks into the body.
-                if !code_footer_blanks.is_empty() {
-                    code_body.push_str(&code_footer_blanks);
-                    code_footer_blanks.clear();
-                }
-                // Strip the directive's option indent if present? RST options
-                // are keyed `:option: value` at code_indent before the blank
-                // line. We've already passed those into the body verbatim
-                // since they look like normal indented lines; harmless.
-                code_body.push_str(line);
-                code_body.push('\n');
+                // A later body line claims any buffered interior blanks.
+                code_footer_start = None;
+                code_body_end = line.end;
                 i += 1;
                 continue;
             }
             // Less-indented non-blank line: close the code block.
             in_code_block = false;
-            regions.push(Region::Code {
-                lang: code_lang.take(),
-                header: std::mem::take(&mut code_header),
-                body: std::mem::take(&mut code_body),
-                footer: std::mem::take(&mut code_footer_blanks),
-            });
+            let footer = match code_footer_start.take() {
+                Some(fs) => ByteSpan::new(fs, line.start),
+                None => ByteSpan::new(line.start, line.start),
+            };
+            let body_end = if code_body_end > code_body_start {
+                code_body_end
+            } else {
+                footer.start
+            };
+            regions.push(SpannedRegion::code(
+                input,
+                code_lang.take(),
+                code_header,
+                ByteSpan::new(code_body_start, body_end),
+                footer,
+            ));
             // Fall through to reprocess this line as normal.
         }
 
         // Inside literal block
         if in_literal_block {
-            let leading = line.len() - line.trim_start().len();
-            if line.trim().is_empty() || leading >= literal_indent {
-                regions.push(Region::Structure(format!("{line}\n")));
+            let leading = line_text.len() - line_text.trim_start().len();
+            if line_text.trim().is_empty() || leading >= literal_indent {
+                regions.push(SpannedRegion::structure(input, line.span()));
                 i += 1;
                 continue;
             }
@@ -113,9 +121,9 @@ fn parse_line_based(input: &str) -> Vec<Region> {
 
         // Inside directive body
         if in_directive {
-            let leading = line.len() - line.trim_start().len();
-            if line.trim().is_empty() || leading >= directive_indent {
-                regions.push(Region::Structure(format!("{line}\n")));
+            let leading = line_text.len() - line_text.trim_start().len();
+            if line_text.trim().is_empty() || leading >= directive_indent {
+                regions.push(SpannedRegion::structure(input, line.span()));
                 i += 1;
                 continue;
             }
@@ -123,35 +131,36 @@ fn parse_line_based(input: &str) -> Vec<Region> {
         }
 
         // Blank line
-        if line.trim().is_empty() {
-            flush_prose(&mut current_prose, &mut regions);
-            regions.push(Region::BlankLines(format!("{line}\n")));
+        if line_text.trim().is_empty() {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            regions.push(SpannedRegion::blank(input, line.span()));
             i += 1;
             continue;
         }
 
         // RST code-block directive (.. code-block:: LANG)
-        if let Some(caps) = CODE_DIRECTIVE_RE.captures(line) {
-            flush_prose(&mut current_prose, &mut regions);
+        if let Some(caps) = CODE_DIRECTIVE_RE.captures(line_text) {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
             code_lang = caps.get(1).map(|m| m.as_str().to_string());
-            code_header = format!("{line}\n");
+            code_header = line.span();
             // Body indent: directive_indent + 3 spaces is the rst convention;
             // be liberal and accept any deeper indent of the first body line.
-            let leading = line.len() - line.trim_start().len();
+            let leading = line_text.len() - line_text.trim_start().len();
             code_indent = leading + 3;
-            code_body.clear();
-            code_footer_blanks.clear();
+            code_body_start = line.end;
+            code_body_end = line.end;
+            code_footer_start = None;
             in_code_block = true;
             i += 1;
             continue;
         }
 
         // RST directive (.. something::)
-        let trimmed = line.trim_start();
+        let trimmed = line_text.trim_start();
         if trimmed.starts_with(".. ") && trimmed.contains("::") {
-            flush_prose(&mut current_prose, &mut regions);
-            regions.push(Region::Structure(format!("{line}\n")));
-            let leading = line.len() - trimmed.len();
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            regions.push(SpannedRegion::structure(input, line.span()));
+            let leading = line_text.len() - trimmed.len();
             directive_indent = leading + 3;
             in_directive = true;
             i += 1;
@@ -160,24 +169,24 @@ fn parse_line_based(input: &str) -> Vec<Region> {
 
         // RST comment (.. without directive)
         if trimmed.starts_with(".. ") && !trimmed.contains("::") {
-            flush_prose(&mut current_prose, &mut regions);
-            regions.push(Region::Structure(format!("{line}\n")));
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            regions.push(SpannedRegion::structure(input, line.span()));
             i += 1;
             continue;
         }
 
         // Section underline
-        if is_underline(line) {
-            flush_prose(&mut current_prose, &mut regions);
-            regions.push(Region::Structure(format!("{line}\n")));
+        if is_underline(line_text) {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            regions.push(SpannedRegion::structure(input, line.span()));
             i += 1;
             continue;
         }
 
         // Section title (next line is underline)
-        if i + 1 < total && is_underline(lines[i + 1]) {
-            flush_prose(&mut current_prose, &mut regions);
-            regions.push(Region::Structure(format!("{line}\n")));
+        if i + 1 < total && is_underline(lines[i + 1].text) {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            regions.push(SpannedRegion::structure(input, line.span()));
             i += 1;
             continue;
         }
@@ -186,8 +195,8 @@ fn parse_line_based(input: &str) -> Vec<Region> {
         if trimmed.starts_with(':') && trimmed.len() > 2 {
             if let Some(colon_pos) = trimmed[1..].find(':') {
                 if colon_pos > 0 && colon_pos < trimmed.len() - 2 {
-                    flush_prose(&mut current_prose, &mut regions);
-                    regions.push(Region::Structure(format!("{line}\n")));
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                    regions.push(SpannedRegion::structure(input, line.span()));
                     i += 1;
                     continue;
                 }
@@ -196,15 +205,16 @@ fn parse_line_based(input: &str) -> Vec<Region> {
 
         // Literal block intro (line ending with ::)
         if trimmed.ends_with("::") {
-            flush_prose(&mut current_prose, &mut regions);
-            regions.push(Region::Structure(format!("{line}\n")));
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            regions.push(SpannedRegion::structure(input, line.span()));
             // Find indent of next non-blank line
             let mut j = i + 1;
-            while j < total && lines[j].trim().is_empty() {
+            while j < total && lines[j].text.trim().is_empty() {
                 j += 1;
             }
             if j < total {
-                let next_indent = lines[j].len() - lines[j].trim_start().len();
+                let next = lines[j].text;
+                let next_indent = next.len() - next.trim_start().len();
                 if next_indent > 0 {
                     literal_indent = next_indent;
                     in_literal_block = true;
@@ -216,28 +226,35 @@ fn parse_line_based(input: &str) -> Vec<Region> {
 
         // Grid/simple table rows
         if trimmed.starts_with('|') || trimmed.starts_with('+') {
-            flush_prose(&mut current_prose, &mut regions);
-            regions.push(Region::Structure(format!("{line}\n")));
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            regions.push(SpannedRegion::structure(input, line.span()));
             i += 1;
             continue;
         }
 
         // Regular prose
-        if !current_prose.is_empty() {
-            current_prose.push(' ');
-        }
-        current_prose.push_str(trimmed);
+        push_prose_line(&mut current_prose, &mut prose_span, line, true, true);
         i += 1;
     }
 
-    flush_prose(&mut current_prose, &mut regions);
+    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
     if in_code_block {
-        regions.push(Region::Code {
-            lang: code_lang.take(),
-            header: std::mem::take(&mut code_header),
-            body: std::mem::take(&mut code_body),
-            footer: std::mem::take(&mut code_footer_blanks),
-        });
+        let footer = match code_footer_start {
+            Some(fs) => ByteSpan::new(fs, input.len()),
+            None => ByteSpan::new(input.len(), input.len()),
+        };
+        let body_end = if code_body_end > code_body_start {
+            code_body_end
+        } else {
+            footer.start
+        };
+        regions.push(SpannedRegion::code(
+            input,
+            code_lang.take(),
+            code_header,
+            ByteSpan::new(code_body_start, body_end),
+            footer,
+        ));
     }
     regions
 }
@@ -256,6 +273,7 @@ fn is_underline(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::parser::Region;
 
     #[test]
     fn simple_prose() {

--- a/src/parser/span.rs
+++ b/src/parser/span.rs
@@ -1,0 +1,274 @@
+//! Source-byte spans for splice reflow.
+//!
+//! Native parsers record half-open `[start, end)` ranges into the original
+//! input. Structure, blank, and code regions are those slices; only prose
+//! (and a configured code-comment body) is rewritten. Output is assembled
+//! by copying the gaps between rewrite ranges.
+
+use crate::parser::Region;
+
+/// Half-open byte range `[start, end)` into the parser input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct ByteSpan {
+    pub start: usize,
+    pub end: usize,
+}
+
+impl ByteSpan {
+    pub const fn new(start: usize, end: usize) -> Self {
+        Self { start, end }
+    }
+
+    pub const fn is_empty(self) -> bool {
+        self.start == self.end
+    }
+
+    /// Slice `input` if the range is in bounds and on a char boundary.
+    pub fn slice(self, input: &str) -> Option<&str> {
+        input.get(self.start..self.end)
+    }
+}
+
+/// Origin recorded by a parser for one [`Region`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RegionOrigin {
+    /// One contiguous source range (prose, structure, blank).
+    Whole(ByteSpan),
+    /// Fenced/env code block with independently recorded parts.
+    Code {
+        header: ByteSpan,
+        body: ByteSpan,
+        footer: ByteSpan,
+    },
+}
+
+impl RegionOrigin {
+    pub fn whole(self) -> ByteSpan {
+        match self {
+            RegionOrigin::Whole(s) => s,
+            RegionOrigin::Code { header, footer, .. } => {
+                ByteSpan::new(header.start, footer.end.max(header.end))
+            }
+        }
+    }
+
+    pub fn code(self) -> Option<CodeSpans> {
+        match self {
+            RegionOrigin::Code {
+                header,
+                body,
+                footer,
+            } => Some(CodeSpans {
+                header,
+                body,
+                footer,
+            }),
+            RegionOrigin::Whole(_) => None,
+        }
+    }
+}
+
+/// Header/body/footer spans of a [`Region::Code`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CodeSpans {
+    pub header: ByteSpan,
+    pub body: ByteSpan,
+    pub footer: ByteSpan,
+}
+
+/// A classified region plus the parser-recorded source origin, if any.
+///
+/// Pandoc reconstructs regions from an AST and leaves `origin` unset.
+/// Native line parsers always set it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SpannedRegion {
+    pub region: Region,
+    pub origin: Option<RegionOrigin>,
+}
+
+impl SpannedRegion {
+    pub fn unspanned(region: Region) -> Self {
+        Self {
+            region,
+            origin: None,
+        }
+    }
+
+    pub fn prose(text: String, span: ByteSpan) -> Self {
+        Self {
+            region: Region::Prose(text),
+            origin: Some(RegionOrigin::Whole(span)),
+        }
+    }
+
+    pub fn structure(input: &str, span: ByteSpan) -> Self {
+        Self {
+            region: Region::Structure(input[span.start..span.end].to_string()),
+            origin: Some(RegionOrigin::Whole(span)),
+        }
+    }
+
+    pub fn blank(input: &str, span: ByteSpan) -> Self {
+        Self {
+            region: Region::BlankLines(input[span.start..span.end].to_string()),
+            origin: Some(RegionOrigin::Whole(span)),
+        }
+    }
+
+    pub fn code(
+        input: &str,
+        lang: Option<String>,
+        header: ByteSpan,
+        body: ByteSpan,
+        footer: ByteSpan,
+    ) -> Self {
+        Self {
+            region: Region::Code {
+                lang,
+                header: input[header.start..header.end].to_string(),
+                body: input[body.start..body.end].to_string(),
+                footer: input[footer.start..footer.end].to_string(),
+            },
+            origin: Some(RegionOrigin::Code {
+                header,
+                body,
+                footer,
+            }),
+        }
+    }
+}
+
+/// One physical line of `input`, with byte offsets.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Line<'a> {
+    /// Byte offset of the first character of the line.
+    pub start: usize,
+    /// Byte offset past the terminator (`\n` or `\r\n`), or EOF.
+    pub end: usize,
+    /// Line text without the terminator.
+    pub text: &'a str,
+}
+
+impl Line<'_> {
+    pub fn span(self) -> ByteSpan {
+        ByteSpan::new(self.start, self.end)
+    }
+
+    /// Range of `text` only (no terminator).
+    pub fn content_span(self) -> ByteSpan {
+        ByteSpan::new(self.start, self.start + self.text.len())
+    }
+
+    /// Range of the terminator, empty at EOF with no trailing newline.
+    pub fn terminator_span(self) -> ByteSpan {
+        ByteSpan::new(self.start + self.text.len(), self.end)
+    }
+}
+
+/// Split `input` into lines the way [`str::lines`] does, but keep offsets.
+///
+/// Terminators are `\n` or `\r\n`. A final line without a terminator is
+/// included. `""` yields no lines.
+pub fn iter_lines(input: &str) -> Vec<Line<'_>> {
+    let mut lines = Vec::new();
+    let bytes = input.as_bytes();
+    let mut start = 0;
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\n' {
+            let content_end = if i > start && bytes[i - 1] == b'\r' {
+                i - 1
+            } else {
+                i
+            };
+            lines.push(Line {
+                start,
+                end: i + 1,
+                text: &input[start..content_end],
+            });
+            start = i + 1;
+        }
+        i += 1;
+    }
+    if start < input.len() {
+        lines.push(Line {
+            start,
+            end: input.len(),
+            text: &input[start..],
+        });
+    }
+    lines
+}
+
+/// Append a physical line to the running prose buffer and extend its span.
+///
+/// `include_terminator` is true for ordinary paragraphs (the original
+/// newline is inside the rewrite range) and false for list-item text
+/// (the terminator is a separate Structure slice).
+pub fn push_prose_line(
+    prose: &mut String,
+    prose_span: &mut Option<ByteSpan>,
+    line: &Line<'_>,
+    join_space: bool,
+    include_terminator: bool,
+) {
+    if !prose.is_empty() && join_space {
+        prose.push(' ');
+    }
+    prose.push_str(line.text.trim());
+    let end = if include_terminator {
+        line.end
+    } else {
+        line.start + line.text.len()
+    };
+    match prose_span {
+        None => *prose_span = Some(ByteSpan::new(line.start, end)),
+        Some(s) => s.end = end,
+    }
+}
+
+/// Flush accumulated prose into the region list.
+pub fn flush_prose_spanned(
+    prose: &mut String,
+    prose_span: &mut Option<ByteSpan>,
+    regions: &mut Vec<SpannedRegion>,
+) {
+    if prose.is_empty() {
+        return;
+    }
+    let span = prose_span.take().unwrap_or(ByteSpan::new(0, 0));
+    regions.push(SpannedRegion::prose(std::mem::take(prose), span));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn iter_lines_matches_str_lines_and_keeps_newlines() {
+        let input = "a\nb\n\nc";
+        let lines = iter_lines(input);
+        let plain: Vec<&str> = input.lines().collect();
+        assert_eq!(lines.iter().map(|l| l.text).collect::<Vec<_>>(), plain);
+        assert_eq!(lines[0].span().slice(input), Some("a\n"));
+        assert_eq!(lines[1].span().slice(input), Some("b\n"));
+        assert_eq!(lines[2].span().slice(input), Some("\n"));
+        assert_eq!(lines[3].span().slice(input), Some("c"));
+        assert!(lines[3].terminator_span().is_empty());
+    }
+
+    #[test]
+    fn iter_lines_empty() {
+        assert!(iter_lines("").is_empty());
+    }
+
+    #[test]
+    fn iter_lines_crlf() {
+        let input = "a\r\nb\r\n";
+        let lines = iter_lines(input);
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].text, "a");
+        assert_eq!(lines[0].span().slice(input), Some("a\r\n"));
+        assert_eq!(lines[1].text, "b");
+    }
+}

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use crate::config::CodeLang;
-use crate::parser::Region;
+use crate::parser::{Region, RegionOrigin, SpannedRegion};
 use crate::sentence::SentenceSplitter;
 
 /// Configuration for the reflow engine.
@@ -39,6 +39,81 @@ pub fn reflow(
         }
     }
     reflow_sequential(regions, splitter, config)
+}
+
+/// Reflow using parser-recorded byte ranges: non-prose is copied from
+/// `source`, and only prose (plus a configured code-comment body) is
+/// rewritten. Falls back to concatenating region strings when any region
+/// lacks an origin (pandoc AST path).
+pub fn reflow_spanned(
+    source: &str,
+    spanned: &[SpannedRegion],
+    splitter: &dyn SentenceSplitter,
+    config: &ReflowConfig,
+) -> String {
+    if spanned.is_empty() {
+        return String::new();
+    }
+    if !spanned.iter().all(|s| s.origin.is_some()) {
+        let regions: Vec<Region> = spanned.iter().map(|s| s.region.clone()).collect();
+        return reflow(&regions, splitter, config);
+    }
+    splice(source, spanned, splitter, config)
+}
+
+fn splice(
+    source: &str,
+    spanned: &[SpannedRegion],
+    splitter: &dyn SentenceSplitter,
+    config: &ReflowConfig,
+) -> String {
+    let regions: Vec<Region> = spanned.iter().map(|s| s.region.clone()).collect();
+    let mut rewrites: Vec<(usize, usize, String)> = Vec::new();
+    for (idx, sr) in spanned.iter().enumerate() {
+        let origin = sr.origin.as_ref().expect("splice requires origins");
+        match (&sr.region, origin) {
+            (Region::Prose(text), RegionOrigin::Whole(span)) => {
+                let replacement = reflow_prose(text, idx, &regions, splitter, config);
+                rewrites.push((span.start, span.end, replacement));
+            }
+            (
+                Region::Code { lang, body, .. },
+                RegionOrigin::Code {
+                    body: body_span, ..
+                },
+            ) => {
+                let code_cfg = lang
+                    .as_deref()
+                    .and_then(|l| config.code.and_then(|m| m.get(l)));
+                if let Some(cfg) = code_cfg {
+                    let reflowed = crate::code_block::reflow_code_body(
+                        lang.as_deref().unwrap_or(""),
+                        body,
+                        cfg,
+                        splitter,
+                        config.format_code,
+                    );
+                    if reflowed != *body {
+                        rewrites.push((body_span.start, body_span.end, reflowed));
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    rewrites.sort_by_key(|(start, _, _)| *start);
+    let mut out = String::with_capacity(source.len());
+    let mut cursor = 0usize;
+    for (start, end, repl) in rewrites {
+        if start < cursor || end > source.len() || start > end {
+            continue;
+        }
+        out.push_str(&source[cursor..start]);
+        out.push_str(&repl);
+        cursor = end;
+    }
+    out.push_str(&source[cursor..]);
+    out
 }
 
 fn reflow_sequential(
@@ -109,53 +184,65 @@ fn reflow_one(
             output.push_str(footer);
         }
         Region::Prose(text) => {
-            let hang = match idx.checked_sub(1).and_then(|i| regions.get(i)) {
-                Some(Region::Structure(s)) => hanging_prefix(s),
-                _ => String::new(),
-            };
-            let hanging = hang.chars().count();
-            let wrap_width = if config.max_width > 0 && hanging > 0 {
-                config.max_width.saturating_sub(hanging).max(1)
+            output.push_str(&reflow_prose(text, idx, regions, splitter, config));
+        }
+    }
+    output
+}
+
+fn reflow_prose(
+    text: &str,
+    idx: usize,
+    regions: &[Region],
+    splitter: &dyn SentenceSplitter,
+    config: &ReflowConfig,
+) -> String {
+    let mut output = String::new();
+    let hang = match idx.checked_sub(1).and_then(|i| regions.get(i)) {
+        Some(Region::Structure(s)) => hanging_prefix(s),
+        _ => String::new(),
+    };
+    let hanging = hang.chars().count();
+    let wrap_width = if config.max_width > 0 && hanging > 0 {
+        config.max_width.saturating_sub(hanging).max(1)
+    } else {
+        config.max_width
+    };
+    let sentences = splitter.split(text);
+    let nsent = sentences.len();
+    for (i, sentence) in sentences.iter().enumerate() {
+        let wrapped = if wrap_width > 0 {
+            if config.clause_breaks {
+                wrap_with_clause_breaks(sentence, wrap_width)
             } else {
-                config.max_width
-            };
-            let sentences = splitter.split(text);
-            let nsent = sentences.len();
-            for (i, sentence) in sentences.iter().enumerate() {
-                let wrapped = if wrap_width > 0 {
-                    if config.clause_breaks {
-                        wrap_with_clause_breaks(sentence, wrap_width)
-                    } else {
-                        textwrap::fill(sentence, wrap_width)
-                    }
-                } else {
-                    sentence.clone()
-                };
-                let lines: Vec<&str> = wrapped.lines().collect();
-                for (j, line) in lines.iter().enumerate() {
-                    if hanging > 0 && (i > 0 || j > 0) {
-                        output.push_str(&hang);
-                    }
-                    output.push_str(line);
-                    if j + 1 < lines.len() {
-                        output.push('\n');
-                    }
-                }
-                if i + 1 < nsent {
-                    output.push('\n');
-                }
+                textwrap::fill(sentence, wrap_width)
             }
-            if !sentences.is_empty() {
-                // No forced paragraph break before inline islands (math/code) or
-                // tight punctuation structures — those continue the same line.
-                let suppress = matches!(
-                    regions.get(idx + 1),
-                    Some(Region::Structure(s)) if suppress_prose_trailing_newline(s)
-                );
-                if !suppress {
-                    output.push('\n');
-                }
+        } else {
+            sentence.clone()
+        };
+        let lines: Vec<&str> = wrapped.lines().collect();
+        for (j, line) in lines.iter().enumerate() {
+            if hanging > 0 && (i > 0 || j > 0) {
+                output.push_str(&hang);
             }
+            output.push_str(line);
+            if j + 1 < lines.len() {
+                output.push('\n');
+            }
+        }
+        if i + 1 < nsent {
+            output.push('\n');
+        }
+    }
+    if !sentences.is_empty() {
+        // No forced paragraph break before inline islands (math/code) or
+        // tight punctuation structures — those continue the same line.
+        let suppress = matches!(
+            regions.get(idx + 1),
+            Some(Region::Structure(s)) if suppress_prose_trailing_newline(s)
+        );
+        if !suppress {
+            output.push('\n');
         }
     }
     output

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -329,6 +329,11 @@ fn wrap_words_preferring_clause(text: &str, max_width: usize) -> Vec<String> {
     lines
 }
 
+/// True when `s` is a list or quote marker that continuation lines hang from.
+pub(crate) fn is_hanging_marker(s: &str) -> bool {
+    !hanging_prefix(s).is_empty()
+}
+
 /// Prefix emitted on continuation lines after a list or quote marker.
 /// Lists hang with spaces of marker width; Markdown quotes repeat the
 /// quote prefix (`> `, `> > `, including leading indent). Empty when `s`

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -41,22 +41,26 @@ pub fn reflow(
     reflow_sequential(regions, splitter, config)
 }
 
+/// Why splice could not proceed. Callers fail closed (original document
+/// or an error) instead of skipping the bad range.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+#[error("{0}")]
+pub struct SpliceError(pub String);
+
 /// Reflow using parser-recorded byte ranges: non-prose is copied from
-/// `source`, and only prose (plus a configured code-comment body) is
-/// rewritten. Falls back to concatenating region strings when any region
-/// lacks an origin (pandoc AST path).
+/// `source`, and only prose (plus rewritten comment spans inside code)
+/// is rewritten. Missing origins or invalid spans are errors.
 pub fn reflow_spanned(
     source: &str,
     spanned: &[SpannedRegion],
     splitter: &dyn SentenceSplitter,
     config: &ReflowConfig,
-) -> String {
+) -> Result<String, SpliceError> {
     if spanned.is_empty() {
-        return String::new();
+        return Ok(String::new());
     }
-    if !spanned.iter().all(|s| s.origin.is_some()) {
-        let regions: Vec<Region> = spanned.iter().map(|s| s.region.clone()).collect();
-        return reflow(&regions, splitter, config);
+    if let Some((i, _)) = spanned.iter().enumerate().find(|(_, s)| s.origin.is_none()) {
+        return Err(SpliceError(format!("region {i} has no source origin")));
     }
     splice(source, spanned, splitter, config)
 }
@@ -66,11 +70,14 @@ fn splice(
     spanned: &[SpannedRegion],
     splitter: &dyn SentenceSplitter,
     config: &ReflowConfig,
-) -> String {
+) -> Result<String, SpliceError> {
     let regions: Vec<Region> = spanned.iter().map(|s| s.region.clone()).collect();
     let mut rewrites: Vec<(usize, usize, String)> = Vec::new();
     for (idx, sr) in spanned.iter().enumerate() {
-        let origin = sr.origin.as_ref().expect("splice requires origins");
+        let origin = sr
+            .origin
+            .as_ref()
+            .ok_or_else(|| SpliceError(format!("region {idx} has no source origin")))?;
         match (&sr.region, origin) {
             (Region::Prose(text), RegionOrigin::Whole(span)) => {
                 let replacement = reflow_prose(text, idx, &regions, splitter, config);
@@ -105,15 +112,18 @@ fn splice(
     let mut out = String::with_capacity(source.len());
     let mut cursor = 0usize;
     for (start, end, repl) in rewrites {
-        if start < cursor || end > source.len() || start > end {
-            continue;
+        if start < cursor || end > source.len() || start > end || source.get(start..end).is_none() {
+            return Err(SpliceError(format!(
+                "invalid splice span {start}..{end} (cursor={cursor}, len={})",
+                source.len()
+            )));
         }
         out.push_str(&source[cursor..start]);
         out.push_str(&repl);
         cursor = end;
     }
     out.push_str(&source[cursor..]);
-    out
+    Ok(out)
 }
 
 fn reflow_sequential(
@@ -402,6 +412,38 @@ mod tests {
         let regions = vec![Region::Prose(input.to_string())];
         let config = ReflowConfig::default();
         reflow(&regions, &UnicodeSentenceSplitter::new(), &config)
+    }
+
+    #[test]
+    fn missing_origin_is_error() {
+        let spanned = vec![crate::parser::SpannedRegion::unspanned(Region::Prose(
+            "Hi.".into(),
+        ))];
+        let err = reflow_spanned(
+            "Hi.",
+            &spanned,
+            &UnicodeSentenceSplitter::new(),
+            &ReflowConfig::default(),
+        )
+        .unwrap_err();
+        assert!(err.0.contains("origin"), "{err}");
+    }
+
+    #[test]
+    fn invalid_span_is_error() {
+        use crate::parser::{ByteSpan, RegionOrigin, SpannedRegion};
+        let spanned = vec![SpannedRegion {
+            region: Region::Prose("Hi.".into()),
+            origin: Some(RegionOrigin::Whole(ByteSpan::new(0, 99))),
+        }];
+        let err = reflow_spanned(
+            "Hi.",
+            &spanned,
+            &UnicodeSentenceSplitter::new(),
+            &ReflowConfig::default(),
+        )
+        .unwrap_err();
+        assert!(err.0.contains("invalid splice span"), "{err}");
     }
 
     #[test]

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -987,7 +987,8 @@ mod tests {
         let cfg = FormatConfig {
             format: Format::Plaintext,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             !out.contains("world.\nHow"),
@@ -1085,7 +1086,8 @@ mod tests {
         let cfg = FormatConfig {
             format: Format::Plaintext,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         for input in samples {
             let out = format_text(input, &cfg).unwrap();
             assert!(

--- a/tests/code_block_reflow.rs
+++ b/tests/code_block_reflow.rs
@@ -40,6 +40,7 @@ fn config(format: Format, code: HashMap<String, CodeLang>) -> FormatConfig {
         code,
         ..Default::default()
     }
+    .without_safety_backstops()
 }
 
 /// Round-trip helper. Returns the once-formatted output and asserts the

--- a/tests/pandoc_ast_backend.rs
+++ b/tests/pandoc_ast_backend.rs
@@ -12,7 +12,15 @@ use snapper_fmt::parser::Region;
 use snapper_fmt::parser::pandoc::{
     PandocBackend, PandocParser, ffi_available, regions_from_pandoc_json,
 };
-use snapper_fmt::{FormatConfig, format_text};
+use snapper_fmt::{FormatConfig, PandocCannotSplice, format_text};
+
+fn assert_pandoc_refuses(input: &str, cfg: &FormatConfig) {
+    let err = format_text(input, cfg).expect_err("pandoc must refuse splice");
+    assert!(
+        err.downcast_ref::<PandocCannotSplice>().is_some(),
+        "expected PandocCannotSplice, got {err:?}"
+    );
+}
 
 fn fixture(name: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -131,18 +139,7 @@ fn format_text_cli_backend_stable_across_two_runs_when_pandoc_present() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    let run1 = format_text(&input, &cfg).expect("run1");
-    let run2 = format_text(&input, &cfg).expect("run2");
-    assert_eq!(run1, run2, "AST/CLI reflow must be stable across two runs");
-    // Header title from AST (no requirement for invented ### markers).
-    assert!(
-        run1.to_lowercase().contains("title"),
-        "Header title text should remain after pandoc+snapper: {run1}"
-    );
-    assert!(
-        run1.contains("print") || run1.contains("python"),
-        "CodeBlock body should remain (not sentence-reflowed away): {run1}"
-    );
+    assert_pandoc_refuses(&input, &cfg);
 }
 
 #[test]
@@ -184,9 +181,7 @@ fn format_text_ffi_live_stable_when_lib_present() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    let run1 = format_text(&input, &cfg).expect("ffi run1");
-    let run2 = format_text(&input, &cfg).expect("ffi run2");
-    assert_eq!(run1, run2);
+    assert_pandoc_refuses(&input, &cfg);
 }
 
 /// Pandoc parse first: Header node → Structure; title never Prose (no reflow).
@@ -225,9 +220,10 @@ fn numbered_heading_after_pandoc_parse_not_prose() {
     );
 }
 
-/// End-to-end: pandoc parse → snapper reflow on prose only.
+/// Pandoc has no source offsets, so format_text refuses rather than
+/// reconstruct (and rather than drop `###` from ATX lines).
 #[test]
-fn format_text_pandoc_then_snapper_numbered_header_stable() {
+fn format_text_pandoc_refuses_numbered_heading() {
     let input = read_fixture("numbered_heading.md");
     let backend = if ffi_available() {
         PandocBackend::Ffi
@@ -244,43 +240,22 @@ fn format_text_pandoc_then_snapper_numbered_header_stable() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    let run1 = format_text(&input, &cfg).expect("run1");
-    let run2 = format_text(&input, &cfg).expect("run2");
-    assert_eq!(run1, run2, "stable across two runs");
-
-    let heading_line = run1
-        .lines()
-        .find(|l| l.contains("cargo binstall"))
-        .expect("heading title present after pandoc+snapper");
+    assert_pandoc_refuses(&input, &cfg);
+    let native = format_text(
+        &input,
+        &FormatConfig {
+            format: Format::Markdown,
+            use_pandoc: false,
+            ..Default::default()
+        }
+        .without_safety_backstops(),
+    )
+    .unwrap();
     assert!(
-        heading_line.contains("1.") && heading_line.contains("cargo binstall"),
-        "Header title not sentence-split: {heading_line:?}\nfull:\n{run1}"
-    );
-    // Success is node-kind based — do not require invented ATX `###` markers.
-    assert!(
-        !heading_line.trim_start().starts_with("###"),
-        "pandoc path must not invent ATX markers as structure proof: {heading_line:?}"
-    );
-    assert!(
-        !run1.lines().any(|l| {
-            let t = l.trim();
-            t == "1." || t == "`cargo binstall` (preferred binary install)"
-        }),
-        "title must not be split by snapper reflow:\n{run1}"
-    );
-
-    // Body Para was reflowed: multi-sentence prose becomes separate lines.
-    assert!(
-        run1.contains("Hello world.\n") && run1.contains("Second sentence"),
-        "prose Para must be reflowed by snapper:\n{run1}"
-    );
-    assert!(
-        run1.contains("print") || run1.contains("python"),
-        "code preserved: {run1}"
-    );
-    assert!(
-        run1.contains('|') && (run1.contains("---") || run1.contains('1')),
-        "Table cells as structure from AST:\n{run1}"
+        native
+            .lines()
+            .any(|l| l == "### 1. `cargo binstall` (preferred binary install)"),
+        "native splice must keep ATX hashes:\n{native}"
     );
 }
 
@@ -303,11 +278,18 @@ fn format_text_pandoc_math_and_code_protected() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    let run1 = format_text(&input, &cfg).expect("run1");
-    let run2 = format_text(&input, &cfg).expect("run2");
-    assert_eq!(run1, run2);
+    assert_pandoc_refuses(&input, &cfg);
+    let run1 = format_text(
+        &input,
+        &FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        }
+        .without_safety_backstops(),
+    )
+    .expect("native");
 
-    // Ordinary multi-sentence prose reflowed.
+    // Ordinary multi-sentence prose reflowed (native splice).
     assert!(
         run1.contains("First sentence.\n") && run1.contains("Second sentence"),
         "plain prose reflowed:\n{run1}"
@@ -360,44 +342,28 @@ fn format_text_pandoc_latex_math_code_envs() {
         pandoc_format: Some("latex".into()),
         ..Default::default()
     };
-    let out = match format_text(&input, &cfg) {
-        Ok(o) => o,
-        Err(e) => {
-            eprintln!("skipping latex pandoc path: {e}");
-            return;
-        }
-    };
-    // Require real sentence reflow (fixture has "Hello world. Second sentence." on one line).
-    assert!(
-        out.contains("Hello world.\n") && out.contains("Second sentence"),
-        "latex pandoc must reflow multi-sentence prose:\n{out}"
-    );
-    let native = format_text(
+    assert_pandoc_refuses(&input, &cfg);
+    let out = format_text(
         &input,
         &FormatConfig {
             format: Format::Latex,
             use_pandoc: false,
             ..Default::default()
-        },
+        }
+        .without_safety_backstops(),
     )
     .expect("native latex");
     assert!(
-        native.contains("Hello world.\n") && native.contains("Second sentence"),
-        "native latex reflow for parity:\n{native}"
+        out.contains("Hello world.\n") && out.contains("Second sentence"),
+        "native latex must reflow multi-sentence prose:\n{out}"
     );
-    // Equation / display math not orphaned by "E = mc" / "2." split as prose lines only.
     assert!(
         !out.lines().any(|l| l.trim() == "2." && !l.contains("mc")),
         "math period must not orphan a bare '2.' prose line:\n{out}"
     );
-    // minted/lstlisting/verbatim → CodeBlock with fence emit + lang when known
     assert!(
-        out.contains("```") && (out.contains("print(1.0)") || out.contains("print")),
-        "latex-origin CodeBlocks as fenced code units:\n{out}"
-    );
-    assert!(
-        out.contains("```python") || out.matches("```").count() >= 2,
-        "language fence or multiple code units:\n{out}"
+        out.contains("print(1.0)") || out.contains("\\begin{minted}"),
+        "native latex keeps minted/lstlisting bodies:\n{out}"
     );
 }
 
@@ -419,14 +385,25 @@ fn format_text_pandoc_table_list_quote() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    let run1 = format_text(&input, &cfg).expect("run1");
-    let run2 = format_text(&input, &cfg).expect("run2");
-    assert_eq!(run1, run2);
+    assert_pandoc_refuses(&input, &cfg);
+    let run1 = format_text(
+        &input,
+        &FormatConfig {
+            format: Format::Markdown,
+            use_pandoc: false,
+            ..Default::default()
+        }
+        .without_safety_backstops(),
+    )
+    .expect("native");
     assert!(
         run1.contains("| a |") || run1.contains("| a | b |"),
         "table cells:\n{run1}"
     );
-    assert!(run1.contains("---"), "table separator:\n{run1}");
+    assert!(
+        run1.contains("---") || run1.contains("| - |"),
+        "table separator:\n{run1}"
+    );
     assert!(
         run1.contains("- ") || run1.lines().any(|l| l.starts_with("-")),
         "list markers:\n{run1}"
@@ -446,7 +423,8 @@ fn default_path_numbered_atx_source_line_not_split() {
         format: Format::Markdown,
         use_pandoc: false,
         ..Default::default()
-    };
+    }
+    .without_safety_backstops();
     let out = format_text(&input, &cfg).expect("default format");
     assert!(
         out.lines()
@@ -477,10 +455,20 @@ fn pandoc_org_verbatim_inner_equals_stays_one_span() {
         pandoc_format: Some("org".into()),
         ..Default::default()
     };
-    let out = format_text(input, &cfg).expect("pandoc org format");
+    assert_pandoc_refuses(input, &cfg);
+    let out = format_text(
+        input,
+        &FormatConfig {
+            format: Format::Org,
+            use_pandoc: false,
+            ..Default::default()
+        }
+        .without_safety_backstops(),
+    )
+    .expect("native org");
     assert!(
         !out.lines().any(|l| l.trim() == "=" || l.starts_with("= ")),
-        "pandoc path must not orphan a verbatim closer, got:\n{out}"
+        "native path must not orphan a verbatim closer, got:\n{out}"
     );
     assert!(
         out.contains("x = 1") && out.contains("s ="),

--- a/tests/pandoc_parity_speed.rs
+++ b/tests/pandoc_parity_speed.rs
@@ -43,6 +43,7 @@ fn native_cfg(format: Format) -> FormatConfig {
         use_pandoc: false,
         ..Default::default()
     }
+    .without_safety_backstops()
 }
 
 fn median_ms(mut samples: Vec<f64>) -> f64 {
@@ -96,29 +97,23 @@ fn parity_md_prose_reflow_and_structure() {
     };
     let input = read("pandoc_ast/math_code.md");
     let native = format_text(&input, &native_cfg(Format::Markdown)).expect("native");
-    let pandoc =
-        format_text(&input, &pandoc_cfg(Format::Markdown, backend, "markdown")).expect("pandoc");
-    let p2 =
-        format_text(&input, &pandoc_cfg(Format::Markdown, backend, "markdown")).expect("pandoc2");
-    assert_eq!(pandoc, p2, "pandoc dual-run");
+    let err = format_text(&input, &pandoc_cfg(Format::Markdown, backend, "markdown"))
+        .expect_err("pandoc must refuse splice");
+    assert!(
+        err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
+            .is_some(),
+        "{err:?}"
+    );
 
     assert!(
         has_sentence_reflow(&native, "First sentence.", "Second sentence"),
         "native reflow:\n{native}"
     );
     assert!(
-        has_sentence_reflow(&pandoc, "First sentence.", "Second sentence"),
-        "pandoc reflow:\n{pandoc}"
+        native.contains("```python") && native.contains("print(1.0)"),
+        "code unit:\n{native}"
     );
-    assert!(
-        pandoc.contains("```python") && pandoc.contains("print(1.0)"),
-        "code unit:\n{pandoc}"
-    );
-    assert!(
-        pandoc.contains("$E = mc^2.$") || pandoc.contains("mc^2"),
-        "math present:\n{pandoc}"
-    );
-    assert!(native.contains("Title") && pandoc.contains("Title"));
+    assert!(native.contains("Title"));
 }
 
 #[test]
@@ -128,10 +123,13 @@ fn parity_org_multi_sentence() {
     };
     let input = read("sample.org");
     let native = format_text(&input, &native_cfg(Format::Org)).expect("native");
-    let pandoc = format_text(&input, &pandoc_cfg(Format::Org, backend, "org"))
-        .unwrap_or_else(|e| panic!("org pandoc failed: {e}"));
-    let p2 = format_text(&input, &pandoc_cfg(Format::Org, backend, "org")).unwrap();
-    assert_eq!(pandoc, p2, "org pandoc dual-run");
+    let err = format_text(&input, &pandoc_cfg(Format::Org, backend, "org"))
+        .expect_err("org pandoc must refuse splice");
+    assert!(
+        err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
+            .is_some()
+    );
+    let pandoc = native.clone();
 
     // Multi-sentence prose reflow (fixture: "This is the first paragraph... It has multiple...")
     assert!(
@@ -232,92 +230,50 @@ fn speed_library_native_vs_pandoc_report() {
     let mut lines = vec![format!("md_native_format_text_med_ms={n_md:.3}")];
 
     if snapper_fmt::parser::pandoc::pandoc_available() {
-        let cli = time_format(
+        let err = format_text(
             &md,
             &pandoc_cfg(Format::Markdown, PandocBackend::Cli, "markdown"),
-            20,
-            3,
+        )
+        .expect_err("cli refuse");
+        assert!(
+            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
+                .is_some()
         );
-        lines.push(format!("md_pandoc_cli_uncached_med_ms={cli:.3}"));
-        lines.push(format!(
-            "md_cli_uncached_over_native={:.2}",
-            cli / n_md.max(1e-9)
-        ));
+        lines.push("md_pandoc_cli=refused_no_splice".into());
     }
     if ffi_available() {
-        let ffi = time_format(
+        let err = format_text(
             &md,
             &pandoc_cfg(Format::Markdown, PandocBackend::Ffi, "markdown"),
-            20,
-            3,
+        )
+        .expect_err("ffi refuse");
+        assert!(
+            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
+                .is_some()
         );
-        lines.push(format!("md_pandoc_ffi_uncached_med_ms={ffi:.3}"));
-        lines.push(format!(
-            "md_ffi_uncached_over_native={:.2}",
-            ffi / n_md.max(1e-9)
-        ));
-        assert!(ffi < 500.0, "md FFI pathologically slow: {ffi}");
+        lines.push("md_pandoc_ffi=refused_no_splice".into());
     }
 
     let org = read("sample.org");
     let n_org = time_format(&org, &native_cfg(Format::Org), 40, 5);
     lines.push(format!("org_native_format_text_med_ms={n_org:.3}"));
     if snapper_fmt::parser::pandoc::pandoc_available() {
-        let cli = time_format(
-            &org,
-            &pandoc_cfg(Format::Org, PandocBackend::Cli, "org"),
-            20,
-            3,
+        let err = format_text(&org, &pandoc_cfg(Format::Org, PandocBackend::Cli, "org"))
+            .expect_err("org cli refuse");
+        assert!(
+            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
+                .is_some()
         );
-        lines.push(format!("org_pandoc_cli_uncached_med_ms={cli:.3}"));
-        lines.push(format!(
-            "org_cli_uncached_over_native={:.2}",
-            cli / n_org.max(1e-9)
-        ));
+        lines.push("org_pandoc_cli=refused_no_splice".into());
     }
     if ffi_available() {
-        let ffi = time_format(
-            &org,
-            &pandoc_cfg(Format::Org, PandocBackend::Ffi, "org"),
-            20,
-            3,
-        );
-        lines.push(format!("org_pandoc_ffi_uncached_med_ms={ffi:.3}"));
-        lines.push(format!(
-            "org_ffi_uncached_over_native={:.2}",
-            ffi / n_org.max(1e-9)
-        ));
+        let err = format_text(&org, &pandoc_cfg(Format::Org, PandocBackend::Ffi, "org"))
+            .expect_err("org ffi refuse");
         assert!(
-            ffi / n_org.max(1e-9) < 50.0,
-            "org warm FFI not same-order vs native: {ffi} / {n_org}"
+            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
+                .is_some()
         );
-    }
-
-    // Cached path: re-enable cache, prime once, time hits.
-    let cache_dir = tempfile::tempdir().expect("cache dir");
-    unsafe {
-        std::env::set_var("SNAPPER_PANDOC_CACHE", "1");
-        std::env::set_var("SNAPPER_PANDOC_CACHE_DIR", cache_dir.path());
-    }
-    cache::clear_memory();
-    if let Some(backend) = best_backend() {
-        let _ = format_text(&md, &pandoc_cfg(Format::Markdown, backend, "markdown")).unwrap();
-        let cached = time_format(
-            &md,
-            &pandoc_cfg(Format::Markdown, backend, "markdown"),
-            40,
-            5,
-        );
-        lines.push(format!("md_pandoc_cached_med_ms={cached:.3}"));
-        lines.push(format!(
-            "md_cached_over_native={:.2}",
-            cached / n_md.max(1e-9)
-        ));
-        // Cached must be competitive with native (walker + reflow only).
-        assert!(
-            cached / n_md.max(1e-9) < 10.0,
-            "cached path should be near-native: {cached} vs {n_md}"
-        );
+        lines.push("org_pandoc_ffi=refused_no_splice".into());
     }
 
     eprintln!("{}", lines.join("\n"));
@@ -328,22 +284,14 @@ fn speed_library_native_vs_pandoc_report() {
 
     if snapper_fmt::parser::pandoc::pandoc_available() {
         let tex = read("pandoc_ast/math_code.tex");
-        let out = format_text(
+        let err = format_text(
             &tex,
             &pandoc_cfg(Format::Latex, PandocBackend::Cli, "latex"),
         )
-        .expect("latex pandoc");
+        .expect_err("latex refuse");
         assert!(
-            has_sentence_reflow(&out, "Hello world.", "Second sentence"),
-            "latex prose reflow:\n{out}"
-        );
-        assert!(
-            out.contains("```") && out.contains("print"),
-            "latex code: {out}"
-        );
-        assert!(
-            out.contains("mc^2") || out.contains("$$"),
-            "latex math: {out}"
+            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
+                .is_some()
         );
     }
 
@@ -352,7 +300,6 @@ fn speed_library_native_vs_pandoc_report() {
         std::env::remove_var("SNAPPER_PANDOC_CACHE_DIR");
     }
     cache::clear_memory();
-    drop(cache_dir);
 }
 
 /// Always exercises fail-closed via a real snapper subprocess + bad lib path.

--- a/tests/safety_props.rs
+++ b/tests/safety_props.rs
@@ -1,0 +1,64 @@
+//! Property tests for `format_text` / `format_bytes` per [`Format`].
+//!
+//! With both safety backstops off: idempotency, oracle match, and
+//! invalid UTF-8 is a hard error. These are the always-on stand-in for
+//! a libfuzzer target (see `fuzz/fuzz_targets/format_text.rs`).
+
+use proptest::prelude::*;
+use snapper_fmt::format::Format;
+use snapper_fmt::oracle;
+use snapper_fmt::{FormatConfig, InvalidUtf8Error, format_bytes, format_text};
+
+fn cfg(format: Format) -> FormatConfig {
+    FormatConfig {
+        format,
+        fixpoint_backstop: false,
+        render_backstop: false,
+        ..Default::default()
+    }
+}
+
+fn format_of(n: u8) -> Format {
+    match n % 5 {
+        0 => Format::Plaintext,
+        1 => Format::Markdown,
+        2 => Format::Org,
+        3 => Format::Latex,
+        _ => Format::Rst,
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig {
+        cases: 64,
+        ..ProptestConfig::default()
+    })]
+
+    #[test]
+    fn format_text_idempotent_and_oracle(
+        s in "[A-Za-z][A-Za-z0-9 ,;:'\"]{0,120}\\. [A-Za-z][A-Za-z0-9 ,;:'\"]{0,80}\\.",
+        fmt_tag in 0u8..5,
+    ) {
+        let format = format_of(fmt_tag);
+        let c = cfg(format);
+        let out = format_text(&s, &c).expect("format_text on valid UTF-8");
+        let twice = format_text(&out, &c).expect("second pass");
+        prop_assert_eq!(&out, &twice, "not idempotent for {:?}", format);
+        prop_assert!(
+            oracle::matches(format, &s, &out),
+            "oracle mismatch format={:?}\n in={:?}\n out={:?}",
+            format,
+            s,
+            out
+        );
+    }
+
+    #[test]
+    fn invalid_utf8_bytes_error(mut bytes in prop::collection::vec(any::<u8>(), 0..64)) {
+        if std::str::from_utf8(&bytes).is_ok() {
+            bytes.push(0xff);
+        }
+        let err = format_bytes(&bytes, &cfg(Format::Plaintext)).unwrap_err();
+        prop_assert!(err.downcast_ref::<InvalidUtf8Error>().is_some());
+    }
+}

--- a/tests/safety_props.rs
+++ b/tests/safety_props.rs
@@ -36,7 +36,7 @@ proptest! {
 
     #[test]
     fn format_text_idempotent_and_oracle(
-        s in "[A-Za-z][A-Za-z0-9 ,;:'\"]{0,120}\\. [A-Za-z][A-Za-z0-9 ,;:'\"]{0,80}\\.",
+        s in "[A-Za-z#*][A-Za-z0-9#* ,;:'\"]{0,80}\\. [A-Za-z][A-Za-z0-9 ,;:'\"]{0,40}\\.",
         fmt_tag in 0u8..5,
     ) {
         let format = format_of(fmt_tag);
@@ -50,6 +50,26 @@ proptest! {
             format,
             s,
             out
+        );
+    }
+
+    #[test]
+    #[test]
+    fn format_text_paragraph_break_oracle(
+        a in "[A-Za-z][A-Za-z0-9 ,;:'\"]{0,40}\\.",
+        b in "[A-Za-z][A-Za-z0-9 ,;:'\"]{0,40}\\.",
+        fmt_tag in 0u8..5,
+    ) {
+        let s = format!("{a}\n\n{b}");
+        let format = format_of(fmt_tag);
+        let c = cfg(format);
+        let out = format_text(&s, &c).expect("format_text");
+        let twice = format_text(&out, &c).expect("second pass");
+        prop_assert_eq!(&out, &twice);
+        prop_assert!(
+            oracle::matches(format, &s, &out),
+            "oracle mismatch format={:?}\n in={:?}\n out={:?}",
+            format, s, out
         );
     }
 

--- a/tests/safety_splice.rs
+++ b/tests/safety_splice.rs
@@ -1,0 +1,250 @@
+//! Safety-bar tests: splice (non-prose is an input slice), fixpoint, and
+//! format-local render oracle.
+//!
+//! Production `format_text` enables the fixpoint and render backstops.
+//! These tests turn them off so a planner that needs the backstop fails
+//! here instead of being masked.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::Path;
+
+use snapper_fmt::format::Format;
+use snapper_fmt::oracle;
+use snapper_fmt::parser::{Region, RegionOrigin, parser_for_format};
+use snapper_fmt::{FormatConfig, InvalidUtf8Error, format_bytes, format_text};
+
+fn fixture(name: &str) -> String {
+    let p = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name);
+    std::fs::read_to_string(p).unwrap()
+}
+
+fn cfg(format: Format) -> FormatConfig {
+    FormatConfig {
+        format,
+        fixpoint_backstop: false,
+        render_backstop: false,
+        ..Default::default()
+    }
+}
+
+fn non_prose_payload(regions: &[Region]) -> Vec<u8> {
+    let mut out = Vec::new();
+    for r in regions {
+        match r {
+            Region::Structure(s) | Region::BlankLines(s) => out.extend(s.as_bytes()),
+            Region::Code {
+                header,
+                body,
+                footer,
+                ..
+            } => {
+                out.extend(header.as_bytes());
+                out.extend(body.as_bytes());
+                out.extend(footer.as_bytes());
+            }
+            Region::Prose(_) => {}
+        }
+    }
+    out
+}
+
+fn hash_bytes(b: &[u8]) -> u64 {
+    let mut h = DefaultHasher::new();
+    b.hash(&mut h);
+    h.finish()
+}
+
+/// Structure/Code/Blank must be the original input slice, not a
+/// reconstructed `format!("{line}\\n")` that invents a trailing newline.
+#[test]
+fn structure_without_newline_is_exact_slice() {
+    let input = "## Title";
+    let regions = parser_for_format(Format::Markdown).parse(input);
+    match regions.as_slice() {
+        [Region::Structure(s)] => {
+            assert_eq!(
+                s.as_str(),
+                input,
+                "structure must be the input slice, not a re-serialized line"
+            );
+        }
+        other => panic!("expected one Structure, got {other:?}"),
+    }
+}
+
+#[test]
+fn org_headline_without_newline_is_exact_slice() {
+    let input = "* TODO a headline";
+    let regions = parser_for_format(Format::Org).parse(input);
+    match regions.as_slice() {
+        [Region::Structure(s)] => {
+            assert_eq!(s.as_str(), input);
+        }
+        other => panic!("expected one Structure, got {other:?}"),
+    }
+}
+
+fn assert_non_prose_hash_stable(name: &str, format: Format) {
+    let input = fixture(name);
+    let parser = parser_for_format(format);
+    let before = non_prose_payload(&parser.parse(&input));
+    let formatted = format_text(&input, &cfg(format)).unwrap();
+    let after = non_prose_payload(&parser.parse(&formatted));
+    assert_eq!(
+        hash_bytes(&before),
+        hash_bytes(&after),
+        "non-prose hash changed on {name}\n--- before ---\n{}\n--- after ---\n{}",
+        String::from_utf8_lossy(&before),
+        String::from_utf8_lossy(&after)
+    );
+    assert_eq!(
+        before, after,
+        "non-prose bytes changed on {name} (hash collision check)"
+    );
+}
+
+#[test]
+fn non_prose_hash_sample_md() {
+    assert_non_prose_hash_stable("sample.md", Format::Markdown);
+}
+
+#[test]
+fn non_prose_hash_sample_tex() {
+    assert_non_prose_hash_stable("sample.tex", Format::Latex);
+}
+
+#[test]
+fn non_prose_hash_edge_cases_org() {
+    assert_non_prose_hash_stable("edge_cases.org", Format::Org);
+}
+
+/// Native parsers record a byte span for every region, and Structure/Code/Blank
+/// text equals the input slice.
+#[test]
+fn recorded_spans_are_input_slices_on_fixtures() {
+    for (name, format) in [
+        ("sample.md", Format::Markdown),
+        ("sample.tex", Format::Latex),
+        ("edge_cases.org", Format::Org),
+    ] {
+        let input = fixture(name);
+        let spanned = parser_for_format(format).parse_full(&input);
+        for sr in &spanned {
+            let origin = sr
+                .origin
+                .unwrap_or_else(|| panic!("{name}: native parser must record origin for {sr:?}"));
+            match (&sr.region, origin) {
+                (Region::Prose(_), RegionOrigin::Whole(span)) => {
+                    assert!(span.end <= input.len(), "{name}: prose span out of range");
+                }
+                (Region::Structure(s) | Region::BlankLines(s), RegionOrigin::Whole(span)) => {
+                    let slice = &input[span.start..span.end];
+                    assert_eq!(
+                        s.as_str(),
+                        slice,
+                        "{name}: non-prose region is not an input slice\nregion={s:?}\nslice={slice:?}"
+                    );
+                }
+                (
+                    Region::Code {
+                        header,
+                        body,
+                        footer,
+                        ..
+                    },
+                    RegionOrigin::Code {
+                        header: hs,
+                        body: bs,
+                        footer: fs,
+                    },
+                ) => {
+                    assert_eq!(header.as_str(), &input[hs.start..hs.end], "{name} header");
+                    assert_eq!(body.as_str(), &input[bs.start..bs.end], "{name} body");
+                    assert_eq!(footer.as_str(), &input[fs.start..fs.end], "{name} footer");
+                }
+                other => panic!("{name}: origin kind mismatch: {other:?}"),
+            }
+        }
+    }
+}
+
+/// With the fixpoint backstop off, a second pass must already be a no-op
+/// on the fixtures. A planner that needs the loop fails here.
+#[test]
+fn fixtures_are_single_pass_fixpoints() {
+    for (name, format) in [
+        ("sample.md", Format::Markdown),
+        ("sample.tex", Format::Latex),
+        ("edge_cases.org", Format::Org),
+        ("sample.txt", Format::Plaintext),
+    ] {
+        let input = fixture(name);
+        let c = cfg(format);
+        let once = format_text(&input, &c).unwrap();
+        let twice = format_text(&once, &c).unwrap();
+        assert_eq!(once, twice, "{name} is not a single-pass fixpoint");
+    }
+}
+
+/// Oracle holds on the fixtures with the render backstop disabled.
+#[test]
+fn fixtures_pass_oracle_without_backstop() {
+    for (name, format) in [
+        ("sample.md", Format::Markdown),
+        ("sample.tex", Format::Latex),
+        ("edge_cases.org", Format::Org),
+        ("sample.txt", Format::Plaintext),
+    ] {
+        let input = fixture(name);
+        let out = format_text(&input, &cfg(format)).unwrap();
+        assert!(
+            oracle::matches(format, &input, &out),
+            "{name}: oracle mismatch\n--- in ---\n{input}\n--- out ---\n{out}"
+        );
+    }
+}
+
+#[test]
+fn invalid_utf8_is_a_hard_error() {
+    let mut bytes = b"Hello world. Next.\n".to_vec();
+    bytes.push(0xff);
+    let err = format_bytes(&bytes, &cfg(Format::Plaintext)).unwrap_err();
+    assert!(
+        err.downcast_ref::<InvalidUtf8Error>().is_some(),
+        "expected InvalidUtf8Error, got {err:?}"
+    );
+}
+
+/// A mid-token period+capital (`a0.A.`) changes the prose word sequence if
+/// split. Production backstops must fail closed to the original.
+#[test]
+fn render_backstop_keeps_mid_token_period_capital() {
+    let input = "A. a0.A.";
+    let out = format_text(
+        input,
+        &FormatConfig {
+            format: Format::Plaintext,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(out, input);
+}
+
+#[test]
+fn production_fixpoint_returns_original_on_cap() {
+    // Empty and already-formatted inputs converge in one extra pass.
+    let input = "Hello world.\nThis is a test.\n";
+    let out = format_text(
+        input,
+        &FormatConfig {
+            format: Format::Plaintext,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(out, "Hello world.\nThis is a test.\n");
+}

--- a/tests/safety_splice.rs
+++ b/tests/safety_splice.rs
@@ -87,6 +87,56 @@ fn org_headline_without_newline_is_exact_slice() {
     }
 }
 
+/// Planner property: format_text must not invent a terminator on a
+/// no-newline headline. Backstops off so a masked no-op is a failure.
+#[test]
+fn format_text_preserves_no_nl_headlines() {
+    for (format, input) in [
+        (Format::Markdown, "## Title"),
+        (Format::Org, "* TODO a headline"),
+        (Format::Latex, "\\begin{document}\n\\section{A title}"),
+    ] {
+        let out = format_text(input, &cfg(format)).unwrap();
+        assert_eq!(out, input, "{format:?} invented bytes:\n{out:?}");
+        assert!(
+            oracle::matches(format, input, &out),
+            "{format:?} oracle rejected a no-op headline"
+        );
+    }
+}
+
+/// The oracle must see an invented newline on a structure line as a
+/// mutation, not as equivalent whitespace.
+#[test]
+fn oracle_rejects_invented_newline_on_headlines() {
+    assert!(
+        !oracle::matches(Format::Markdown, "## Title", "## Title\n"),
+        "MD oracle must catch invented newline on ATX title"
+    );
+    assert!(
+        !oracle::matches(Format::Org, "* TODO a headline", "* TODO a headline\n"),
+        "Org oracle must catch invented newline on headline"
+    );
+    let tex_in = "\\begin{document}\n\\section{A title}";
+    let tex_nl = "\\begin{document}\n\\section{A title}\n";
+    assert!(
+        !oracle::matches(Format::Latex, tex_in, tex_nl),
+        "LaTeX oracle must catch invented newline on section"
+    );
+}
+
+#[test]
+fn oracle_rejects_structure_kind_change() {
+    assert!(
+        !oracle::matches(Format::Markdown, "## Title\n\nHi.", "Title\n\nHi."),
+        "dropping ATX marks is a structure mutation"
+    );
+    assert!(
+        !oracle::matches(Format::Org, "* TODO a\n\nHi.", "TODO a\n\nHi."),
+        "dropping stars is a structure mutation"
+    );
+}
+
 fn assert_non_prose_hash_stable(name: &str, format: Format) {
     let input = fixture(name);
     let parser = parser_for_format(format);
@@ -234,17 +284,26 @@ fn render_backstop_keeps_mid_token_period_capital() {
     assert_eq!(out, input);
 }
 
+/// The fixpoint helper returns the original document when the step
+/// function cycles A/B within the cap.
 #[test]
-fn production_fixpoint_returns_original_on_cap() {
-    // Empty and already-formatted inputs converge in one extra pass.
-    let input = "Hello world.\nThis is a test.\n";
-    let out = format_text(
-        input,
-        &FormatConfig {
-            format: Format::Plaintext,
-            ..Default::default()
-        },
-    )
+fn fixpoint_ab_cycle_returns_original() {
+    use std::cell::Cell;
+    let tick = Cell::new(0u8);
+    let out = snapper_fmt::run_fixpoint("A", true, |_| {
+        let n = tick.get();
+        tick.set(n + 1);
+        Ok(if n % 2 == 0 {
+            "B".to_string()
+        } else {
+            "A".to_string()
+        })
+    })
     .unwrap();
-    assert_eq!(out, "Hello world.\nThis is a test.\n");
+    assert_eq!(out, "A");
+    assert!(
+        tick.get() >= 2,
+        "must observe the cycle, ticks={}",
+        tick.get()
+    );
 }

--- a/tests/sentence_delim_props.rs
+++ b/tests/sentence_delim_props.rs
@@ -17,6 +17,7 @@ fn plaintext_cfg() -> FormatConfig {
         format: Format::Plaintext,
         ..Default::default()
     }
+    .without_safety_backstops()
 }
 
 fn format_plain(input: &str) -> String {
@@ -122,7 +123,8 @@ fn multi_format_prose_respects_delimiter_spans() {
         let cfg = FormatConfig {
             format,
             ..Default::default()
-        };
+        }
+        .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             newlines_respect_delimiter_spans(&out),
@@ -163,7 +165,8 @@ fn code_block_comment_respects_quotes() {
             m
         },
         ..Default::default()
-    };
+    }
+    .without_safety_backstops();
     let out = format_text(input, &cfg).unwrap();
     assert!(
         !out.contains("Hello.\n// World") && !out.contains("Hello.\nWorld"),


### PR DESCRIPTION
Native parsers record source spans. Structure, blank, and code fences are input slices. Prose is the rewrite.

`format_text` runs to a byte fixpoint or returns the original (cap 4). A render/region oracle mismatch also returns the original. Tests disable those backstops.

`--use-pandoc` format_text refuses: the AST has no source offsets. Classification still works.

Rebased onto #16.