### PR TITLE
fix(mcp): wire tool_handler so tools/list is not empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 ## Unreleased (main)
+#### Bug Fixes
+- (**mcp**) `#[tool_handler]` implements `list_tools` / `call_tool`; `initialize` advertises tools and names the server `snapper` instead of the empty `rmcp` default
 
 - - -
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -5,7 +5,7 @@
 
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::wrapper::Parameters;
-use rmcp::{Json, ServerHandler, ServiceExt, tool, tool_router};
+use rmcp::{Json, ServerHandler, ServiceExt, tool, tool_handler, tool_router};
 use serde::{Deserialize, Serialize};
 
 use crate::FormatConfig;
@@ -141,8 +141,7 @@ pub struct SplitSentencesResult {
 // -- Server --
 
 pub struct SnapperMcpServer {
-    /// Held for `#[tool_router]` / `ServerHandler` generated accessors.
-    #[allow(dead_code)]
+    /// Read by `#[tool_handler]` for `list_tools` / `call_tool`.
     tool_router: ToolRouter<Self>,
 }
 
@@ -261,6 +260,10 @@ impl SnapperMcpServer {
     }
 }
 
+#[tool_handler(
+    name = "snapper",
+    instructions = "Semantic line-break formatter. Tools: format_text, detect_format, check_formatting, split_sentences."
+)]
 impl ServerHandler for SnapperMcpServer {}
 
 // -- Helpers --
@@ -363,6 +366,41 @@ mod tests {
                 clause_breaks,
             }))
             .0
+    }
+
+    #[test]
+    fn server_info_advertises_tools_and_snapper_name() {
+        let info = ServerHandler::get_info(&SnapperMcpServer::new());
+        assert!(
+            info.capabilities.tools.is_some(),
+            "initialize must advertise tools, got {:?}",
+            info.capabilities
+        );
+        assert_eq!(
+            info.server_info.name, "snapper",
+            "clients should see snapper, not the rmcp default"
+        );
+    }
+
+    #[test]
+    fn tool_router_lists_the_four_tools() {
+        let names: Vec<String> = SnapperMcpServer::new()
+            .tool_router
+            .list_all()
+            .into_iter()
+            .map(|t| t.name.to_string())
+            .collect();
+        for expected in [
+            "format_text",
+            "detect_format",
+            "check_formatting",
+            "split_sentences",
+        ] {
+            assert!(
+                names.iter().any(|n| n == expected),
+                "missing {expected} in {names:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -142,6 +142,8 @@ pub struct SplitSentencesResult {
 
 pub struct SnapperMcpServer {
     /// Read by `#[tool_handler]` for `list_tools` / `call_tool`.
+    /// Clippy does not see the macro use, so this is not dead.
+    #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
 }
 


### PR DESCRIPTION
`snapper mcp` on v0.10.0 does the handshake and then serves nothing: `initialize` advertises empty capabilities, `tools/list` is `[]`, and `tools/call` is `-32601`.

Cause is `impl ServerHandler for SnapperMcpServer {}` with no `#[tool_handler]`. The `#[tool_router]` methods were already there; the handler never wired `list_tools` / `call_tool`, so clients saw the rmcp default (`serverInfo.name = rmcp`).

This adds `#[tool_handler(name = "snapper", ...)]` and tests that `get_info` advertises tools and that the four tools are on the router.

Closes #27
