### PR TITLE
fix(ci): pin cargo-dist by sha256, drop rustup.sh pipes

### DIFF
--- a/.github/workflows/nvim_test.yml
+++ b/.github/workflows/nvim_test.yml
@@ -39,11 +39,10 @@ jobs:
           target/
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
     - name: Install snapper binary
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-        source ~/.cargo/env
-        cargo install --path . --force
+      run: cargo install --path . --force
 
     - name: Install plenary.nvim for testing
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,10 +61,8 @@ jobs:
           persist-credentials: false
           submodules: recursive
       - name: Install dist
-        # we specify bash to get pipefail; it guards against the `curl` command
-        # failing. otherwise `sh` won't catch that `curl` returned non-0
         shell: bash
-        run: "curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.30.3/cargo-dist-installer.sh | sh"
+        run: bash scripts/install_cargo_dist.sh
       - name: Cache dist
         uses: actions/upload-artifact@v4
         with:
@@ -120,15 +118,12 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Install Rust non-interactively if not already installed
+      - name: Install Rust
         if: ${{ matrix.container }}
-        run: |
-          if ! command -v cargo > /dev/null 2>&1; then
-            curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-            echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-          fi
+        uses: dtolnay/rust-toolchain@stable
       - name: Install dist
-        run: ${{ matrix.install_dist.run }}
+        shell: bash
+        run: bash scripts/install_cargo_dist.sh
       # Get the dist-manifest
       - name: Fetch local artifacts
         uses: actions/download-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file. See [conven
 - (**mcp**) `#[tool_handler]` implements `list_tools` / `call_tool`; `initialize` advertises tools and names the server `snapper` instead of the empty `rmcp` default
 - (**vscode**) `vscode-languageclient` is a runtime dependency only, so `vsce package` ships the module the extension `require`s
 - (**vscode**) `out/extension.js` is an esbuild bundle (`vscode` stays external); the VSIX no longer needs `node_modules` at runtime
+- (**ci**) release and nvim workflows install cargo-dist from a sha256-pinned archive and Rust via `dtolnay/rust-toolchain`; they no longer pipe rustup.sh or cargo-dist-installer.sh into `sh`
 
 - - -
 

--- a/scripts/check_release_ready.sh
+++ b/scripts/check_release_ready.sh
@@ -105,6 +105,19 @@ expect "## v$version" CHANGELOG.md
 # The public availability contract must hold too.
 bash "$repo_root/scripts/check_public_contract.sh" || fail "check_public_contract.sh failed"
 
+# Release CI must not pipe a downloaded installer into a shell.
+pipe_hits="$(
+  grep -nE 'curl.*\|[[:space:]]*sh' \
+    "$repo_root/.github/workflows/release.yml" \
+    "$repo_root/.github/workflows/nvim_test.yml" || true
+)"
+if [[ -n "$pipe_hits" ]]; then
+  fail "workflow still pipes a curl download into sh:"$'\n'"$pipe_hits"
+fi
+if ! grep -Fq 'scripts/install_cargo_dist.sh' "$repo_root/.github/workflows/release.yml"; then
+  fail "release.yml does not install cargo-dist via scripts/install_cargo_dist.sh"
+fi
+
 if [[ "$mode" == "pre" ]]; then
   if [[ -n "$(git -C "$repo_root" tag -l "v$version")" ]]; then
     fail "local tag v$version already exists; a consumed tag must never move"

--- a/scripts/install_cargo_dist.sh
+++ b/scripts/install_cargo_dist.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Install cargo-dist 0.30.3 from a versioned archive after sha256.
+# Do not pipe the installer script into sh.
+set -euo pipefail
+
+VER=0.30.3
+os="$(uname -s)"
+arch="$(uname -m)"
+case "$os" in
+Linux)
+    case "$arch" in
+    x86_64)
+        target=x86_64-unknown-linux-gnu
+        ext=tar.xz
+        sha=214ab0f512b9cad7f26dd4804ecbb73ad898db6beaae48f0ce30baf3b9a763f6
+        ;;
+    aarch64 | arm64)
+        target=aarch64-unknown-linux-gnu
+        ext=tar.xz
+        sha=721ba4602df82b22bcbe2de615cd2f520b51e50d6faef5f74ddeb6b67cae5116
+        ;;
+    *)
+        printf 'unsupported Linux arch: %s\n' "$arch" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+Darwin)
+    case "$arch" in
+    x86_64)
+        target=x86_64-apple-darwin
+        ext=tar.xz
+        sha=81e53353e142ed4bd838be82abc59309cd580e67f8c61eebb4e932ef1982480d
+        ;;
+    arm64)
+        target=aarch64-apple-darwin
+        ext=tar.xz
+        sha=e5b587c7fe71a89ee3325745984ac412982d6c0e6ec8d4d5072fe579b38765cf
+        ;;
+    *)
+        printf 'unsupported Darwin arch: %s\n' "$arch" >&2
+        exit 1
+        ;;
+    esac
+    ;;
+MINGW* | MSYS* | CYGWIN*)
+    target=x86_64-pc-windows-msvc
+    ext=zip
+    sha=8fe2d2ce1be4e6e2efe26700490b1765dff203595544bddf3e67378b72c0e228
+    ;;
+*)
+    printf 'unsupported OS: %s\n' "$os" >&2
+    exit 1
+    ;;
+esac
+
+base="cargo-dist-${target}"
+url="https://github.com/axodotdev/cargo-dist/releases/download/v${VER}/${base}.${ext}"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+archive="${work}/${base}.${ext}"
+curl --proto '=https' --tlsv1.2 -fsSL -o "$archive" "$url"
+got="$(sha256sum "$archive" | awk '{print $1}')"
+if [[ "$got" != "$sha" ]]; then
+    printf 'checksum mismatch for %s\n  expected %s\n  got      %s\n' "$url" "$sha" "$got" >&2
+    exit 1
+fi
+
+dest="${CARGO_HOME:-$HOME/.cargo}/bin"
+mkdir -p "$dest"
+if [[ "$ext" == zip ]]; then
+    unzip -q -o "$archive" -d "$work"
+    install -m 0755 "${work}/${base}/dist.exe" "${dest}/dist.exe"
+else
+    tar -xJf "$archive" -C "$work"
+    install -m 0755 "${work}/${base}/dist" "${dest}/dist"
+fi
+printf 'installed cargo-dist %s to %s\n' "$VER" "$dest"


### PR DESCRIPTION
`release.yml` installed cargo-dist by piping `cargo-dist-installer.sh` into `sh`, and installed Rust the same way from `sh.rustup.rs`. A substituted download would run in the release environment.

This downloads the v0.30.3 archive and checks the published sha256 (`scripts/install_cargo_dist.sh`), and uses `dtolnay/rust-toolchain` like the rest of CI. `check_release_ready.sh` fails if those pipes return.

`nvim_test.yml` had the same rustup pipe; that is gone too.
