### PR TITLE
feat: configurable LaTeX verbatim and structure envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file. See [conven
 - (**safety**) property tests and a `cargo fuzz` target (fixture corpus) drive `format_text` per format with the backstops off
 - (**code-block**) comment reflow copies non-comment lines as original slices; only comment spans are rewritten
 #### Bug Fixes
+- (**latex**) render oracle and `--check` payloads honor `[latex]` extras, so a configured `\\Verb!%!` is not a comment and production backstops no longer revert the file
 - (**latex**) tokenize `\\verb` / `\\lstinline` (optional `[...]`) before split so inner `%` is not a comment and inner `.!?` do not split; unmatched `\\verb` runs to EOL; unlisted `\\begin` / `\\end` are region bounds (optional `[...]` stays on the begin token); mid-line `\\begin{equation}` leaves leading words as prose; nested same-name envs (including verbatim/lstlisting) close on matching depth, so `\\end{python}` inside lstlisting does not steal the closer; listing body scans raw `\\begin`/`\\end` (no `%` stop, no `\\verb` skip) so `print(1) % \\end{lstlisting}` and `print(\"%\")` still close
 - (**check**) fused and long run on the parser prose payload, so `1. Hello world.` and `See Fig. 1. % TODO cite` are not false fused
 - (**reflow**) splice keeps the trailing space before a mid-line TeX `%` comment so that line stays one source line

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. See [conven
 ## Unreleased (main)
 
 #### Features
+- (**latex**) `[latex].verbatim_envs` / `structure_envs` / `verbatim_commands` in `.snapperrc.toml` add names to the built-in lists (minted/lstlisting/verbatim, `NON_PROSE_ENVS`, `\\verb`/`\\lstinline`); missing keys keep today's defaults. Extra command names are tokenized like `\\verb` before split. No regex `other:` key
 - (**reflow**) `--clause-breaks` / `clause_breaks` with `max_width = 0` inserts a newline after every independent-clause mark (`,`, `;`, `:`, em dash, `--`) that is already followed by whitespace; a one-clause sentence stays one line; `max_width > 0` keeps wrap-prefer-clause. Tokens such as `1,000`, URLs, `--flags`, and unspaced dashes never split. `--check` uses the same mode
 - (**cli** / **check**) `--check --output-format json|sarif` emits 1-indexed `fused` / `wrap` / `long` diagnostics with excerpts; `long` is advisory unless `--strict-long`; stdin `--check` honors the same JSON/SARIF and exit codes; SARIF URIs are repo-relative (or `file:` plus `invocations[0].workingDirectory`)
 - (**mcp**) `check_formatting` returns `would_reformat` identical to CLI `--check`, plus the same line diagnostics

--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -182,9 +182,10 @@ Adding =algorithm= or =comment= stops reflow of those environments.
 :CUSTOM_ID: field-verbatim-commands
 :END:
 
-String array of command names tokenized like =\verb= before sentence split (the next character is the delimiter).
-Built-in: =verb=, =lstinline= (=lstinline= still accepts optional =[...]= and ={...}=).
-Adding =Verb= (fancyvrb) keeps =\Verb|a.b! c|= atomic and treats an inner =%= as content, not a comment.
+String array of extra command names tokenized like the built-in verb command before sentence split.
+The next character after the name is the delimiter.
+Built-in names are =verb= and =lstinline=; =lstinline= still accepts optional =[...]= and ={...}=.
+Adding =Verb= (fancyvrb) keeps that command's delimited body atomic and treats an inner =%= as content, not a comment.
 
 * Code-block sections (=[code.<lang>]=)
 :PROPERTIES:

--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -44,6 +44,11 @@ extra_abbreviations = ["PROPERTIES", "DEADLINE"]
 [latex]
 extra_abbreviations = ["Thm", "Lem"]
 max_width = 100
+# Extra names are added to the built-in lists. Missing keys keep those lists.
+# No regex `other:` matching.
+verbatim_envs = ["Verbatim"]
+structure_envs = ["algorithm", "comment"]
+verbatim_commands = ["Verb"]
 
 # Per-language code-block comment reflow and optional formatters.
 # Used when the parser emits a Region::Code with a matching language.
@@ -149,6 +154,37 @@ Add =[org]=, =[latex]=, =[markdown]=, =[rst]=, or =[plaintext]= sections to over
 
 Per-format =extra_abbreviations= merge with the top-level list.
 Per-format =max_width= overrides the top-level value.
+
+The following keys are meaningful under =[latex]= only.
+Missing keys (or empty arrays) keep the built-in lists; present entries are added to those lists.
+There is no regex =other:= key (latexindent's pattern-based extra matching is not supported).
+
+** verbatim_envs (latex)
+:PROPERTIES:
+:CUSTOM_ID: field-verbatim-envs
+:END:
+
+String array of environment names treated like =minted= / =lstlisting= / =verbatim= (=Region::Code=, no reflow).
+Built-in: =minted=, =lstlisting=, =verbatim=.
+Adding =Verbatim= (fancyvrb) stops reflow of that environment.
+
+** structure_envs (latex)
+:PROPERTIES:
+:CUSTOM_ID: field-structure-envs
+:END:
+
+String array of environment names treated like =equation= / =figure= (=Region::Structure=, no reflow).
+Built-in: the =NON_PROSE_ENVS= list (equation, align, figure, table, tabular, tikzpicture, and starred variants, plus the built-in code envs).
+Adding =algorithm= or =comment= stops reflow of those environments.
+
+** verbatim_commands (latex)
+:PROPERTIES:
+:CUSTOM_ID: field-verbatim-commands
+:END:
+
+String array of command names tokenized like =\verb= before sentence split (the next character is the delimiter).
+Built-in: =verb=, =lstinline= (=lstinline= still accepts optional =[...]= and ={...}=).
+Adding =Verb= (fancyvrb) keeps =\Verb|a.b! c|= atomic and treats an inner =%= as content, not a comment.
 
 * Code-block sections (=[code.<lang>]=)
 :PROPERTIES:

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -71,6 +71,7 @@ These tokens within prose are not split across lines:
 :END:
 - Preamble (everything before =\begin{document}=)
 - Non-prose environments: equation, align, figure, table, tabular, tikzpicture, and their starred variants (plus other non-code envs)
+- Extra names from =[latex].structure_envs= in =.snapperrc.toml= (for example =algorithm=, =comment=)
 - Display math: =\[...\]=
 - Comment lines (starting with =%=)
 - =\end{document}=
@@ -81,7 +82,9 @@ These tokens within prose are not split across lines:
 :CUSTOM_ID: latex-code
 :END:
 - =\\begin{...}= / =\\end{...}= lines are structure
+- Extra names from =[latex].verbatim_envs= (for example fancyvrb =Verbatim=) are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= =language== option)
+- Inline =\verb= / =\lstinline= (and extra =[latex].verbatim_commands=, for example =\Verb=) stay atomic; inner =.!?%= do not split or comment
 
 *** Prose regions (reflowed)
 :PROPERTIES:

--- a/src/check.rs
+++ b/src/check.rs
@@ -71,15 +71,18 @@ const WRAP_CONNECTORS: &[&str] = &[
 /// Collect fused / wrap / long diagnostics for `input`.
 ///
 /// `long_threshold` is character count, already resolved by
-/// [`resolve_long_threshold`].
+/// [`resolve_long_threshold`]. `config` supplies `[latex]` extras so
+/// `--check` uses the same region kinds as `format_text`. `None` keeps
+/// the built-in lists.
 pub fn collect_diagnostics(
     input: &str,
     format: Format,
     splitter: &dyn SentenceSplitter,
     long_threshold: usize,
+    config: Option<&FormatConfig>,
 ) -> Vec<LineDiagnostic> {
     let lines: Vec<&str> = input.lines().collect();
-    let payloads = source_line_payloads(input, format);
+    let payloads = source_line_payloads(input, format, config);
     debug_assert_eq!(
         payloads.len(),
         lines.len(),
@@ -223,7 +226,13 @@ mod tests {
 
     fn diags(input: &str) -> Vec<LineDiagnostic> {
         let splitter = UnicodeSentenceSplitter::new();
-        collect_diagnostics(input, Format::Plaintext, &splitter, DEFAULT_LONG_THRESHOLD)
+        collect_diagnostics(
+            input,
+            Format::Plaintext,
+            &splitter,
+            DEFAULT_LONG_THRESHOLD,
+            None,
+        )
     }
 
     fn kinds_on(diags: &[LineDiagnostic], line: usize) -> Vec<DiagnosticKind> {
@@ -363,7 +372,7 @@ mod tests {
     fn long_uses_resolved_threshold() {
         let splitter = UnicodeSentenceSplitter::new();
         let line = "Short clause, still short.\n";
-        let found = collect_diagnostics(line, Format::Plaintext, &splitter, 5);
+        let found = collect_diagnostics(line, Format::Plaintext, &splitter, 5, None);
         assert!(
             found.iter().any(|d| d.kind == DiagnosticKind::Long),
             "threshold 5 must flag a comma-bearing line, got {found:?}"
@@ -390,7 +399,13 @@ mod tests {
     fn structure_and_code_are_not_prose() {
         let md = "# Title. Still a heading.\n\n```\nHello. World.\n```\n\nBody sentence.\n";
         let splitter = UnicodeSentenceSplitter::new();
-        let found = collect_diagnostics(md, Format::Markdown, &splitter, DEFAULT_LONG_THRESHOLD);
+        let found = collect_diagnostics(
+            md,
+            Format::Markdown,
+            &splitter,
+            DEFAULT_LONG_THRESHOLD,
+            None,
+        );
         assert!(
             found.iter().all(|d| d.kind != DiagnosticKind::Fused),
             "headings and fenced code must not produce fused, got {found:?}"
@@ -425,7 +440,8 @@ mod tests {
             "Real prose. Second sentence.\n",
         );
         let splitter = UnicodeSentenceSplitter::new();
-        let found = collect_diagnostics(input, Format::Org, &splitter, DEFAULT_LONG_THRESHOLD);
+        let found =
+            collect_diagnostics(input, Format::Org, &splitter, DEFAULT_LONG_THRESHOLD, None);
         assert_no_kind_on(
             &found,
             DiagnosticKind::Fused,
@@ -453,7 +469,13 @@ mod tests {
             "Body one. Body two.\n",
         );
         let splitter = UnicodeSentenceSplitter::new();
-        let found = collect_diagnostics(input, Format::Markdown, &splitter, DEFAULT_LONG_THRESHOLD);
+        let found = collect_diagnostics(
+            input,
+            Format::Markdown,
+            &splitter,
+            DEFAULT_LONG_THRESHOLD,
+            None,
+        );
         assert_no_kind_on(
             &found,
             DiagnosticKind::Fused,
@@ -481,7 +503,13 @@ mod tests {
             "\\end{document}\n",
         );
         let splitter = UnicodeSentenceSplitter::new();
-        let found = collect_diagnostics(input, Format::Latex, &splitter, DEFAULT_LONG_THRESHOLD);
+        let found = collect_diagnostics(
+            input,
+            Format::Latex,
+            &splitter,
+            DEFAULT_LONG_THRESHOLD,
+            None,
+        );
         assert_no_kind_on(
             &found,
             DiagnosticKind::Fused,
@@ -515,7 +543,8 @@ mod tests {
             "Body one. Body two.\n",
         );
         let splitter = UnicodeSentenceSplitter::new();
-        let found = collect_diagnostics(input, Format::Rst, &splitter, DEFAULT_LONG_THRESHOLD);
+        let found =
+            collect_diagnostics(input, Format::Rst, &splitter, DEFAULT_LONG_THRESHOLD, None);
         assert_no_kind_on(
             &found,
             DiagnosticKind::Fused,
@@ -540,8 +569,13 @@ mod tests {
             "After one. After two.\n",
         );
         let splitter = UnicodeSentenceSplitter::new();
-        let found =
-            collect_diagnostics(input, Format::Plaintext, &splitter, DEFAULT_LONG_THRESHOLD);
+        let found = collect_diagnostics(
+            input,
+            Format::Plaintext,
+            &splitter,
+            DEFAULT_LONG_THRESHOLD,
+            None,
+        );
         assert_no_kind_on(
             &found,
             DiagnosticKind::Fused,
@@ -603,19 +637,20 @@ mod tests {
 
     fn no_fused(input: &str, format: Format) -> Vec<LineDiagnostic> {
         let splitter = UnicodeSentenceSplitter::new();
-        collect_diagnostics(input, format, &splitter, DEFAULT_LONG_THRESHOLD)
+        collect_diagnostics(input, format, &splitter, DEFAULT_LONG_THRESHOLD, None)
     }
 
     #[test]
     fn numbered_list_payload_is_item_text() {
         use crate::parser::source_line_payloads;
-        let md = source_line_payloads("1. Hello world.\n", Format::Markdown);
+        let md = source_line_payloads("1. Hello world.\n", Format::Markdown, None);
         assert_eq!(md[0].as_deref(), Some("Hello world."));
-        let org = source_line_payloads("1. Hello world.\n", Format::Org);
+        let org = source_line_payloads("1. Hello world.\n", Format::Org, None);
         assert_eq!(org[0].as_deref(), Some("Hello world."));
         let tex = source_line_payloads(
             "\\begin{document}\nSee Fig. 1. % TODO cite\n\\end{document}\n",
             Format::Latex,
+            None,
         );
         assert_eq!(
             tex[1].as_deref().map(str::trim),
@@ -723,13 +758,49 @@ mod tests {
             ),
         ];
         for (fmt, input) in cases {
-            let kinds = source_line_payloads(input, fmt);
+            let kinds = source_line_payloads(input, fmt, None);
             assert_eq!(
                 kinds.len(),
                 input.lines().count(),
                 "line map length mismatch for {fmt:?}"
             );
         }
+    }
+
+    #[test]
+    fn configured_verb_inner_percent_is_fused_not_comment() {
+        let input = "\\begin{document}\nCode \\Verb!%! here. Next sentence.\n\\end{document}\n";
+        let config = FormatConfig {
+            format: Format::Latex,
+            latex_verbatim_commands: vec!["Verb".into()],
+            ..Default::default()
+        };
+        let splitter = UnicodeSentenceSplitter::new().with_verbatim_commands(vec!["Verb".into()]);
+        let found = collect_diagnostics(
+            input,
+            Format::Latex,
+            &splitter,
+            DEFAULT_LONG_THRESHOLD,
+            Some(&config),
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 2 && d.kind == DiagnosticKind::Fused),
+            "configured Verb inner % is content; the line is fused, got {found:?}"
+        );
+        let payloads = source_line_payloads(input, Format::Latex, Some(&config));
+        assert_eq!(
+            payloads[1].as_deref().map(str::trim),
+            Some("Code \\Verb!%! here. Next sentence."),
+            "extras must keep % inside Verb as prose, got {payloads:?}"
+        );
+        let builtin = source_line_payloads(input, Format::Latex, None);
+        assert_ne!(
+            builtin[1].as_deref().map(str::trim),
+            Some("Code \\Verb!%! here. Next sentence."),
+            "built-in lists treat % as a comment, got {builtin:?}"
+        );
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,17 @@ use serde::Deserialize;
 pub struct FormatOverrides {
     pub extra_abbreviations: Vec<String>,
     pub max_width: Option<usize>,
+    /// Extra LaTeX environments treated as code (no reflow).
+    /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
+    /// minted/lstlisting/verbatim list; entries are added to it.
+    pub verbatim_envs: Vec<String>,
+    /// Extra LaTeX environments treated as structure (no reflow).
+    /// Meaningful under `[latex]` only. Missing or empty keeps
+    /// `NON_PROSE_ENVS`; entries are added to that list.
+    pub structure_envs: Vec<String>,
+    /// Extra LaTeX command names tokenized like `\verb` before split.
+    /// Meaningful under `[latex]` only. Missing or empty keeps verb/lstinline.
+    pub verbatim_commands: Vec<String>,
 }
 
 /// Per-language entry under the `[code]` table.
@@ -162,6 +173,30 @@ impl ProjectConfig {
             _ => None,
         };
         overrides.and_then(|ov| ov.max_width).or(self.max_width)
+    }
+
+    /// Extra `[latex].verbatim_envs` names. Empty when the key is missing.
+    pub fn latex_verbatim_envs(&self) -> Vec<String> {
+        self.latex
+            .as_ref()
+            .map(|ov| ov.verbatim_envs.clone())
+            .unwrap_or_default()
+    }
+
+    /// Extra `[latex].structure_envs` names. Empty when the key is missing.
+    pub fn latex_structure_envs(&self) -> Vec<String> {
+        self.latex
+            .as_ref()
+            .map(|ov| ov.structure_envs.clone())
+            .unwrap_or_default()
+    }
+
+    /// Extra `[latex].verbatim_commands` names. Empty when the key is missing.
+    pub fn latex_verbatim_commands(&self) -> Vec<String> {
+        self.latex
+            .as_ref()
+            .map(|ov| ov.verbatim_commands.clone())
+            .unwrap_or_default()
     }
 
     #[cfg(any(feature = "cli", feature = "watch"))]
@@ -329,5 +364,38 @@ max_width = 72
         let config = ProjectConfig::parse(toml).unwrap();
         assert_eq!(config.max_width_for_format("rst"), Some(72));
         assert_eq!(config.abbreviations_for_format("rst"), vec!["Fig"]);
+    }
+
+    #[test]
+    fn parse_latex_env_and_command_lists() {
+        let toml = r#"
+[latex]
+extra_abbreviations = ["Thm"]
+verbatim_envs = ["Verbatim"]
+structure_envs = ["algorithm", "comment"]
+verbatim_commands = ["Verb"]
+"#;
+        let config = ProjectConfig::parse(toml).unwrap();
+        assert_eq!(config.latex_verbatim_envs(), vec!["Verbatim"]);
+        assert_eq!(config.latex_structure_envs(), vec!["algorithm", "comment"]);
+        assert_eq!(config.latex_verbatim_commands(), vec!["Verb"]);
+        assert_eq!(config.abbreviations_for_format("latex"), vec!["Thm"]);
+    }
+
+    #[test]
+    fn missing_latex_env_keys_are_empty_extras() {
+        let config = ProjectConfig::parse("[latex]\nextra_abbreviations = [\"Thm\"]\n").unwrap();
+        assert!(config.latex_verbatim_envs().is_empty());
+        assert!(config.latex_structure_envs().is_empty());
+        assert!(config.latex_verbatim_commands().is_empty());
+    }
+
+    #[test]
+    fn latex_other_regex_key_is_ignored() {
+        // latexindent's `other:` regex matching is not supported.
+        let config = ProjectConfig::parse("[latex]\nother = \".*code\"\n").unwrap();
+        assert!(config.latex_verbatim_envs().is_empty());
+        assert!(config.latex_structure_envs().is_empty());
+        assert!(config.latex_verbatim_commands().is_empty());
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -67,6 +67,12 @@ max_width = 0
 # that is already followed by whitespace.
 # clause_breaks = false
 
+# Extra LaTeX environments / commands (added to the built-in lists).
+# [latex]
+# verbatim_envs = ["Verbatim"]
+# structure_envs = ["algorithm", "comment"]
+# verbatim_commands = ["Verb"]
+
 # Advisory long-line threshold when max_width is 0 (default 120)
 # long_threshold = 120
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,6 +111,15 @@ pub struct FormatConfig {
     /// original document. Production default `true`; tests set `false`
     /// and assert the oracle themselves.
     pub render_backstop: bool,
+    /// Extra LaTeX environments treated as code (no reflow), added to
+    /// minted/lstlisting/verbatim. Empty keeps the built-in list.
+    pub latex_verbatim_envs: Vec<String>,
+    /// Extra LaTeX environments treated as structure (no reflow), added
+    /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.
+    pub latex_structure_envs: Vec<String>,
+    /// Extra LaTeX command names tokenized like `\verb` before split.
+    /// Empty keeps verb/lstinline.
+    pub latex_verbatim_commands: Vec<String>,
 }
 
 impl Default for FormatConfig {
@@ -131,6 +140,9 @@ impl Default for FormatConfig {
             clause_breaks: false,
             fixpoint_backstop: true,
             render_backstop: true,
+            latex_verbatim_envs: vec![],
+            latex_structure_envs: vec![],
+            latex_verbatim_commands: vec![],
         }
     }
 }
@@ -206,7 +218,11 @@ pub fn build_splitter(config: &FormatConfig) -> Result<Box<dyn SentenceSplitter>
                     &config.extra_abbreviations,
                 )
             };
-            Ok(Box::new(neural.map_err(|e| anyhow::anyhow!("{e}"))?))
+            Ok(Box::new(
+                neural
+                    .map_err(|e| anyhow::anyhow!("{e}"))?
+                    .with_verbatim_commands(config.latex_verbatim_commands.clone()),
+            ))
         }
         #[cfg(not(feature = "neural"))]
         {
@@ -215,10 +231,10 @@ pub fn build_splitter(config: &FormatConfig) -> Result<Box<dyn SentenceSplitter>
             ))
         }
     } else {
-        Ok(Box::new(UnicodeSentenceSplitter::for_lang(
-            &config.neural_lang,
-            &config.extra_abbreviations,
-        )))
+        Ok(Box::new(
+            UnicodeSentenceSplitter::for_lang(&config.neural_lang, &config.extra_abbreviations)
+                .with_verbatim_commands(config.latex_verbatim_commands.clone()),
+        ))
     }
 }
 
@@ -345,7 +361,7 @@ fn format_once(
     }
 
     let spanned: Vec<SpannedRegion> =
-        parser::parser_for_format(config.format).parse_full(work_input);
+        parser::parser_for_format_config(config.format, Some(config)).parse_full(work_input);
     match reflow_spanned(work_input, &spanned, splitter, &reflow_config) {
         Ok(out) => Ok(out),
         Err(_) => Ok(work_input.to_string()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -282,8 +282,13 @@ pub fn format_text_with_splitter(
 
     let candidate = if config.render_backstop
         && candidate != work_input
-        && !oracle::matches_ex(config.format, work_input, &candidate, config.format_code)
-    {
+        && !oracle::matches_ex(
+            config.format,
+            work_input,
+            &candidate,
+            config.format_code,
+            Some(config),
+        ) {
         work_input.to_string()
     } else {
         candidate

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -97,7 +97,7 @@ impl SnapperLsp {
             resolve_long_threshold(config.max_width, project.long_threshold)
         };
 
-        collect_diagnostics(text, *format, splitter.as_ref(), threshold)
+        collect_diagnostics(text, *format, splitter.as_ref(), threshold, Some(&config))
             .into_iter()
             .map(|d| {
                 let line = d.line.saturating_sub(1) as u32;

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -51,6 +51,9 @@ impl SnapperLsp {
             format,
             max_width: project.max_width_for_format(format_str).unwrap_or(0),
             extra_abbreviations: project.abbreviations_for_format(format_str),
+            latex_verbatim_envs: project.latex_verbatim_envs(),
+            latex_structure_envs: project.latex_structure_envs(),
+            latex_verbatim_commands: project.latex_verbatim_commands(),
             clause_breaks: project.clause_breaks.unwrap_or(false),
             ..Default::default()
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,8 @@ fn run() -> Result<()> {
         if cli.check {
             let splitter = build_splitter(&config).context("failed to build sentence splitter")?;
             let threshold = resolve_long_threshold(config.max_width, project_config.long_threshold);
-            let diagnostics = collect_diagnostics(&input, format, splitter.as_ref(), threshold);
+            let diagnostics =
+                collect_diagnostics(&input, format, splitter.as_ref(), threshold, Some(&config));
             let would = output != input;
             let long_fail =
                 cli.strict_long && diagnostics.iter().any(|d| d.kind == DiagnosticKind::Long);
@@ -254,7 +255,8 @@ fn run() -> Result<()> {
                     .ok_or_else(|| anyhow::anyhow!("splitter cache miss for {path_str}"))?;
                 let threshold =
                     resolve_long_threshold(config.max_width, project_config.long_threshold);
-                let diagnostics = collect_diagnostics(input, format, splitter.as_ref(), threshold);
+                let diagnostics =
+                    collect_diagnostics(input, format, splitter.as_ref(), threshold, Some(&config));
                 let would = output != input;
                 let long_fail =
                     cli.strict_long && diagnostics.iter().any(|d| d.kind == DiagnosticKind::Long);

--- a/src/main.rs
+++ b/src/main.rs
@@ -399,6 +399,9 @@ fn build_format_config(
         neural_lang,
         neural_model_path: cli.model_path.clone(),
         extra_abbreviations: project_config.abbreviations_for_format(format_key),
+        latex_verbatim_envs: project_config.latex_verbatim_envs(),
+        latex_structure_envs: project_config.latex_structure_envs(),
+        latex_verbatim_commands: project_config.latex_verbatim_commands(),
         use_pandoc: cli.use_pandoc,
         #[cfg(feature = "pandoc")]
         pandoc_backend: cli

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -170,7 +170,13 @@ impl SnapperMcpServer {
         let splitter = crate::build_splitter(&config).unwrap();
         let would = would_reformat(&params.text, &config).unwrap_or(true);
         let threshold = resolve_long_threshold(params.max_width, None);
-        let diagnostics = collect_diagnostics(&params.text, format, splitter.as_ref(), threshold);
+        let diagnostics = collect_diagnostics(
+            &params.text,
+            format,
+            splitter.as_ref(),
+            threshold,
+            Some(&config),
+        );
         let violations: Vec<usize> = diagnostics
             .iter()
             .filter(|d| d.kind == DiagnosticKind::Fused)

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -12,25 +12,29 @@
 //! reflow already allowed by the code-byte check).
 
 use crate::format::Format;
-use crate::parser::{Region, parser_for_format};
+use crate::parser::{Region, parser_for_format, parser_for_format_config};
 
 /// True when `output` is a render-safe reflow of `original`.
 pub fn matches(format: Format, original: &str, output: &str) -> bool {
-    matches_ex(format, original, output, false)
+    matches_ex(format, original, output, false, None)
 }
 
 /// `allow_code_body_rewrite` is set when an opt-in external formatter may
 /// replace a code body. Comment-only reflow does not need it.
+///
+/// `config` supplies `[latex]` extras so the oracle parses with the same
+/// region kinds as `format_once`. `None` keeps the built-in lists.
 pub fn matches_ex(
     format: Format,
     original: &str,
     output: &str,
     allow_code_body_rewrite: bool,
+    config: Option<&crate::FormatConfig>,
 ) -> bool {
     if original == output {
         return true;
     }
-    if !structure_tree_ok(format, original, output, allow_code_body_rewrite) {
+    if !structure_tree_ok(format, original, output, allow_code_body_rewrite, config) {
         return false;
     }
     if format == Format::Markdown {
@@ -44,12 +48,13 @@ fn structure_tree_ok(
     original: &str,
     output: &str,
     allow_code_body_rewrite: bool,
+    config: Option<&crate::FormatConfig>,
 ) -> bool {
     // Hang list/quote continuations (`> One.` / `> Two.`) reparse as more
     // regions than the source. Coalesce adjacent same-marker items so the
     // tree compares as one item with the same prose words.
-    let a = coalesce_hang_items(&parser_for_format(format).parse(original));
-    let b = coalesce_hang_items(&parser_for_format(format).parse(output));
+    let a = coalesce_hang_items(&parser_for_format_config(format, config).parse(original));
+    let b = coalesce_hang_items(&parser_for_format_config(format, config).parse(output));
     if a.len() != b.len() {
         return false;
     }
@@ -336,6 +341,25 @@ mod tests {
             "- One.\n  Two.\n"
         ));
         assert!(matches(Format::Org, "- One. Two.\n", "- One.\n  Two.\n"));
+    }
+
+    #[test]
+    fn configured_verb_percent_tree_matches_across_split() {
+        let original = "\\begin{document}\nCode \\Verb!%! here. Next sentence.\n\\end{document}\n";
+        let output = "\\begin{document}\nCode \\Verb!%! here.\nNext sentence.\n\\end{document}\n";
+        let cfg = crate::FormatConfig {
+            format: Format::Latex,
+            latex_verbatim_commands: vec!["Verb".into()],
+            ..Default::default()
+        };
+        assert!(
+            !matches(Format::Latex, original, output),
+            "built-in lists treat inner % as a comment, so the trees diverge"
+        );
+        assert!(
+            matches_ex(Format::Latex, original, output, false, Some(&cfg)),
+            "extras must parse the same region tree as format_once"
+        );
     }
 
     #[test]

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -1440,20 +1440,46 @@ Some text.
             format: crate::format::Format::Latex,
             latex_verbatim_commands: vec!["Verb".into()],
             ..Default::default()
-        }
-        .without_safety_backstops();
+        };
+        assert!(
+            cfg.render_backstop && cfg.fixpoint_backstop,
+            "this case is the production backstop path"
+        );
         let out = format_text(input, &cfg).unwrap();
         assert!(
             out.contains(r"\Verb!%!"),
             "configured Verb with inner % must stay intact, got:\n{out}"
         );
         assert!(
-            out.contains("here."),
-            "text after configured Verb must not be commented out, got:\n{out}"
+            out.contains("Code \\Verb!%! here.\nNext sentence."),
+            "production backstops must not revert the whole file, got:\n{out}"
         );
         assert!(
-            out.contains("Next sentence."),
-            "following sentence must remain, got:\n{out}"
+            !out.contains("Code \\Verb!%! here. Next sentence."),
+            "inner % is not a comment; the fused line must split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn configured_verb_does_not_steal_verbatim() {
+        use crate::format_text;
+
+        let input =
+            "\\begin{document}\nUse \\Verbatim|x.y| here. Next sentence.\n\\end{document}\n";
+        let cfg = crate::FormatConfig {
+            format: crate::format::Format::Latex,
+            latex_verbatim_commands: vec!["Verb".into()],
+            ..Default::default()
+        };
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains("Use \\Verbatim|x.y| here.\nNext sentence."),
+            "\\Verb must not consume \\Verbatim, so the next sentence must split, got:\n{out}"
+        );
+        assert!(
+            out.contains(r"\Verbatim|x.y|"),
+            "\\Verbatim must remain in the source, got:\n{out}"
         );
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::parser::{ByteSpan, FormatParser, Line, SpannedRegion, flush_prose_spanned, iter_lines};
-use crate::sentence::unicode::latex_verb_span_end;
+use crate::sentence::unicode::latex_verb_span_end_with;
 
 // Environments whose content is NOT prose (math, code, figures, tables)
 static NON_PROSE_ENVS: &[&str] = &[
@@ -41,8 +41,8 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\\begin\{lstlisting\}\s*\[[^\]]*language\s*=\s*([A-Za-z0-9_+.\-]+)").unwrap()
 });
 
-/// Source-code environments whose body should be emitted as `Region::Code`.
-fn is_code_env(name: &str) -> bool {
+/// Built-in source-code environments whose body is `Region::Code`.
+fn is_builtin_code_env(name: &str) -> bool {
     matches!(name, "minted" | "lstlisting" | "verbatim")
 }
 
@@ -59,40 +59,66 @@ static SECTION_CMD_RE: LazyLock<Regex> = LazyLock::new(|| {
     .unwrap()
 });
 
-pub struct LatexParser;
+#[derive(Debug, Default, Clone)]
+pub struct LatexParser {
+    extra_verbatim_envs: Vec<String>,
+    extra_structure_envs: Vec<String>,
+    extra_verbatim_commands: Vec<String>,
+}
 
 impl LatexParser {
+    pub(crate) fn from_config(config: Option<&crate::FormatConfig>) -> Self {
+        match config {
+            Some(c) => Self {
+                extra_verbatim_envs: c.latex_verbatim_envs.clone(),
+                extra_structure_envs: c.latex_structure_envs.clone(),
+                extra_verbatim_commands: c.latex_verbatim_commands.clone(),
+            },
+            None => Self::default(),
+        }
+    }
+
     fn is_comment(line: &str) -> bool {
         line.trim_start().starts_with('%')
     }
 
     /// Byte offset of the first `%` that is not escaped as `\%` and is not
-    /// inside `\verb` / `\lstinline`.
-    fn unescaped_percent(line: &str) -> Option<usize> {
-        let bytes = line.as_bytes();
-        let mut i = 0;
-        while i < bytes.len() {
-            if bytes[i] == b'\\' {
-                if let Some(end) = latex_verb_span_end(line, i) {
-                    i = end;
-                    continue;
-                }
-                if i + 1 < bytes.len() {
-                    i += 2;
-                    continue;
-                }
-            }
-            if bytes[i] == b'%' {
-                return Some(i);
-            }
-            i += 1;
-        }
-        None
+    /// inside `\verb` / `\lstinline` / configured verbatim commands.
+    fn unescaped_percent(&self, line: &str) -> Option<usize> {
+        unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
 
-    fn is_non_prose_env(name: &str) -> bool {
-        NON_PROSE_ENVS.contains(&name)
+    fn is_code_env(&self, name: &str) -> bool {
+        is_builtin_code_env(name) || self.extra_verbatim_envs.iter().any(|e| e == name)
     }
+
+    fn is_non_prose_env(&self, name: &str) -> bool {
+        NON_PROSE_ENVS.contains(&name)
+            || self.extra_structure_envs.iter().any(|e| e == name)
+            || self.is_code_env(name)
+    }
+}
+
+fn unescaped_percent_with(line: &str, extra_cmds: &[String]) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            if let Some(end) = latex_verb_span_end_with(line, i, extra_cmds) {
+                i = end;
+                continue;
+            }
+            if i + 1 < bytes.len() {
+                i += 2;
+                continue;
+            }
+        }
+        if bytes[i] == b'%' {
+            return Some(i);
+        }
+        i += 1;
+    }
+    None
 }
 
 /// `\begin{name}` or `\end{name}` on a line.
@@ -126,13 +152,13 @@ fn thru_eol_if_blank_rest(line: Line<'_>, rel: usize) -> usize {
     }
 }
 
-fn find_env_at(line: &str, from: usize) -> Option<EnvHit> {
+fn find_env_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<EnvHit> {
     let bytes = line.as_bytes();
     let mut i = from;
-    let stop = LatexParser::unescaped_percent(line).unwrap_or(line.len());
+    let stop = unescaped_percent_with(line, extra_cmds).unwrap_or(line.len());
     while i < stop {
         if bytes[i] == b'\\' {
-            if let Some(end) = latex_verb_span_end(line, i) {
+            if let Some(end) = latex_verb_span_end_with(line, i, extra_cmds) {
                 i = end;
                 continue;
             }
@@ -200,9 +226,15 @@ fn skip_optional_brackets(line: &str, open_at: usize, stop: usize) -> Option<usi
     None
 }
 
-fn find_matching_end(line: &str, from: usize, name: &str, mut depth: usize) -> Option<usize> {
+fn find_matching_end(
+    line: &str,
+    from: usize,
+    name: &str,
+    mut depth: usize,
+    extra_cmds: &[String],
+) -> Option<usize> {
     let mut i = from;
-    while let Some(hit) = find_env_at(line, i) {
+    while let Some(hit) = find_env_at(line, i, extra_cmds) {
         if hit.name != name {
             i = hit.end;
             continue;
@@ -278,6 +310,7 @@ fn find_matching_raw_end(line: &str, from: usize, name: &str, mut depth: usize) 
 
 struct ParseState<'a> {
     input: &'a str,
+    parser: &'a LatexParser,
     regions: Vec<SpannedRegion>,
     current_prose: String,
     prose_span: Option<ByteSpan>,
@@ -389,7 +422,7 @@ impl<'a> ParseState<'a> {
             return;
         }
 
-        let pct = LatexParser::unescaped_percent(line.text);
+        let pct = self.parser.unescaped_percent(line.text);
         let code = match pct {
             Some(idx) => &line.text[..idx],
             None => line.text,
@@ -427,7 +460,7 @@ impl<'a> ParseState<'a> {
             .expect("consume_non_prose_line only when inside")
             .to_string();
         let mut i = 0;
-        while let Some(hit) = find_env_at(line.text, i) {
+        while let Some(hit) = find_env_at(line.text, i, &self.parser.extra_verbatim_commands) {
             if hit.name != name {
                 i = hit.end;
                 continue;
@@ -498,9 +531,9 @@ impl<'a> ParseState<'a> {
     fn consume_code_span(&mut self, code: &str, line: Line<'_>) -> bool {
         let mut i = 0;
         while i < code.len() {
-            if let Some(hit) = find_env_at(code, i) {
+            if let Some(hit) = find_env_at(code, i, &self.parser.extra_verbatim_commands) {
                 self.append_prose_slice(line.start + i, &code[i..hit.start]);
-                if hit.is_begin && is_code_env(&hit.name) {
+                if hit.is_begin && self.parser.is_code_env(&hit.name) {
                     self.flush();
                     if let Some(end_at) = find_matching_raw_end(line.text, hit.end, &hit.name, 1) {
                         let header = ByteSpan::new(line.start + hit.start, line.start + end_at);
@@ -515,9 +548,15 @@ impl<'a> ParseState<'a> {
                     self.enter_code(&hit.name, line, hit.start);
                     return true;
                 }
-                if hit.is_begin && LatexParser::is_non_prose_env(&hit.name) {
+                if hit.is_begin && self.parser.is_non_prose_env(&hit.name) {
                     self.flush();
-                    if let Some(end_at) = find_matching_end(code, hit.end, &hit.name, 1) {
+                    if let Some(end_at) = find_matching_end(
+                        code,
+                        hit.end,
+                        &hit.name,
+                        1,
+                        &self.parser.extra_verbatim_commands,
+                    ) {
                         let end = if code[end_at..].trim().is_empty() {
                             thru_eol_if_blank_rest(line, end_at)
                         } else {
@@ -571,6 +610,7 @@ impl FormatParser for LatexParser {
     fn parse_full(&self, input: &str) -> Vec<SpannedRegion> {
         let mut state = ParseState {
             input,
+            parser: self,
             regions: Vec::new(),
             current_prose: String::new(),
             prose_span: None,
@@ -652,7 +692,7 @@ mod tests {
     #[test]
     fn section_command_title_is_structure_not_prose() {
         let input = "\\begin{document}\n\\section{A long title. With two sentences.}\nBody.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         assert!(
             regions.iter().any(|r| matches!(
                 r,
@@ -706,7 +746,7 @@ mod tests {
 \begin{document}
 Hello world.
 \end{document}";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         // First 3 lines are preamble structure (including \begin{document})
         assert!(matches!(&regions[0], Region::Structure(_)));
         assert!(matches!(&regions[1], Region::Structure(_)));
@@ -725,7 +765,7 @@ E = mc^2
 \end{equation}
 More text.
 \end{document}";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         let structure_count = regions
             .iter()
             .filter(|r| matches!(r, Region::Structure(_)))
@@ -740,7 +780,7 @@ More text.
 % This is a comment
 Some text.
 \end{document}";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         let comment_region = regions.iter().find(|r| {
             if let Region::Structure(s) = r {
                 s.contains("% This is a comment")
@@ -810,7 +850,7 @@ Some text.
             out.contains("% TODO cite"),
             "trailing comment must be kept: {out}"
         );
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         assert!(
             regions
                 .iter()
@@ -873,7 +913,7 @@ Some text.
             out.contains("Next sentence."),
             "following sentence must remain, got:\n{out}"
         );
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         assert!(
             !regions.iter().any(
                 |r| matches!(r, Region::Structure(s) if s.contains("%!") || s.trim() == "%!\n")
@@ -905,7 +945,7 @@ Some text.
         use crate::format_text;
 
         let input = "\\begin{document}\nBefore the claim. More before.\n\\begin{theorem}\nA statement. Another claim.\n\\end{theorem}\nAfter the claim. More after.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         assert!(
             regions
                 .iter()
@@ -960,7 +1000,7 @@ Some text.
     #[test]
     fn mid_line_begin_equation_leaves_leading_words_as_prose() {
         let input = "\\begin{document}\ninducing \\begin{equation}\nE = mc^2\n\\end{equation}\nAfter.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         assert!(
             regions
                 .iter()
@@ -987,7 +1027,7 @@ Some text.
     #[test]
     fn nested_same_name_envs_close_on_matching_depth() {
         let input = "\\begin{document}\n\\begin{equation}\n\\begin{equation}\nx = 1\n\\end{equation}\ny = 2\n\\end{equation}\nAfter the nest. Next.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         assert!(
             !regions
                 .iter()
@@ -1014,7 +1054,7 @@ Some text.
         use crate::format_text;
 
         let input = "\\begin{document}\nSee \\verb|a%b. Next sentence.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         assert!(
             !regions.iter().any(|r| {
                 matches!(r, Region::Structure(s) if s.contains("%b") || s.contains("%b."))
@@ -1044,7 +1084,7 @@ Some text.
         use crate::format_text;
 
         let input = "\\begin{document}\nBefore.\n\\begin{lstlisting}\nprint(1)\n\\end{python} \\end{lstlisting}\nAfter the listing. Next.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         let code = regions.iter().find_map(|r| match r {
             Region::Code { body, footer, .. } => Some((body.as_str(), footer.as_str())),
             _ => None,
@@ -1083,7 +1123,7 @@ Some text.
     #[test]
     fn nested_same_name_verbatim_closes_on_matching_depth() {
         let input = "\\begin{document}\n\\begin{verbatim}\n\\begin{verbatim}\ninner\n\\end{verbatim}\nstill body\n\\end{verbatim}\nAfter the nest.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         let code = regions.iter().find_map(|r| match r {
             Region::Code { body, footer, .. } => Some((body.as_str(), footer.as_str())),
             _ => None,
@@ -1120,7 +1160,7 @@ Some text.
         use crate::format_text;
 
         let input = "\\begin{document}\n\\begin{lstlisting}\nprint(1) % \\end{lstlisting}\nAfter the listing. Next.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         let code = regions.iter().find_map(|r| match r {
             Region::Code { body, footer, .. } => Some((body.as_str(), footer.as_str())),
             _ => None,
@@ -1161,7 +1201,7 @@ Some text.
         use crate::format_text;
 
         let input = "\\begin{document}\n\\begin{lstlisting} print(\"%\") \\end{lstlisting}\nAfter.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         assert!(
             regions.iter().any(|r| matches!(r, Region::Code { .. })),
             "same-line lstlisting must be Code, got: {regions:?}"
@@ -1193,7 +1233,7 @@ Some text.
     #[test]
     fn theorem_optional_args_stay_on_the_begin_token() {
         let input = "\\begin{document}\nBefore.\n\\begin{theorem}[A. B. C.]\nA statement. Another.\n\\end{theorem}\nAfter.\n\\end{document}\n";
-        let regions = LatexParser.parse(input);
+        let regions = LatexParser::default().parse(input);
         assert!(
             regions.iter().any(|r| {
                 matches!(r, Region::Structure(s) if s.contains(r"\begin{theorem}[A. B. C.]"))
@@ -1212,5 +1252,209 @@ Some text.
                 .any(|r| matches!(r, Region::Prose(p) if p.contains("A statement"))),
             "theorem body must stay prose, got: {regions:?}"
         );
+    }
+
+    #[test]
+    fn missing_env_keys_keep_builtin_algorithm_as_prose() {
+        use crate::format_text;
+
+        // algorithm is not in NON_PROSE_ENVS; missing config keeps that list.
+        let input = "\\begin{document}\nBefore the algo. More before.\n\\begin{algorithm}\nFirst step. Second step.\n\\end{algorithm}\nAfter the algo. More after.\n\\end{document}\n";
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("First step.\nSecond step."),
+            "unlisted algorithm body must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn configured_structure_envs_stop_algorithm_and_comment_reflow() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nBefore.\n\\begin{algorithm}\nFirst step. Second step.\n\\end{algorithm}\n\\begin{comment}\nHidden one. Hidden two.\n\\end{comment}\nAfter the block. Next.\n\\end{document}\n";
+        let cfg = crate::FormatConfig {
+            format: crate::format::Format::Latex,
+            latex_structure_envs: vec!["algorithm".into(), "comment".into()],
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains("First step. Second step."),
+            "algorithm body must not reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First step.\nSecond step."),
+            "algorithm must stay one source line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Hidden one. Hidden two."),
+            "comment body must not reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("Hidden one.\nHidden two."),
+            "comment env must stay one source line, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after configured envs must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn configured_verbatim_env_stops_fancyvrb_reflow() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nBefore.\n\\begin{Verbatim}\nFirst line. Second line.\n\\end{Verbatim}\nAfter the listing. Next.\n\\end{document}\n";
+        let default_out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            default_out.contains("First line.\nSecond line."),
+            "unlisted Verbatim body is prose and reflows, got:\n{default_out}"
+        );
+
+        let cfg = crate::FormatConfig {
+            format: crate::format::Format::Latex,
+            latex_verbatim_envs: vec!["Verbatim".into()],
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains("First line. Second line."),
+            "configured Verbatim body must not reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "Verbatim must stay verbatim, got:\n{out}"
+        );
+        let regions = LatexParser::from_config(Some(&cfg)).parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "configured Verbatim must be Code, got: {regions:?}"
+        );
+        assert!(
+            out.contains("After the listing.\nNext."),
+            "prose after Verbatim must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn configured_verbatim_command_is_tokenized_like_verb() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nUse \\Verb|a.b! c| here. Next sentence.\n\\end{document}\n";
+        let default_out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            !default_out.contains("Use \\Verb|a.b! c| here.\nNext sentence."),
+            "unlisted Verb must not stay atomic like verb, got:\n{default_out}"
+        );
+
+        let cfg = crate::FormatConfig {
+            format: crate::format::Format::Latex,
+            latex_verbatim_commands: vec!["Verb".into()],
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains(r"\Verb|a.b! c|"),
+            "configured Verb must stay intact, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\Verb|a.\n") && !out.contains("\\Verb|a.b!\n"),
+            "inner .!? must not split configured Verb, got:\n{out}"
+        );
+        assert!(
+            out.contains("Use \\Verb|a.b! c| here.\nNext sentence."),
+            "configured Verb must tokenize like verb before split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn configured_lists_keep_builtin_minted_and_equation() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nIntro. More intro.\n\\begin{equation}\nE = mc^2\n\\end{equation}\n\\begin{minted}{python}\nprint(1)\nprint(2)\n\\end{minted}\nAfter. Next.\n\\end{document}\n";
+        let cfg = crate::FormatConfig {
+            format: crate::format::Format::Latex,
+            latex_verbatim_envs: vec!["Verbatim".into()],
+            latex_structure_envs: vec!["algorithm".into()],
+            latex_verbatim_commands: vec!["Verb".into()],
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains("\\begin{equation}\nE = mc^2\n\\end{equation}"),
+            "built-in equation must stay structure, got:\n{out}"
+        );
+        assert!(
+            out.contains("\\begin{minted}{python}\nprint(1)\nprint(2)\n\\end{minted}"),
+            "built-in minted must stay a code env, got:\n{out}"
+        );
+        assert!(
+            out.contains("Intro.\nMore intro."),
+            "surrounding prose must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn configured_lists_keep_eq_ref_nbsp() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nSee Eq.~\\ref{eq:diff}. Next.\n\\end{document}\n";
+        let cfg = crate::FormatConfig {
+            format: crate::format::Format::Latex,
+            latex_verbatim_envs: vec!["Verbatim".into()],
+            latex_structure_envs: vec!["algorithm".into()],
+            latex_verbatim_commands: vec!["Verb".into()],
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains("Eq.~\\ref{eq:diff}."),
+            "must not invent a space before ~, got:\n{out}"
+        );
+        assert!(
+            !out.contains("Eq. ~"),
+            "abbreviation merge must not insert a space before ~, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn configured_verb_inner_percent_is_not_a_comment() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nCode \\Verb!%! here. Next sentence.\n\\end{document}\n";
+        let cfg = crate::FormatConfig {
+            format: crate::format::Format::Latex,
+            latex_verbatim_commands: vec!["Verb".into()],
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains(r"\Verb!%!"),
+            "configured Verb with inner % must stay intact, got:\n{out}"
+        );
+        assert!(
+            out.contains("here."),
+            "text after configured Verb must not be commented out, got:\n{out}"
+        );
+        assert!(
+            out.contains("Next sentence."),
+            "following sentence must remain, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -86,12 +86,20 @@ fn line_prose_payload(input: &str, line: Line<'_>, spanned: &[SpannedRegion]) ->
     }
 }
 
-/// Create the appropriate parser for a given format.
+/// Create the appropriate parser for a given format (built-in lists only).
 pub fn parser_for_format(format: crate::format::Format) -> Box<dyn FormatParser> {
+    parser_for_format_config(format, None)
+}
+
+/// Create a parser, applying `[latex]` extras from `config` when present.
+pub fn parser_for_format_config(
+    format: crate::format::Format,
+    config: Option<&crate::FormatConfig>,
+) -> Box<dyn FormatParser> {
     use crate::format::Format;
     match format {
         Format::Org => Box::new(org::OrgParser),
-        Format::Latex => Box::new(latex::LatexParser),
+        Format::Latex => Box::new(latex::LatexParser::from_config(config)),
         Format::Markdown => Box::new(markdown::MarkdownParser),
         Format::Rst => Box::new(rst::RstParser),
         Format::Plaintext => Box::new(plaintext::PlaintextParser),

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -53,8 +53,13 @@ pub trait FormatParser {
 /// `None` means the line has no prose rewrite range (structure, code, blank,
 /// pragma-off). `Some` is the original-source slice the parser sent to the
 /// splitter for that line (list/quote body, mid-line comment prefix).
-pub fn source_line_payloads(input: &str, format: crate::format::Format) -> Vec<Option<String>> {
-    let spanned = parser_for_format(format).parse_full(input);
+/// `config` supplies `[latex]` extras; `None` keeps the built-in lists.
+pub fn source_line_payloads(
+    input: &str,
+    format: crate::format::Format,
+    config: Option<&crate::FormatConfig>,
+) -> Vec<Option<String>> {
+    let spanned = parser_for_format_config(format, config).parse_full(input);
     iter_lines(input)
         .into_iter()
         .map(|line| line_prose_payload(input, line, &spanned))

--- a/src/sentence/neural.rs
+++ b/src/sentence/neural.rs
@@ -3,7 +3,7 @@ use std::sync::Mutex;
 use nnsplit::NNSplit;
 
 use super::SentenceSplitter;
-use super::unicode::{UnicodeSentenceSplitter, protect_inline_tokens, restore_inline_tokens};
+use super::unicode::{UnicodeSentenceSplitter, protect_inline_tokens_with, restore_inline_tokens};
 
 /// nnsplit downloads models to `~/.cache/nnsplit/` on first use; concurrent
 /// loads race the download and can observe a partially written model
@@ -43,6 +43,12 @@ impl NeuralSentenceSplitter {
         })
     }
 
+    /// Extra LaTeX command names tokenized like `\verb` before split.
+    pub fn with_verbatim_commands(mut self, cmds: Vec<String>) -> Self {
+        self.post = self.post.with_verbatim_commands(cmds);
+        self
+    }
+
     /// Load from a custom ONNX model file path.
     pub fn from_path(path: &std::path::Path) -> Result<Self, Box<dyn std::error::Error>> {
         Self::from_path_with_extras(path, "en", &[])
@@ -73,7 +79,8 @@ impl SentenceSplitter for NeuralSentenceSplitter {
             return vec![];
         }
 
-        let (protected, placeholders) = protect_inline_tokens(text);
+        let (protected, placeholders) =
+            protect_inline_tokens_with(text, self.post.verbatim_commands());
 
         let splits = self.inner.split(&[protected.as_str()]);
         let raw: Vec<String> = if splits.is_empty() {

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -56,6 +56,8 @@ pub struct UnicodeSentenceSplitter {
     lang_abbrev_pattern: Regex,
     /// Compiled multi-abbreviation pattern for the selected language.
     lang_multi_pattern: Regex,
+    /// Extra LaTeX command names tokenized like `\verb` before split.
+    extra_verbatim_commands: Vec<String>,
 }
 
 impl UnicodeSentenceSplitter {
@@ -95,7 +97,18 @@ impl UnicodeSentenceSplitter {
             extra_pattern,
             lang_abbrev_pattern,
             lang_multi_pattern,
+            extra_verbatim_commands: Vec::new(),
         }
+    }
+
+    /// Extra LaTeX command names tokenized like `\verb` before split.
+    pub fn with_verbatim_commands(mut self, cmds: Vec<String>) -> Self {
+        self.extra_verbatim_commands = cmds;
+        self
+    }
+
+    pub(crate) fn verbatim_commands(&self) -> &[String] {
+        &self.extra_verbatim_commands
     }
 }
 
@@ -108,8 +121,17 @@ impl Default for UnicodeSentenceSplitter {
 /// Protect links, emphasis, math, and other inline tokens so a base segmenter
 /// (UAX or neural) cannot cut inside them. Shared by rules and neural paths.
 pub fn protect_inline_tokens(text: &str) -> (String, Vec<String>) {
+    protect_inline_tokens_with(text, &[])
+}
+
+/// Like [`protect_inline_tokens`], with extra LaTeX command names treated
+/// like `\verb` (delimiter is the next character).
+pub fn protect_inline_tokens_with(
+    text: &str,
+    extra_verbatim_commands: &[String],
+) -> (String, Vec<String>) {
     let mut placeholders: Vec<String> = Vec::new();
-    let after_verb = protect_latex_verbatim(text, &mut placeholders);
+    let after_verb = protect_latex_verbatim(text, &mut placeholders, extra_verbatim_commands);
     let after_spans = protect_paired_spans(&after_verb, &mut placeholders);
     let protected = INLINE_TOKEN_RE.replace_all(&after_spans, |caps: &regex::Captures| {
         let idx = placeholders.len();
@@ -120,13 +142,17 @@ pub fn protect_inline_tokens(text: &str) -> (String, Vec<String>) {
 }
 
 /// `\verb|...|` / `\lstinline[...]!...!` so inner `.!?%` cannot split or comment.
-fn protect_latex_verbatim(text: &str, placeholders: &mut Vec<String>) -> String {
+fn protect_latex_verbatim(
+    text: &str,
+    placeholders: &mut Vec<String>,
+    extra_verbatim_commands: &[String],
+) -> String {
     let mut out = String::with_capacity(text.len());
     let bytes = text.as_bytes();
     let mut i = 0;
     while i < text.len() {
         if bytes[i] == b'\\' {
-            if let Some(end) = latex_verb_span_end(text, i) {
+            if let Some(end) = latex_verb_span_end_with(text, i, extra_verbatim_commands) {
                 push_placeholder(&mut out, placeholders, &text[i..end]);
                 i = end;
                 continue;
@@ -139,13 +165,18 @@ fn protect_latex_verbatim(text: &str, placeholders: &mut Vec<String>) -> String 
     out
 }
 
-/// Byte end of a `\verb` / `\lstinline` span starting at `at`, or `None`.
+/// Byte end of a `\verb` / `\lstinline` / extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*`: next character is the delimiter; content runs to the
 /// same character. `\lstinline` / `\lstinline*` may take optional `[...]`
-/// before a delimiter or a `{...}` brace body. With no closer, the span
-/// runs to end of line so an inner `%` is not a comment.
-pub(crate) fn latex_verb_span_end(text: &str, at: usize) -> Option<usize> {
+/// before a delimiter or a `{...}` brace body. Extra names are tokenized
+/// like `\verb`. With no closer, the span runs to end of line so an inner
+/// `%` is not a comment.
+pub(crate) fn latex_verb_span_end_with(
+    text: &str,
+    at: usize,
+    extra_verbatim_commands: &[String],
+) -> Option<usize> {
     let rest = text.get(at..)?;
     if !rest.starts_with('\\') {
         return None;
@@ -157,12 +188,14 @@ pub(crate) fn latex_verb_span_end(text: &str, at: usize) -> Option<usize> {
             return None;
         }
         (after_bs + "lstinline".len(), true)
-    } else {
-        let stripped = tail.strip_prefix("verb")?;
+    } else if let Some(stripped) = tail.strip_prefix("verb") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
         }
         (after_bs + "verb".len(), false)
+    } else {
+        let name = match_extra_verb_command(tail, extra_verbatim_commands)?;
+        (after_bs + name.len(), false)
     };
 
     if text.get(i..)?.starts_with('*') {
@@ -207,6 +240,27 @@ fn line_end(text: &str, from: usize) -> usize {
         .find('\n')
         .map(|rel| from + rel)
         .unwrap_or(text.len())
+}
+
+/// Longest extra command name that is a prefix of `tail` and is not
+/// followed by an ASCII letter (`\Verb` must not steal `\Verbatim`).
+fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&'a str> {
+    let mut best: Option<&str> = None;
+    for name in extras {
+        if name.is_empty() || name == "verb" || name == "lstinline" {
+            continue;
+        }
+        let Some(stripped) = tail.strip_prefix(name.as_str()) else {
+            continue;
+        };
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            continue;
+        }
+        if best.is_none_or(|b| name.len() > b.len()) {
+            best = Some(name.as_str());
+        }
+    }
+    best
 }
 
 fn skip_ascii_ws(text: &str, mut i: usize) -> usize {
@@ -601,7 +655,8 @@ impl SentenceSplitter for UnicodeSentenceSplitter {
             return vec![];
         }
 
-        let (protected, placeholders) = protect_inline_tokens(text);
+        let (protected, placeholders) =
+            protect_inline_tokens_with(text, &self.extra_verbatim_commands);
 
         // UAX #29 sentence bounds. `unicode_sentences()` filters
         // whitespace-only segments but also drops trailing closing
@@ -1081,6 +1136,24 @@ mod tests {
         assert_eq!(
             split(text),
             vec![r"Use \verb|a.b! c| here.".to_string(), "Next.".to_string()]
+        );
+    }
+
+    #[test]
+    fn extra_verbatim_command_is_tokenized_like_verb() {
+        let text = r"Use \Verb|a.b! c| here. Next.";
+        let extras = ["Verb".to_string()];
+        let (_, placeholders) = protect_inline_tokens_with(text, &extras);
+        assert!(
+            placeholders.iter().any(|p| p == r"\Verb|a.b! c|"),
+            "extra Verb span must be protected, got {placeholders:?}"
+        );
+        assert!(
+            !protect_inline_tokens(text)
+                .1
+                .iter()
+                .any(|p| p == r"\Verb|a.b! c|"),
+            "unlisted Verb must not be protected"
         );
     }
 

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -1158,6 +1158,32 @@ mod tests {
     }
 
     #[test]
+    fn extra_verb_does_not_steal_verbatim() {
+        let extras = ["Verb".to_string()];
+        assert_eq!(
+            latex_verb_span_end_with(r"\Verbatim|x.y|", 0, &extras),
+            None,
+            "Verb must not match as a prefix of Verbatim"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\Verb|x.y|", 0, &extras),
+            Some(r"\Verb|x.y|".len())
+        );
+        let text = r"Use \Verbatim|x.y| here. Next.";
+        let (_, placeholders) = protect_inline_tokens_with(text, &extras);
+        assert!(
+            placeholders.iter().all(|p| p != r"\Verbatim|x.y|"),
+            "Verbatim must not become a verb span, got {placeholders:?}"
+        );
+        assert_eq!(
+            UnicodeSentenceSplitter::new()
+                .with_verbatim_commands(extras.to_vec())
+                .split(text),
+            vec![r"Use \Verbatim|x.y| here.".to_string(), "Next.".to_string()]
+        );
+    }
+
+    #[test]
     fn latex_lstinline_inner_percent_stays_atomic() {
         let text = r"Code \lstinline!%! here. Next.";
         let (_, placeholders) = protect_inline_tokens(text);

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -128,6 +128,9 @@ fn format_file_in_place(
             .clone()
             .unwrap_or_else(|| "en".to_string()),
         extra_abbreviations: project_config.abbreviations_for_format(format_key),
+        latex_verbatim_envs: project_config.latex_verbatim_envs(),
+        latex_structure_envs: project_config.latex_structure_envs(),
+        latex_verbatim_commands: project_config.latex_verbatim_commands(),
         clause_breaks: project_config.clause_breaks.unwrap_or(false),
         ..Default::default()
     };

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -489,6 +489,36 @@ fn config_per_format_width_applies() {
 }
 
 #[test]
+fn config_latex_envs_and_commands_apply() {
+    let dir = tempfile::tempdir().unwrap();
+    fs::write(
+        dir.path().join(".snapperrc.toml"),
+        "[latex]\nverbatim_envs = [\"Verbatim\"]\nstructure_envs = [\"algorithm\", \"comment\"]\nverbatim_commands = [\"Verb\"]\n",
+    )
+    .unwrap();
+    let input = "\\begin{document}\n\\begin{algorithm}\nFirst step. Second step.\n\\end{algorithm}\nUse \\Verb|a.b! c| here. Next sentence.\n\\end{document}\n";
+    let out = pipe_stdin_in_dir(input, &["--format", "latex"], dir.path());
+    assert!(
+        out.status.success(),
+        "stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let result = String::from_utf8(out.stdout).unwrap();
+    assert!(
+        result.contains("First step. Second step."),
+        "algorithm body must not reflow, got:\n{result}"
+    );
+    assert!(
+        !result.contains("First step.\nSecond step."),
+        "algorithm must stay one source line, got:\n{result}"
+    );
+    assert!(
+        result.contains("Use \\Verb|a.b! c| here.\nNext sentence."),
+        "configured Verb must tokenize like verb, got:\n{result}"
+    );
+}
+
+#[test]
 fn markdown_numbered_atx_heading_not_split() {
     // snapper-25kc / rtrash README regression
     let input =


### PR DESCRIPTION
`.snapperrc.toml` `[latex]` lists (`verbatim_envs`, `structure_envs`, `verbatim_commands`) add names to the built-in minted/lstlisting/verbatim, `NON_PROSE_ENVS`, and verb/lstinline sets. Missing keys keep today's defaults. No regex `other:` key.

The render oracle and `--check` payloads use the same extras, so a configured verb command with an inner `%` is not a comment and production backstops do not revert the file. `w.r.t.` was already on `EN_MULTI_ABBREVS`. `Eq.~\ref{}` still has no invented space.
