### PR TITLE
fix(sentence): markup closer-split needs a real next sentence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. See [conven
 - - -
 ## Unreleased (main)
 #### Bug Fixes
+- (**sentence**) a period immediately before markup closers only starts a new sentence when the next token is a capital letter (or a quote then a capital), so plaintext `.`` "` is not split
 - (**rst**) list continuation paragraphs after a blank keep their hanging indent, so a two-space second sentence is not outdented to column 0
 - (**rst**) definition lists (flush term plus indented definition) stay structure, so the term is not glued onto the definition line
 - (**rst**) simple tables (`=====  =====` column borders) stay structure, so header and body rows are not glued onto one line

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -830,7 +830,7 @@ fn take_markup_terminal_sentence(seg: &str) -> Option<(String, String)> {
     // sentence.
     static CAP: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r#"(?s)^(.*?[.!?](?:\*{1,3}|_{1,3}|`+|~{1,2}|\]\([^)]*\))+)\s+(["'A-Z][\s\S]*)$"#,
+            r#"(?s)^(.*?[.!?](?:\*{1,3}|_{1,3}|`+|~{1,2}|\]\([^)]*\))+)\s+([A-Z][\s\S]*|["'][A-Z][\s\S]*)$"#,
         )
         .expect("valid markup-terminal sentence regex")
     });
@@ -1784,6 +1784,16 @@ mod tests {
                 "Then read more.".to_string()
             ]
         );
+        assert_eq!(
+            split("**Bold sentence.** \"Quoted next.\""),
+            vec![
+                "**Bold sentence.**".to_string(),
+                "\"Quoted next.\"".to_string()
+            ]
+        );
+        // PR #52 CI seed: period before backticks, then quote-backtick.
+        // Next token is not a capital letter, so this is not a new sentence.
+        assert_eq!(split("`.`` \"`"), vec!["`.`` \"`".to_string()]);
     }
 
     #[test]

--- a/tests/sentence_delim_props.rs
+++ b/tests/sentence_delim_props.rs
@@ -20,6 +20,19 @@ fn plaintext_cfg() -> FormatConfig {
     .without_safety_backstops()
 }
 
+/// PR #52 CI seed: period before backticks, then quote-backtick.
+/// Markup closer-split must not invent a newline inside a DelimState span.
+#[test]
+fn plaintext_period_before_backticks_quote_is_span_safe() {
+    let input = ".`` \"`";
+    let out = format_plain(input);
+    assert_eq!(format_plain(&out), out, "idempotence");
+    assert!(
+        newlines_respect_delimiter_spans(&out),
+        "span newline\n in={input:?}\n out={out:?}"
+    );
+}
+
 fn format_plain(input: &str) -> String {
     let mut s = input.to_string();
     if !s.ends_with('\n') {


### PR DESCRIPTION
PR #52 CI failed `proptest_plaintext_idempotent_and_span_safe` on `.`` "`.

`split_after_markup_sentence_end` treated any `["'A-Z]` after a markup closer as a new sentence. A quote that is not followed by a capital is not a new sentence. `**Bold sentence.** Next` and `**Bold sentence.** "Quoted next."` still split.

This is snapper-wd37. It is not the RST comment bug; it unblocks the #52 check job.

