### PR TITLE
chore(release): prepare v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. See [conven
 - - -
 ## Unreleased (main)
 
+- - -
+
+## v0.10.0 - 2026-08-10
 #### Features
 - (**latex**) `[latex].verbatim_envs` / `structure_envs` / `verbatim_commands` in `.snapperrc.toml` add names to the built-in lists (minted/lstlisting/verbatim, `NON_PROSE_ENVS`, `\\verb`/`\\lstinline`); missing keys keep today's defaults. Extra command names are tokenized like `\\verb` before split. No regex `other:` key
 - (**reflow**) `--clause-breaks` / `clause_breaks` with `max_width = 0` inserts a newline after every independent-clause mark (`,`, `;`, `:`, em dash, `--`) that is already followed by whitespace; a one-clause sentence stays one line; `max_width > 0` keeps wrap-prefer-clause. Tokens such as `1,000`, URLs, `--flags`, and unspaced dashes never split. `--check` uses the same mode
@@ -35,6 +38,10 @@ All notable changes to this project will be documented in this file. See [conven
 - (**code-block**) a block-comment closer inside a string no longer ends the comment; quote-sequence closers (`"""`) still match naively so Python docstrings reflow
 - (**sentence**) abbreviation merge does not invent a space before LaTeX `~` (so `Eq.~\ref{}` stays attached once org `~code~` pairing no longer swallows that tilde)
 - (**sentence**) restore wrapped placeholders from the outside in, so a markdown-link regex match that contains a paired-span token cannot leak `\x00PHn\x00` into output
+#### Notes
+- Native `format_text` refuses `--use-pandoc` (`PandocCannotSplice`); splice needs source offsets the AST does not carry
+- `--clause-breaks` with the default `max_width = 0` is SemBr rule 5 (break at existing whitespace after clause punct); `max_width > 0` still wrap-prefers
+- Published binaries include the MCP server (`mcp` is a default feature)
 
 - - -
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2221,7 +2221,7 @@ checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "snapper-fmt"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "snapper-fmt"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 description = "Semantic line break formatter for Org, LaTeX, Markdown, RST, and plaintext"

--- a/README.md
+++ b/README.md
@@ -130,6 +130,14 @@ Limit line width (wrap long sentences at word boundaries):
 
     snapper --max-width 80 paper.org
 
+Break after independent-clause punctuation (comma, semicolon, colon, em dash).
+With the default unlimited width this inserts a newline after every such mark that already has whitespace after it:
+
+    snapper --clause-breaks paper.org
+
+With `--max-width` set, overflowing sentences prefer those marks.
+A one-clause sentence stays one line.
+
 Preview changes as a unified diff before committing:
 
     snapper --diff paper.org
@@ -226,7 +234,7 @@ Configuration guide (org source in-tree): `docs/orgmode/howto/mcp-integration.or
 ## Pre-commit hook
 
     - repo: https://github.com/TurtleTech-ehf/snapper
-      rev: v0.9.1
+      rev: v0.10.0
       hooks:
         - id: snapper
 
@@ -333,8 +341,15 @@ Drop a `.snapperrc.toml` in your project root:
     ignore = ["*.bib", "*.cls"]
     format = "org"
     max_width = 0
+    clause_breaks = false
+
+    [latex]
+    verbatim_envs = ["Verbatim"]
+    structure_envs = ["algorithm", "comment"]
+    verbatim_commands = ["Verb"]
 
 `snapper` walks up from the current directory to find it.
+Missing `[latex]` keys keep the built-in minted/lstlisting/verbatim, equation/figure, and verb/lstinline lists.
 
 
 <a id="documentation"></a>

--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -3,7 +3,7 @@
 schema_version: 1
 
 context:
-  version: "0.9.1"
+  version: "0.10.0"
 
 package:
   name: snapper-fmt

--- a/docs/orgmode/howto/ci-enforcement.org
+++ b/docs/orgmode/howto/ci-enforcement.org
@@ -10,7 +10,7 @@ The easiest way to enforce semantic line breaks in CI.
 Add to your workflow:
 
 #+begin_src yaml
-- uses: TurtleTech-ehf/snapper@v0.9.1
+- uses: TurtleTech-ehf/snapper@v0.10.0
   with:
     files: '**/*.org **/*.tex **/*.md'
 #+end_src
@@ -20,7 +20,7 @@ This installs snapper and runs =--check= on the specified files.
 For GitHub Code Scanning integration (SARIF annotations on PRs):
 
 #+begin_src yaml
-- uses: TurtleTech-ehf/snapper@v0.9.1
+- uses: TurtleTech-ehf/snapper@v0.10.0
   with:
     files: '**/*.org **/*.tex **/*.md'
     sarif: 'true'
@@ -35,7 +35,7 @@ Add to =.pre-commit-config.yaml=:
 
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.9.1
+  rev: v0.10.0
   hooks:
     - id: snapper
 #+end_src

--- a/docs/orgmode/howto/vale-integration.org
+++ b/docs/orgmode/howto/vale-integration.org
@@ -70,7 +70,7 @@ A typical workflow:
 
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.9.1
+  rev: v0.10.0
   hooks:
     - id: snapper
 - repo: https://github.com/errata-ai/vale

--- a/docs/orgmode/tutorials/quickstart.org
+++ b/docs/orgmode/tutorials/quickstart.org
@@ -223,7 +223,7 @@ Add to your =.pre-commit-config.yaml=:
 
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.9.1
+  rev: v0.10.0
   hooks:
     - id: snapper
 #+end_src

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -3,7 +3,7 @@ import os
 project = "snapper"
 copyright = '2026--present, <a href="https://rgoswami.me">Rohit Goswami</a>'
 author = "Rohit Goswami"
-release = "0.9.1"
+release = "0.10.0"
 html_logo = "../../branding/logo/snapper_logo.png"
 
 extensions = [

--- a/editors/obsidian/manifest.json
+++ b/editors/obsidian/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "snapper",
   "name": "Snapper - Semantic Line Breaks",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "minAppVersion": "1.0.0",
   "description": "Format prose with semantic line breaks for clean git diffs. Supports Org-mode, LaTeX, Markdown, and plaintext.",
   "author": "TurtleTech",

--- a/editors/obsidian/package-lock.json
+++ b/editors/obsidian/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-snapper",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-snapper",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@snapper/wasm": "file:../../packages/snapper-wasm",
@@ -17,7 +17,7 @@
     },
     "../../packages/snapper-wasm": {
       "name": "@snapper/wasm",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dev": true,
       "license": "MIT",
       "devDependencies": {

--- a/editors/obsidian/package.json
+++ b/editors/obsidian/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-snapper",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "Obsidian plugin for snapper semantic line break formatter",
   "scripts": {

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -1,6 +1,6 @@
 # snapper - Semantic Line Breaks
 
-Requires **snapper** CLI **0.9.1+** on your PATH (or set `snapper.path`). Install: `cargo install snapper-fmt` or the [release installer](https://github.com/TurtleTech-ehf/snapper/releases/tag/v0.9.1).
+Requires **snapper** CLI **0.10.0+** on your PATH (or set `snapper.path`). Install: `cargo install snapper-fmt` or the [release installer](https://github.com/TurtleTech-ehf/snapper/releases/tag/v0.10.0).
 
 
 Format prose so each sentence occupies its own line, producing clean git diffs for collaborative writing.

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -2,7 +2,7 @@
   "name": "snapper",
   "displayName": "snapper - Semantic Line Breaks",
   "description": "Format prose with semantic line breaks for clean git diffs",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "publisher": "TurtleTech",
   "license": "MIT",
   "repository": {

--- a/editors/word/README.md
+++ b/editors/word/README.md
@@ -2,7 +2,7 @@
 
 Office add-in that formats document prose with **semantic line breaks** (one sentence per line) using the **snapper WASM** build (`@snapper/wasm`). Useful when drafting in Word and exporting to Org, Markdown, or LaTeX for git-friendly diffs.
 
-**Version:** 0.9.1 (tracks snapper-fmt)
+**Version:** 0.10.0 (tracks snapper-fmt)
 
 Development preview; not published in AppSource.
 

--- a/editors/word/manifest.xml
+++ b/editors/word/manifest.xml
@@ -5,7 +5,7 @@
   xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
   xsi:type="TaskPaneApp">
   <Id>a8f3c2e1-9b4d-4e7a-8c5f-1d2e3f4a5b6c</Id>
-  <Version>0.9.1</Version>
+  <Version>0.10.0</Version>
   <ProviderName>TurtleTech ehf</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="Snapper — Semantic Line Breaks"/>

--- a/editors/word/package-lock.json
+++ b/editors/word/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "word-snapper",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "word-snapper",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "@snapper/wasm": "file:../../packages/snapper-wasm",
@@ -21,7 +21,7 @@
     },
     "../../packages/snapper-wasm": {
       "name": "@snapper/wasm",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "dev": true,
       "license": "MIT",
       "devDependencies": {

--- a/editors/word/package.json
+++ b/editors/word/package.json
@@ -1,6 +1,6 @@
 {
   "name": "word-snapper",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "Microsoft Word add-in for snapper semantic line break formatter",
   "scripts": {

--- a/editors/word/src/taskpane/taskpane.html
+++ b/editors/word/src/taskpane/taskpane.html
@@ -10,7 +10,7 @@
 <body>
   <div class="snapper-taskpane">
     <h2>Snapper</h2>
-    <p class="tagline">Semantic line breaks for Word (v0.9.1)</p>
+    <p class="tagline">Semantic line breaks for Word (v0.10.0)</p>
     <p class="hint">Formats paragraphs as plaintext. Use the CLI or VS Code for Org/LaTeX structure awareness.</p>
     <div class="actions">
       <button type="button" id="format-doc">Format Document</button>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@turtletech/snapper-mcp",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "private": true,
   "description": "MCP server for snapper semantic line break formatter",
   "main": "bin/run.js",

--- a/packages/snapper-wasm/package-lock.json
+++ b/packages/snapper-wasm/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@snapper/wasm",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@snapper/wasm",
-      "version": "0.9.1",
+      "version": "0.10.0",
       "license": "MIT",
       "devDependencies": {
         "typescript": "^5.4"

--- a/packages/snapper-wasm/package.json
+++ b/packages/snapper-wasm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snapper/wasm",
-  "version": "0.9.1",
+  "version": "0.10.0",
   "description": "WebAssembly build of snapper semantic line break formatter",
   "type": "module",
   "main": "dist/index.js",

--- a/readme_src.org
+++ b/readme_src.org
@@ -95,6 +95,13 @@ Limit line width (wrap long sentences at word boundaries):
 #+begin_src bash
 snapper --max-width 80 paper.org
 #+end_src
+Break after independent-clause punctuation (comma, semicolon, colon, em dash).
+With the default unlimited width this inserts a newline after every such mark that already has whitespace after it:
+#+begin_src bash
+snapper --clause-breaks paper.org
+#+end_src
+With =--max-width= set, overflowing sentences prefer those marks.
+A one-clause sentence stays one line.
 Preview changes as a unified diff before committing:
 #+begin_src bash
 snapper --diff paper.org
@@ -145,7 +152,7 @@ Configuration guide (org source in-tree): =docs/orgmode/howto/mcp-integration.or
 :END:
 #+begin_src yaml
 - repo: https://github.com/TurtleTech-ehf/snapper
-  rev: v0.9.1
+  rev: v0.10.0
   hooks:
     - id: snapper
 #+end_src
@@ -241,7 +248,14 @@ extra_abbreviations = ["GROMACS", "LAMMPS", "DFT"]
 ignore = ["*.bib", "*.cls"]
 format = "org"
 max_width = 0
+clause_breaks = false
+
+[latex]
+verbatim_envs = ["Verbatim"]
+structure_envs = ["algorithm", "comment"]
+verbatim_commands = ["Verb"]
 #+end_src
+Missing =[latex]= keys keep the built-in minted/lstlisting/verbatim, equation/figure, and verb/lstinline lists.
 ~snapper~ walks up from the current directory to find it.
 * Documentation
 :PROPERTIES:


### PR DESCRIPTION
v0.10.0 from main after the post-0.9.1 splice/check/parser work and the three B issues:

- `--clause-breaks` with default `max_width = 0` is SemBr rule 5 (whitespace after punct only)
- MCP ships in release binaries; `format_text` / `check_formatting` take `clause_breaks` and `range`
- `[latex]` `verbatim_envs` / `structure_envs` / `verbatim_commands` add to the built-in lists

Native `format_text` refuses `--use-pandoc` (`PandocCannotSplice`). Version pins match `scripts/check_release_ready.sh`. Leave the conda sha256 until the tag exists.

After merge: tag `v0.10.0` on the merge commit once main CI is green, then the post-tag steps in `RELEASING.md`.
