### PR TITLE
fix(rst): keep list continuation paragraph hang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. See [conven
 - - -
 ## Unreleased (main)
 #### Bug Fixes
+- (**rst**) list continuation paragraphs after a blank keep their hanging indent, so a two-space second sentence is not outdented to column 0
 - (**rst**) definition lists (flush term plus indented definition) stay structure, so the term is not glued onto the definition line
 - (**rst**) simple tables (`=====  =====` column borders) stay structure, so header and body rows are not glued onto one line
 - (**ci**) `scripts/install_cargo_dist.sh` hashes with `shasum`/`openssl` when `sha256sum` is missing and finds `dist.exe` at the zip root (Windows cargo-dist layout)

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -30,6 +30,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut directive_indent: usize = 0;
     let mut in_definition = false;
     let mut definition_indent: usize = 0;
+    // Hang column of the current list item (`- ` → 2). Continuation
+    // paragraphs after a blank stay in the item when indented this far.
+    let mut list_hang: Option<usize> = None;
     let mut pragma_off = false;
 
     // Code-block directive bookkeeping. Mutually exclusive with `in_directive`.
@@ -243,6 +246,7 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // bullets are not glued onto one line.
         if let Some(marker_len) = rst_list_marker_len(line_text) {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            list_hang = Some(marker_len);
             regions.push(SpannedRegion::structure(
                 input,
                 ByteSpan::new(line.start, line.start + marker_len),
@@ -287,6 +291,27 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             in_definition = true;
             i += 1;
             continue;
+        }
+
+        // List continuation paragraph: after a list item, a later line
+        // indented to the hang (two spaces after `- `) is still the item.
+        // Hang spaces are Structure so splice does not outdent them.
+        if let Some(hang) = list_hang {
+            let leading = line_text.len() - line_text.trim_start().len();
+            if leading >= hang {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(
+                    input,
+                    ByteSpan::new(line.start, line.start + leading),
+                ));
+                if line_text.len() > leading {
+                    current_prose.push_str(line_text[leading..].trim());
+                    prose_span = Some(ByteSpan::new(line.start + leading, line.end));
+                }
+                i += 1;
+                continue;
+            }
+            list_hang = None;
         }
 
         // Regular prose
@@ -627,5 +652,57 @@ mod tests {
             let out = format_text(input, &cfg).unwrap();
             assert_eq!(out, input, "list must stay compact, got:\n{out}");
         }
+    }
+
+    #[test]
+    fn list_continuation_paragraph_keeps_hang_structure() {
+        let input = "- First sentence.\n\n  Second sentence.\n";
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "- ")),
+            "marker must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| { matches!(r, Region::Prose(s) if s.contains("First sentence.")) }),
+            "item text must be Prose, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "  ")),
+            "continuation hang must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| { matches!(r, Region::Prose(s) if s.contains("Second sentence.")) }),
+            "continuation text must be Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn reporter_list_continuation_paragraph_is_identity_under_format() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = "- First sentence.\n\n  Second sentence.\n";
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, input,
+            "list continuation paragraph must stay identity, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n  Second sentence."),
+            "continuation must keep two-space hang, got:\n{out}"
+        );
     }
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -807,6 +807,10 @@ fn hanging_prefix(s: &str) -> String {
     if is_quote_marker(s) {
         return s.to_string();
     }
+    // RST list continuation paragraphs emit the hang spaces as Structure.
+    if !s.is_empty() && !s.contains('\n') && s.bytes().all(|b| b == b' ') {
+        return s.to_string();
+    }
     let width = hanging_indent_width(s);
     if width > 0 {
         " ".repeat(width)
@@ -960,6 +964,8 @@ mod tests {
         assert_eq!(hanging_prefix("  > "), "  > ");
         assert_eq!(hanging_prefix("- "), "  ");
         assert_eq!(hanging_prefix("1. "), "   ");
+        assert_eq!(hanging_prefix("  "), "  ");
+        assert_eq!(hanging_indent_width("  "), 0);
         assert_eq!(hanging_indent_width("> "), 0);
         assert_eq!(hanging_indent_width("- "), 2);
     }
@@ -1398,6 +1404,8 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_prefix("  > "), "  > ");
         assert_eq!(hanging_prefix("- "), "  ");
         assert_eq!(hanging_prefix("1. "), "   ");
+        assert_eq!(hanging_prefix("  "), "  ");
+        assert_eq!(hanging_indent_width("  "), 0);
         assert_eq!(hanging_indent_width("\n"), 0);
         assert_eq!(hanging_indent_width("#+TITLE: Test\n"), 0);
         assert_eq!(hanging_indent_width("$x$"), 0);
@@ -1413,6 +1421,16 @@ They are endowed with reason and conscience and should act towards one another i
             Region::Structure("\n".to_string()),
         ]);
         assert_eq!(result, "- One.\n  Two.\n");
+    }
+
+    #[test]
+    fn space_hang_structure_continues_sentences() {
+        let result = reflow_regions(vec![
+            Region::Structure("  ".to_string()),
+            Region::Prose("Second. Third.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(result, "  Second.\n  Third.\n");
     }
 
     #[test]


### PR DESCRIPTION
A blank line plus a hanging paragraph after an RST list item was regular prose, so splice dropped the indent.

`src/parser/rst.rs` now keeps that continuation hanging under the item. The reporter fixture is identity under `Format::Rst`.

Closes #45
