### PR TITLE
fix(latex): format input chapters without a document env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file. See [conven
 - (**vscode**) `out/extension.js` is an esbuild bundle (`vscode` stays external); the VSIX no longer needs `node_modules` at runtime
 - (**ci**) release and nvim workflows install cargo-dist from a sha256-pinned archive and Rust via `dtolnay/rust-toolchain`; they no longer pipe rustup.sh or cargo-dist-installer.sh into `sh`
 - (**sentence**) a period immediately before Markdown/Org closers (`**`, `*`, backticks, `](url)`) is a sentence end, so `**Bold sentence.** Next` splits and a hand break survives the next run
+- (**latex**) `% snapper:no-preamble` and chapter files with no `\\begin{document}` / `\\documentclass` are body; class and package files stay preamble
 
 - - -
 

--- a/docs/orgmode/faq/index.org
+++ b/docs/orgmode/faq/index.org
@@ -115,7 +115,7 @@ Yes.
 Use =snapper:off= and =snapper:on= pragmas in comments:
 
 - Org: =# snapper:off= / =# snapper:on=
-- LaTeX: =% snapper:off= / =% snapper:on=
+- LaTeX: =% snapper:off= / =% snapper:on=; =% snapper:no-preamble= on =\input= chapters
 - Markdown: =<!-- snapper:off -->= / =<!-- snapper:on -->=
 - RST/Plaintext: =snapper:off= / =snapper:on= on their own line
 

--- a/docs/orgmode/howto/pragmas.org
+++ b/docs/orgmode/howto/pragmas.org
@@ -9,6 +9,7 @@
 Sometimes you need to prevent snapper from reformatting specific regions: hand-formatted poetry, aligned text, carefully laid-out tables in prose, or any text where line breaks carry meaning.
 
 Use =snapper:off= and =snapper:on= pragmas to mark regions that should pass through unchanged.
+LaTeX chapter files included with =\input= can add =% snapper:no-preamble= so snapper treats the file as body instead of waiting for =\begin{document}=.
 
 * Syntax by format
 :PROPERTIES:
@@ -46,6 +47,14 @@ be reformatted.
 % snapper:on
 
 More prose that gets reformatted.
+#+end_src
+
+A =\input= chapter with no =\begin{document}= is body by default.
+Use =% snapper:no-preamble= when the file also has =\documentclass= or you want the flag written down:
+
+#+begin_src latex
+% snapper:no-preamble
+This sentence is a test. This sentence is also a test.
 #+end_src
 
 ** Markdown

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -624,13 +624,20 @@ impl FormatParser for LatexParser {
             in_display_math: false,
             nospace_join: false,
         };
-        let mut in_preamble = true;
+        let mut in_preamble = super::latex_starts_in_preamble(input);
         let mut pragma_off = false;
 
         for line in iter_lines(input) {
             // Check for snapper:off/on pragmas; inside a code environment
             // the per-language reflow path handles pragmas instead.
             if state.in_code_env.is_none() {
+                if super::is_no_preamble_pragma(line.text) {
+                    state.flush();
+                    state
+                        .regions
+                        .push(SpannedRegion::structure(input, line.span()));
+                    continue;
+                }
                 if let Some(on) = super::check_pragma(line.text) {
                     state.flush();
                     pragma_off = !on;
@@ -737,6 +744,63 @@ mod tests {
             "must not reflow mid-title inside braces:\n{out}"
         );
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn fragment_without_begin_document_is_prose() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "This sentence is a test. This sentence is also a test.\n";
+        let cfg = FormatConfig {
+            format: Format::Latex,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, "This sentence is a test.\nThis sentence is also a test.\n",
+            "input chapter without \\begin{{document}} must reflow, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn no_preamble_pragma_formats_body() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input =
+            "% snapper:no-preamble\nThis sentence is a test. This sentence is also a test.\n";
+        let cfg = FormatConfig {
+            format: Format::Latex,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.starts_with("% snapper:no-preamble\n"),
+            "pragma line must stay structure, got:\n{out}"
+        );
+        assert!(
+            out.contains("This sentence is a test.\nThis sentence is also a test."),
+            "pragma must treat the file as body, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn documentclass_without_begin_stays_preamble() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input =
+            "\\documentclass{article}\nThis sentence is a test. This sentence is also a test.\n";
+        let cfg = FormatConfig {
+            format: Format::Latex,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(out, input, "class-only file must stay preamble");
     }
 
     #[test]

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -122,29 +122,49 @@ pub fn flush_prose(prose: &mut String, regions: &mut Vec<Region>) {
     }
 }
 
-/// Check if a line contains a snapper pragma.
-/// Returns Some(false) for "snapper:off", Some(true) for "snapper:on", None otherwise.
-pub fn check_pragma(line: &str) -> Option<bool> {
+/// Comment payload after a format-specific marker (`# `, `% `, `<!-- -->`).
+fn pragma_payload(line: &str) -> &str {
     let trimmed = line.trim();
-    // Strip format-specific comment markers
-    let content = trimmed
-        .strip_prefix("# ") // Org comment
-        .or_else(|| trimmed.strip_prefix("% ")) // LaTeX comment
+    trimmed
+        .strip_prefix("# ")
+        .or_else(|| trimmed.strip_prefix("% "))
         .or_else(|| {
-            // HTML/Markdown comment
             trimmed
                 .strip_prefix("<!-- ")
                 .and_then(|s| s.strip_suffix(" -->"))
         })
-        .unwrap_or(trimmed); // Plaintext: bare pragma
-    let content = content.trim();
-    if content == "snapper:off" {
-        Some(false)
-    } else if content == "snapper:on" {
-        Some(true)
-    } else {
-        None
+        .unwrap_or(trimmed)
+        .trim()
+}
+
+/// Check if a line contains a snapper pragma.
+/// Returns Some(false) for "snapper:off", Some(true) for "snapper:on", None otherwise.
+pub fn check_pragma(line: &str) -> Option<bool> {
+    match pragma_payload(line) {
+        "snapper:off" => Some(false),
+        "snapper:on" => Some(true),
+        _ => None,
     }
+}
+
+/// `% snapper:no-preamble` (or the same payload after `# ` / `<!-- -->`).
+pub fn is_no_preamble_pragma(line: &str) -> bool {
+    pragma_payload(line) == "snapper:no-preamble"
+}
+
+/// LaTeX files stay in preamble mode until `\begin{document}` unless the
+/// file is a body fragment: an explicit `snapper:no-preamble` line, or no
+/// `\begin{document}` and no class/package header.
+pub fn latex_starts_in_preamble(input: &str) -> bool {
+    if input.lines().any(is_no_preamble_pragma) {
+        return false;
+    }
+    if input.contains(r"\begin{document}") {
+        return true;
+    }
+    input.contains(r"\documentclass")
+        || input.contains(r"\ProvidesPackage")
+        || input.contains(r"\ProvidesClass")
 }
 
 #[cfg(test)]
@@ -180,5 +200,32 @@ mod tests {
         assert_eq!(check_pragma("regular text"), None);
         assert_eq!(check_pragma("# a comment"), None);
         assert_eq!(check_pragma(""), None);
+    }
+
+    #[test]
+    fn no_preamble_pragma_payload() {
+        assert!(is_no_preamble_pragma("% snapper:no-preamble"));
+        assert!(is_no_preamble_pragma("  % snapper:no-preamble  "));
+        assert!(!is_no_preamble_pragma("% snapper:off"));
+        assert!(!is_no_preamble_pragma("snapper:no-preamble extra"));
+    }
+
+    #[test]
+    fn latex_fragment_skips_preamble_mode() {
+        assert!(!latex_starts_in_preamble(
+            "This sentence is a test. This sentence is also a test.\n"
+        ));
+        assert!(!latex_starts_in_preamble(
+            "% snapper:no-preamble\n\\begin{document}\nBody.\n\\end{document}\n"
+        ));
+        assert!(latex_starts_in_preamble(
+            "\\begin{document}\nBody.\n\\end{document}\n"
+        ));
+        assert!(latex_starts_in_preamble(
+            "\\documentclass{article}\nThis sentence is a test. More.\n"
+        ));
+        assert!(latex_starts_in_preamble(
+            "\\ProvidesPackage{foo}\n% comments only\n"
+        ));
     }
 }


### PR DESCRIPTION
`in_preamble` started true and only cleared on `\begin{document}`, so `\input` chapters never reflowed. `% snapper:off` does not help; that path is still structure.

`% snapper:no-preamble` forces body, as @ArthurValk asked. A `.tex` file with no `\begin{document}` and no `\documentclass` / `\ProvidesPackage` / `\ProvidesClass` is body by default. Class and package files stay preamble.

Closes #29
