### PR TITLE
fix(vscode): bundle the extension with esbuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [conven
 #### Bug Fixes
 - (**mcp**) `#[tool_handler]` implements `list_tools` / `call_tool`; `initialize` advertises tools and names the server `snapper` instead of the empty `rmcp` default
 - (**vscode**) `vscode-languageclient` is a runtime dependency only, so `vsce package` ships the module the extension `require`s
+- (**vscode**) `out/extension.js` is an esbuild bundle (`vscode` stays external); the VSIX no longer needs `node_modules` at runtime
 
 - - -
 

--- a/editors/vscode/.vscodeignore
+++ b/editors/vscode/.vscodeignore
@@ -3,3 +3,7 @@
 src/**
 .gitignore
 tsconfig.json
+esbuild.config.mjs
+node_modules/**
+**/*.vsix
+**/*.map

--- a/editors/vscode/esbuild.config.mjs
+++ b/editors/vscode/esbuild.config.mjs
@@ -1,0 +1,21 @@
+import esbuild from "esbuild";
+
+const watch = process.argv.includes("--watch");
+
+const ctx = await esbuild.context({
+    entryPoints: ["src/extension.ts"],
+    bundle: true,
+    outfile: "out/extension.js",
+    platform: "node",
+    external: ["vscode"],
+    format: "cjs",
+    sourcemap: true,
+    logLevel: "info",
+});
+
+if (watch) {
+    await ctx.watch();
+} else {
+    await ctx.rebuild();
+    await ctx.dispose();
+}

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -97,8 +97,9 @@
     ]
   },
   "scripts": {
-    "compile": "tsc -p ./",
-    "package": "vsce package"
+    "compile": "node esbuild.config.mjs",
+    "watch": "node esbuild.config.mjs --watch",
+    "package": "npm run compile && vsce package --no-dependencies"
   },
   "devDependencies": {
     "@types/vscode": "^1.75.0",


### PR DESCRIPTION
Same crash as #28. @tjueterb's workaround (`npm install --no-save vscode-languageclient@9.0.1` in the extension dir) is right: `tsc` emitted a `require('vscode-languageclient/node')` the VSIX did not ship, and the duplicate `devDependencies` entry made `--omit=dev` a no-op.

This stacks on #28. `npm run compile` is esbuild, `vscode` stays external, and `vsce package --no-dependencies` ships one `out/extension.js`. No runtime `node_modules` needed.

Closes #30
