### PR TITLE
fix(vscode): keep vscode-languageclient out of devDependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file. See [conven
 ## Unreleased (main)
 #### Bug Fixes
 - (**mcp**) `#[tool_handler]` implements `list_tools` / `call_tool`; `initialize` advertises tools and names the server `snapper` instead of the empty `rmcp` default
+- (**vscode**) `vscode-languageclient` is a runtime dependency only, so `vsce package` ships the module the extension `require`s
 
 - - -
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -103,8 +103,7 @@
   "devDependencies": {
     "@types/vscode": "^1.75.0",
     "esbuild": "^0.28.0",
-    "typescript": "^5.0.0",
-    "vscode-languageclient": "^9.0.0"
+    "typescript": "^5.0.0"
   },
   "dependencies": {
     "vscode-languageclient": "^9.0.0"


### PR DESCRIPTION
Activation dies with `Cannot find module 'vscode-languageclient/node'`, so the palette commands stay as manifest stubs. Thanks @kattleo, the require stack is the whole story.

`vscode-languageclient` was listed in both `dependencies` and `devDependencies`. `vsce package` / `npm install --omit=dev` treats that as a devDep and drops it from the VSIX.

This keeps it in `dependencies` only. #30 stacks the esbuild bundle on top so activate does not need `node_modules` at all.

Closes #28
