### PR TITLE
fix(sentence): split after period inside Markdown closers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file. See [conven
 - (**vscode**) `vscode-languageclient` is a runtime dependency only, so `vsce package` ships the module the extension `require`s
 - (**vscode**) `out/extension.js` is an esbuild bundle (`vscode` stays external); the VSIX no longer needs `node_modules` at runtime
 - (**ci**) release and nvim workflows install cargo-dist from a sha256-pinned archive and Rust via `dtolnay/rust-toolchain`; they no longer pipe rustup.sh or cargo-dist-installer.sh into `sh`
+- (**sentence**) a period immediately before Markdown/Org closers (`**`, `*`, backticks, `](url)`) is a sentence end, so `**Bold sentence.** Next` splits and a hand break survives the next run
 
 - - -
 

--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -26,13 +26,16 @@ This is the successor path for multi-format work (amortizes RTS; avoids process-
 :CUSTOM_ID: requirements
 :END:
 
-**CLI backend.** Pandoc 2.x or 3.x on =PATH=.
+**CLI backend.**
+Pandoc 2.x or 3.x on =PATH=.
 With =--use-pandoc=, a missing or failing pandoc is an explicit error (no silent all-prose).
 
-**FFI backend (dynamic).** Build =native/snapper-pandoc=, set =SNAPPER_PANDOC_LIB= to =libsnapper_pandoc.so= (or put it on the search path).
+**FFI backend (dynamic).**
+Build =native/snapper-pandoc=, set =SNAPPER_PANDOC_LIB= to =libsnapper_pandoc.so= (or put it on the search path).
 A missing library with =--pandoc-backend ffi= errors with =pandoc FFI library unavailable= (fail-closed; never silent all-prose).
 
-**FFI backend (co-linked / one binary).** Feature =pandoc-colink= is a *build* path: produce =libsnapper_pandoc.a= with =native/snapper-pandoc/build-static.sh= (=ghc -staticlib=), then Cargo absorbs that archive into a single =snapper= executable (=--gc-sections=).
+**FFI backend (co-linked / one binary).**
+Feature =pandoc-colink= is a *build* path: produce =libsnapper_pandoc.a= with =native/snapper-pandoc/build-static.sh= (=ghc -staticlib=), then Cargo absorbs that archive into a single =snapper= executable (=--gc-sections=).
 No =SNAPPER_PANDOC_LIB= discovery and no multi-hundred-MB =libHS*= RUNPATH graph.
 
 #+begin_src bash
@@ -60,7 +63,8 @@ snapper --use-pandoc --pandoc-backend ffi paper.md
 Native line parsers remain the default until product flip.
 Use =--use-pandoc= when you need formats without a built-in parser or AST-true structure; prefer FFI for latency once =libsnapper_pandoc= is installed.
 
-**Speed.** Warm in-process FFI is a few times native cost; cold process reloads the GHC RTS (tens of ms).
+**Speed.**
+Warm in-process FFI is a few times native cost; cold process reloads the GHC RTS (tens of ms).
 Snapper also caches pandoc JSON ASTs by content hash (memory + disk under =$XDG_CACHE_HOME/snapper/pandoc-ast=).
 Re-formatting the same source skips pandoc entirely.
 Disable with =SNAPPER_PANDOC_CACHE=0=; override dir with =SNAPPER_PANDOC_CACHE_DIR=.

--- a/src/sentence/neural.rs
+++ b/src/sentence/neural.rs
@@ -3,7 +3,10 @@ use std::sync::Mutex;
 use nnsplit::NNSplit;
 
 use super::SentenceSplitter;
-use super::unicode::{UnicodeSentenceSplitter, protect_inline_tokens_with, restore_inline_tokens};
+use super::unicode::{
+    UnicodeSentenceSplitter, protect_inline_tokens_with, restore_inline_tokens,
+    split_after_markup_sentence_end,
+};
 
 /// nnsplit downloads models to `~/.cache/nnsplit/` on first use; concurrent
 /// loads race the download and can observe a partially written model
@@ -95,7 +98,7 @@ impl SentenceSplitter for NeuralSentenceSplitter {
         };
 
         let restored = restore_inline_tokens(raw, &placeholders);
-        self.post.refine_segments(restored)
+        split_after_markup_sentence_end(self.post.refine_segments(restored))
     }
 }
 

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -1801,6 +1801,27 @@ mod tests {
     }
 
     #[test]
