### PR TITLE
fix(ci): install cargo-dist on Windows and macOS ARM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,14 @@ on:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
+  # Republish an existing tag from a later commit (installer-script
+  # fix) without moving the tag. crates.io / PyPI already consumed it.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing tag to publish (e.g. v0.11.0)'
+        required: true
+        type: string
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
@@ -50,9 +58,9 @@ jobs:
     runs-on: "ubuntu-22.04"
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
-      tag: ${{ !github.event.pull_request && github.ref_name || '' }}
-      tag-flag: ${{ !github.event.pull_request && format('--tag={0}', github.ref_name) || '' }}
-      publishing: ${{ !github.event.pull_request }}
+      tag: ${{ github.event.inputs.tag || (!github.event.pull_request && startsWith(github.ref, 'refs/tags/') && github.ref_name) || '' }}
+      tag-flag: ${{ github.event.inputs.tag && format('--tag={0}', github.event.inputs.tag) || (startsWith(github.ref, 'refs/tags/') && format('--tag={0}', github.ref_name)) || '' }}
+      publishing: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
@@ -75,7 +83,7 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          dist ${{ (!github.event.pull_request && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
+          dist ${{ (github.event.inputs.tag && format('host --steps=create --tag={0}', github.event.inputs.tag)) || (startsWith(github.ref, 'refs/tags/') && format('host --steps=create --tag={0}', github.ref_name)) || 'plan' }} --output-format=json > plan-dist-manifest.json
           echo "dist ran successfully"
           cat plan-dist-manifest.json
           echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 ## Unreleased (main)
+#### Bug Fixes
+- (**ci**) `scripts/install_cargo_dist.sh` hashes with `shasum`/`openssl` when `sha256sum` is missing and finds `dist.exe` at the zip root (Windows cargo-dist layout)
 
 - - -
 

--- a/scripts/check_release_ready.sh
+++ b/scripts/check_release_ready.sh
@@ -117,6 +117,9 @@ fi
 if ! grep -Fq 'scripts/install_cargo_dist.sh' "$repo_root/.github/workflows/release.yml"; then
   fail "release.yml does not install cargo-dist via scripts/install_cargo_dist.sh"
 fi
+if ! bash "$repo_root/scripts/test_install_cargo_dist.sh"; then
+  fail "scripts/test_install_cargo_dist.sh failed"
+fi
 
 if [[ "$mode" == "pre" ]]; then
   if [[ -n "$(git -C "$repo_root" tag -l "v$version")" ]]; then

--- a/scripts/install_cargo_dist.sh
+++ b/scripts/install_cargo_dist.sh
@@ -4,8 +4,21 @@
 set -euo pipefail
 
 VER=0.30.3
-os="$(uname -s)"
-arch="$(uname -m)"
+os="${SNAPPER_UNAME_S:-$(uname -s)}"
+arch="${SNAPPER_UNAME_M:-$(uname -m)}"
+
+digest() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    elif command -v openssl >/dev/null 2>&1; then
+        openssl dgst -sha256 "$1" | awk '{print $NF}'
+    else
+        printf 'no sha256sum, shasum, or openssl on PATH\n' >&2
+        exit 1
+    fi
+}
 case "$os" in
 Linux)
     case "$arch" in
@@ -58,11 +71,16 @@ base="cargo-dist-${target}"
 url="https://github.com/axodotdev/cargo-dist/releases/download/v${VER}/${base}.${ext}"
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
-archive="${work}/${base}.${ext}"
-curl --proto '=https' --tlsv1.2 -fsSL -o "$archive" "$url"
-got="$(sha256sum "$archive" | awk '{print $1}')"
+if [[ -n "${CARGO_DIST_ARCHIVE:-}" ]]; then
+    archive="$CARGO_DIST_ARCHIVE"
+    sha="${CARGO_DIST_SHA:-$sha}"
+else
+    archive="${work}/${base}.${ext}"
+    curl --proto '=https' --tlsv1.2 -fsSL -o "$archive" "$url"
+fi
+got="$(digest "$archive")"
 if [[ "$got" != "$sha" ]]; then
-    printf 'checksum mismatch for %s\n  expected %s\n  got      %s\n' "$url" "$sha" "$got" >&2
+    printf 'checksum mismatch for %s\n  expected %s\n  got      %s\n' "${CARGO_DIST_ARCHIVE:-$url}" "$sha" "$got" >&2
     exit 1
 fi
 
@@ -70,9 +88,15 @@ dest="${CARGO_HOME:-$HOME/.cargo}/bin"
 mkdir -p "$dest"
 if [[ "$ext" == zip ]]; then
     unzip -q -o "$archive" -d "$work"
-    install -m 0755 "${work}/${base}/dist.exe" "${dest}/dist.exe"
+    bin_name=dist.exe
 else
     tar -xJf "$archive" -C "$work"
-    install -m 0755 "${work}/${base}/dist" "${dest}/dist"
+    bin_name=dist
 fi
+bin="$(find "$work" -name "$bin_name" -type f -print -quit)"
+if [[ -z "$bin" ]]; then
+    printf 'cargo-dist archive has no %s\n' "$bin_name" >&2
+    exit 1
+fi
+install -m 0755 "$bin" "${dest}/${bin_name}"
 printf 'installed cargo-dist %s to %s\n' "$VER" "$dest"

--- a/scripts/test_install_cargo_dist.sh
+++ b/scripts/test_install_cargo_dist.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Regression tests for scripts/install_cargo_dist.sh.
+# Reproduces the v0.11.0 Release failures:
+#   aarch64-apple-darwin: sha256sum: command not found
+#   windows-msvc: install cannot stat nested dist.exe (zip is flat)
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+installer="$root/scripts/install_cargo_dist.sh"
+failed=0
+fail() { printf 'FAIL: %s\n' "$1" >&2; failed=1; }
+pass() { printf 'ok: %s\n' "$1"; }
+
+scratch="$(mktemp -d)"
+trap 'rm -rf "$scratch"' EXIT
+
+# --- hasher without sha256sum (macOS ARM runners) ---
+hash_bin="$scratch/hashpath"
+mkdir -p "$hash_bin"
+# Keep the tools the installer needs; omit sha256sum.
+for cmd in bash curl mktemp mkdir install tar unzip awk printf uname tr cat chmod rm ls find openssl xz xzcat; do
+    if p=$(command -v "$cmd"); then
+        ln -s "$p" "$hash_bin/$cmd"
+    fi
+done
+if p=$(command -v shasum); then
+    ln -s "$p" "$hash_bin/shasum"
+fi
+# A tiny local archive so this test does not depend on GitHub.
+payload="$scratch/payload"
+mkdir -p "$payload/cargo-dist-x86_64-unknown-linux-gnu"
+printf '#!/bin/sh\necho dist-ok\n' >"$payload/cargo-dist-x86_64-unknown-linux-gnu/dist"
+chmod +x "$payload/cargo-dist-x86_64-unknown-linux-gnu/dist"
+archive="$scratch/cargo-dist-x86_64-unknown-linux-gnu.tar.xz"
+tar -C "$payload" -cJf "$archive" cargo-dist-x86_64-unknown-linux-gnu
+want_sha="$(sha256sum "$archive" | awk '{print $1}')"
+
+home="$scratch/home-hash"
+mkdir -p "$home"
+set +e
+PATH="$hash_bin" HOME="$home" CARGO_HOME="$home/.cargo" \
+    SNAPPER_UNAME_S=Linux SNAPPER_UNAME_M=x86_64 \
+    CARGO_DIST_ARCHIVE="$archive" CARGO_DIST_SHA="$want_sha" \
+    bash "$installer" >"$scratch/hash.out" 2>"$scratch/hash.err"
+rc=$?
+set -e
+if [[ "$rc" -ne 0 ]]; then
+    fail "installer exits $rc when sha256sum is absent: $(tr '\n' ' ' <"$scratch/hash.err")"
+elif [[ ! -x "$home/.cargo/bin/dist" ]]; then
+    fail "hasher path did not install dist"
+else
+    pass "installer hashes without sha256sum"
+fi
+
+# --- flat Windows zip (real cargo-dist 0.30.3 layout) ---
+win_dir="$scratch/win"
+mkdir -p "$win_dir"
+printf 'MZ-fake\n' >"$win_dir/dist.exe"
+printf 'license\n' >"$win_dir/LICENSE-MIT"
+win_zip="$scratch/cargo-dist-x86_64-pc-windows-msvc.zip"
+python3 - "$win_dir" "$win_zip" <<'PY'
+import sys, zipfile
+from pathlib import Path
+src, dest = Path(sys.argv[1]), Path(sys.argv[2])
+with zipfile.ZipFile(dest, "w") as zf:
+    zf.write(src / "dist.exe", "dist.exe")
+    zf.write(src / "LICENSE-MIT", "LICENSE-MIT")
+PY
+win_sha="$(sha256sum "$win_zip" | awk '{print $1}')"
+home_win="$scratch/home-win"
+mkdir -p "$home_win"
+set +e
+SNAPPER_UNAME_S=MINGW64_NT-10.0 SNAPPER_UNAME_M=x86_64 \
+    CARGO_DIST_ARCHIVE="$win_zip" CARGO_DIST_SHA="$win_sha" \
+    HOME="$home_win" CARGO_HOME="$home_win/.cargo" \
+    bash "$installer" >"$scratch/win.out" 2>"$scratch/win.err"
+rc=$?
+set -e
+if [[ "$rc" -ne 0 ]]; then
+    fail "flat zip install exits $rc: $(tr '\n' ' ' <"$scratch/win.err")"
+elif [[ ! -f "$home_win/.cargo/bin/dist.exe" ]]; then
+    fail "flat zip did not install dist.exe to CARGO_HOME/bin (err=$(tr '\n' ' ' <"$scratch/win.err"))"
+else
+    pass "installer finds dist.exe at zip root"
+fi
+
+if [[ "$failed" -ne 0 ]]; then
+    exit 1
+fi
+printf 'all install_cargo_dist tests passed\n'


### PR DESCRIPTION
v0.11.0 Release failed at Install dist on two runners:

- aarch64-apple-darwin: `sha256sum: command not found` (exit 127)
- windows-msvc: `install: cannot stat .../cargo-dist-x86_64-pc-windows-msvc/dist.exe` (the 0.30.3 zip has `dist.exe` at the root)

crates.io and PyPI already have 0.11.0, so the tag stays. This hashes with `shasum` / `openssl` when `sha256sum` is missing, and finds `dist` / `dist.exe` wherever the archive put them.

`workflow_dispatch` on Release takes an existing tag so we can publish the GitHub assets and Homebrew formula from this commit without moving `v0.11.0`.