+    fn org_markdown_style_bold_period_splits_without_headline() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Org,
+            ..Default::default()
+        };
+        let out = format_text("**CLI backend.** Pandoc 2.x on =PATH=.\n", &cfg).unwrap();
+        assert_eq!(out, "**CLI backend.**\nPandoc 2.x on =PATH=.\n");
+        assert!(
+            !out.lines().any(|l| {
+                let stars = l.chars().take_while(|c| *c == '*').count();
+                stars > 0 && l[stars..].starts_with(' ')
+            }),
+            "split must not invent an org headline, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
     fn markdown_em_with_internal_period_not_split() {
         let text = "This is *the end. Still em* after.";
         let (_, placeholders) = protect_inline_tokens(text);

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -671,7 +671,8 @@ impl SentenceSplitter for UnicodeSentenceSplitter {
         }
 
         let merged = self.refine_segments_from_strs(&raw_segments);
-        restore_inline_tokens(merged, &placeholders)
+        let restored = restore_inline_tokens(merged, &placeholders);
+        split_after_markup_sentence_end(restored)
     }
 }
 
@@ -799,6 +800,49 @@ fn push_segment_preserving_space(dest: &mut String, piece: &str) {
 /// Merge false splits caused by sentence punctuation inside quotes or parens.
 /// E.g., `He said "wow!"` + `and left.` should stay as one sentence when
 /// the next segment starts with a lowercase letter.
+/// Split after `.!?` that sits immediately before Markdown/Org closers.
+///
+/// `**Bold sentence.** Next` is one UAX sentence because the period lives
+/// inside the protected span. Quotes are not paired spans, so they already
+/// split. Mid-span periods (`**the end. Still bold**`) have no closers
+/// after the period and stay one sentence.
+pub(crate) fn split_after_markup_sentence_end(segments: Vec<String>) -> Vec<String> {
+    let mut out = Vec::new();
+    for seg in segments {
+        push_markup_sentence_splits(&mut out, seg.trim());
+    }
+    out.into_iter().filter(|s| !s.is_empty()).collect()
+}
+
+fn push_markup_sentence_splits(out: &mut Vec<String>, seg: &str) {
+    if let Some((head, rest)) = take_markup_terminal_sentence(seg) {
+        out.push(head);
+        push_markup_sentence_splits(out, &rest);
+    } else if !seg.is_empty() {
+        out.push(seg.to_string());
+    }
+}
+
+fn take_markup_terminal_sentence(seg: &str) -> Option<(String, String)> {
+    // Period, then `**` / `*` / `_` / backticks / `~~` / `](url)`, then
+    // whitespace, then a new sentence (uppercase or opening quote). A
+    // lowercase continuation (`[Example Inc.](url) now.`) stays one
+    // sentence.
+    static CAP: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(
+            r#"(?s)^(.*?[.!?](?:\*{1,3}|_{1,3}|`+|~{1,2}|\]\([^)]*\))+)\s+(["'A-Z][\s\S]*)$"#,
+        )
+        .expect("valid markup-terminal sentence regex")
+    });
+    let c = CAP.captures(seg)?;
+    let head = c.get(1)?.as_str().trim();
+    let rest = c.get(2)?.as_str().trim();
+    if head.is_empty() || rest.is_empty() {
+        return None;
+    }
+    Some((head.to_string(), rest.to_string()))
+}
+
 fn merge_quoted_punct_splits(segments: Vec<String>) -> Vec<String> {
     let mut result: Vec<String> = Vec::with_capacity(segments.len());
 
@@ -1710,6 +1754,50 @@ mod tests {
                 "Equity is hard.".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn markdown_period_inside_closers_is_a_sentence_end() {
+        assert_eq!(
+            split("**Bold sentence.** Next one."),
+            vec!["**Bold sentence.**".to_string(), "Next one.".to_string()]
+        );
+        assert_eq!(
+            split("*Italic sentence.* Next one."),
+            vec!["*Italic sentence.*".to_string(), "Next one.".to_string()]
+        );
+        assert_eq!(
+            split("`Code sentence.` Next one."),
+            vec!["`Code sentence.`".to_string(), "Next one.".to_string()]
+        );
+        assert_eq!(
+            split("[Link sentence.](http://x.com) Next one."),
+            vec![
+                "[Link sentence.](http://x.com)".to_string(),
+                "Next one.".to_string()
+            ]
+        );
+        assert_eq!(
+            split("Visit [Example Inc.](https://example.com) now. Then read more."),
+            vec![
+                "Visit [Example Inc.](https://example.com) now.".to_string(),
+                "Then read more.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn markdown_period_inside_closers_survives_format_roundtrip() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let out = format_text("**Bold sentence.** Next one.\n", &cfg).unwrap();
+        assert_eq!(out, "**Bold sentence.**\nNext one.\n");
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 
     #[test]


### PR DESCRIPTION
`**Bold sentence.** Next one.` stays one line because `protect_inline_tokens` swallows the period inside the span. `"Quoted sentence." Next` already splits; quotes are not paired spans. A hand break gets joined on the next run: the two lines are still one sentence.

After restore, split on `.!?` immediately followed by `**` / `*` / backticks / `](url)`. Mid-span periods (`**the end. Still bold**`) stay one sentence.

Closes #31
