### PR TITLE
feat(pandoc): write reflowed AST through pandoc writer

### DIFF
--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -11,6 +11,7 @@ The pandoc path is **parse with pandoc, then apply snapper** — not “guess ma
 1. Pandoc reads the file (any format it supports) into its document AST.
 2. Snapper walks that AST and reflows only prose-bearing nodes (=Para= / =Plain=).
 3. Nodes pandoc already classified as structure (=Header=, =CodeBlock=, =Table=, …) are left alone.
+4. The mutated AST is written through pandoc's writer (=pandoc -f json --wrap=preserve=). This is not a splice of the original bytes.
 
 That is how snapper can format everything pandoc can read (typst, asciidoc, docx, html, …) without inventing per-format line heuristics.
 

--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -11,7 +11,8 @@ The pandoc path is **parse with pandoc, then apply snapper** — not “guess ma
 1. Pandoc reads the file (any format it supports) into its document AST.
 2. Snapper walks that AST and reflows only prose-bearing nodes (=Para= / =Plain=).
 3. Nodes pandoc already classified as structure (=Header=, =CodeBlock=, =Table=, …) are left alone.
-4. The mutated AST is written through pandoc's writer (=pandoc -f json --wrap=preserve=). This is not a splice of the original bytes.
+4. The mutated AST is written through pandoc's writer (=pandoc -f json --wrap=preserve=).
+This is not a splice of the original bytes.
 
 That is how snapper can format everything pandoc can read (typst, asciidoc, docx, html, …) without inventing per-format line heuristics.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -152,8 +152,9 @@ impl Default for FormatConfig {
 #[error("input is not valid UTF-8")]
 pub struct InvalidUtf8Error;
 
-/// Pandoc's AST has no source offsets, so it cannot splice into original
-/// bytes. `format_text` refuses rather than reconstruct.
+/// Historical: the pandoc path used to refuse because the AST has no
+/// source offsets. `format_text` now writes the reflowed AST through
+/// pandoc's writer instead of splicing original bytes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 #[error("pandoc backend cannot splice original source bytes")]
 pub struct PandocCannotSplice;
@@ -268,30 +269,38 @@ pub fn format_text_with_splitter(
         input
     };
 
-    let once = format_once(work_input, config, splitter, config.format_code)?;
-    // Later passes prove prose stability. External code formatters
-    // already ran on the first pass; re-invoking them multiplies
-    // timeout budgets and is not part of the planner fixpoint.
-    let candidate = run_fixpoint(work_input, config.fixpoint_backstop, |cur| {
-        if cur == work_input {
-            Ok(once.clone())
-        } else {
-            format_once(cur, config, splitter, false)
-        }
-    })?;
-
-    let candidate = if config.render_backstop
-        && candidate != work_input
-        && !oracle::matches_ex(
-            config.format,
-            work_input,
-            &candidate,
-            config.format_code,
-            Some(config),
-        ) {
-        work_input.to_string()
+    // The pandoc writer is not a native splice: it normalizes markup, so
+    // the native region-tree oracle and byte fixpoint would veto a correct
+    // write-through and return the original (no sentence breaks).
+    let candidate = if config.use_pandoc {
+        format_once(work_input, config, splitter, config.format_code)?
     } else {
-        candidate
+        let once = format_once(work_input, config, splitter, config.format_code)?;
+        // Later passes prove prose stability. External code formatters
+        // already ran on the first pass; re-invoking them multiplies
+        // timeout budgets and is not part of the planner fixpoint.
+        let candidate = run_fixpoint(work_input, config.fixpoint_backstop, |cur| {
+            if cur == work_input {
+                Ok(once.clone())
+            } else {
+                format_once(cur, config, splitter, false)
+            }
+        })?;
+
+        if config.render_backstop
+            && candidate != work_input
+            && !oracle::matches_ex(
+                config.format,
+                work_input,
+                &candidate,
+                config.format_code,
+                Some(config),
+            )
+        {
+            work_input.to_string()
+        } else {
+            candidate
+        }
     };
 
     let mut output = candidate;
@@ -314,7 +323,7 @@ pub fn format_text_with_splitter(
 }
 
 /// One parse+reflow pass. Native parsers splice into original bytes;
-/// pandoc concatenates reconstructed regions.
+/// pandoc reflows the AST and writes through pandoc's writer.
 fn format_once(
     work_input: &str,
     config: &FormatConfig,
@@ -333,7 +342,7 @@ fn format_once(
     };
 
     // Two pipelines:
-    // - use_pandoc: pandoc parses source → AST → regions by node kind → reflow prose only.
+    // - use_pandoc: parse → reflow Para/Plain in the AST → pandoc writer.
     // - else: native line parsers (markdown/org/…) then splice. Never mixed after success.
     if config.use_pandoc {
         #[cfg(feature = "pandoc")]
@@ -348,14 +357,14 @@ fn format_once(
                     Format::Rst => "rst",
                     Format::Plaintext => "markdown",
                 });
-            let parser =
-                parser::pandoc::PandocParser::with_backend(pandoc_fmt, config.pandoc_backend);
-            // Surface parse errors (no silent all-prose). Splice still
-            // requires source offsets the AST does not carry.
-            parser
-                .try_parse(work_input)
-                .map_err(|e| anyhow::anyhow!("{e}"))?;
-            return Err(anyhow::Error::new(PandocCannotSplice));
+            return parser::pandoc::format_via_pandoc(
+                work_input,
+                pandoc_fmt,
+                config.pandoc_backend,
+                splitter,
+                &reflow_config,
+            )
+            .map_err(|e| anyhow::anyhow!("{e}"));
         }
         #[cfg(not(feature = "pandoc"))]
         {

--- a/src/parser/pandoc/ast.rs
+++ b/src/parser/pandoc/ast.rs
@@ -315,7 +315,7 @@ fn cell_text(cell: &Cell) -> String {
 
 /// True when the para is only math (and ignorable space/breaks) — display or
 /// bare math blocks that must not go through the sentence reflower.
-fn is_math_only_para(inlines: &[Inline]) -> bool {
+pub(super) fn is_math_only_para(inlines: &[Inline]) -> bool {
     let mut saw_math = false;
     for inline in inlines {
         match inline {
@@ -327,7 +327,7 @@ fn is_math_only_para(inlines: &[Inline]) -> bool {
     saw_math
 }
 
-fn format_math(ty: &MathType, body: &str) -> String {
+pub(super) fn format_math(ty: &MathType, body: &str) -> String {
     match ty {
         MathType::DisplayMath => {
             // Keep payload as structure; delimiters are not source-faithful, only non-prose.

--- a/src/parser/pandoc/mod.rs
+++ b/src/parser/pandoc/mod.rs
@@ -1,4 +1,4 @@
-//! Pandoc parses first; snapper reflows second.
+//! Pandoc parses first; snapper reflows second; pandoc writes third.
 //!
 //! For any format pandoc can read:
 //! 1. **Parse** the source with pandoc → document AST (JSON via CLI, or
@@ -6,19 +6,25 @@
 //! 2. **Apply** snapper only to prose-bearing nodes (`Para` / `Plain`); leave
 //!    `Header`, `CodeBlock`, `Table`, etc. alone because the AST says they are
 //!    not prose.
+//! 3. **Write** the mutated AST through pandoc's writer (`pandoc -f json
+//!    --wrap=preserve`). Do not splice original source bytes.
 //!
 //! That is the opposite of the native path (guess structure from source lines,
-//! then reflow). Here pandoc owns structure; snapper owns sentence line breaks
+//! then splice). Here pandoc owns structure; snapper owns sentence line breaks
 //! on the prose leaves.
 //!
 //! Backends that produce the same AST for [`ast::regions_from_pandoc`]:
 //! - **CLI** ([`PandocBackend::Cli`]): `pandoc -t json` (full installed readers).
 //! - **FFI** ([`PandocBackend::Ffi`]): `libsnapper_pandoc` (linked library readers).
+//!
+//! The writer is always the CLI (`libsnapper_pandoc` is reader-only).
 
 pub mod ast;
 pub mod cache;
 pub mod cli;
 pub mod ffi;
+pub mod reflow;
+pub mod write;
 
 use std::path::Path;
 use std::str::FromStr;
@@ -30,6 +36,8 @@ use crate::parser::{FormatParser, Region};
 pub use ast::{regions_from_pandoc, regions_from_pandoc_json};
 pub use cli::pandoc_cli_available as pandoc_available;
 pub use ffi::ffi_available;
+pub use reflow::reflow_pandoc;
+pub use write::write_via_cli;
 
 /// How to obtain the pandoc AST.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -121,6 +129,50 @@ pub fn parse_with_backend(
         cache::put_json(format, input, &json);
     }
     Ok(regions)
+}
+
+/// Obtain pandoc JSON for `(format, input)` (cache, then FFI or CLI).
+pub fn json_with_backend(
+    input: &str,
+    format: &str,
+    backend: PandocBackend,
+) -> Result<String, PandocError> {
+    if let Some(json) = cache::get_json(format, input) {
+        return Ok(json.as_ref().to_string());
+    }
+    let json = match backend.resolve() {
+        PandocBackend::Auto => unreachable!("resolve collapses Auto"),
+        PandocBackend::Ffi => {
+            let (_regs, json) = ffi::parse_via_ffi_with_json(input, format)?;
+            json
+        }
+        PandocBackend::Cli => {
+            let (_regs, json) = cli::parse_via_cli_with_json(input, format)?;
+            json
+        }
+    };
+    cache::put_json(format, input, &json);
+    Ok(json)
+}
+
+/// Parse → reflow Para/Plain → write through pandoc's writer.
+///
+/// Not a splice of the original bytes. The writer needs a `pandoc` binary
+/// even when parse used FFI (`libsnapper_pandoc` has no writers).
+pub fn format_via_pandoc(
+    input: &str,
+    format: &str,
+    backend: PandocBackend,
+    splitter: &dyn crate::sentence::SentenceSplitter,
+    reflow_config: &crate::reflow::ReflowConfig,
+) -> Result<String, PandocError> {
+    let json = json_with_backend(input, format, backend)?;
+    let mut doc: pandoc_ast::Pandoc =
+        serde_json::from_str(&json).map_err(|e| PandocError::Ast(e.to_string()))?;
+    reflow_pandoc(&mut doc, splitter, reflow_config);
+    let out_json =
+        serde_json::to_string(&doc).map_err(|e| PandocError::Ast(format!("serialize AST: {e}")))?;
+    write_via_cli(&out_json, format).map_err(PandocError::from)
 }
 
 /// Parser that uses pandoc for universal format support.

--- a/src/parser/pandoc/reflow.rs
+++ b/src/parser/pandoc/reflow.rs
@@ -1,0 +1,455 @@
+//! Reflow Para/Plain in a pandoc AST. Other node kinds stay structure.
+//!
+//! Sentence (and optional wrap) breaks become `SoftBreak` inlines. The
+//! writer (`--wrap=preserve`) turns those into source line breaks. Math
+//! and inline Code are masked so their periods cannot end a sentence.
+
+use pandoc_ast::{Block, Inline, Pandoc};
+
+use super::ast::{format_math, is_math_only_para};
+use crate::reflow::{ReflowConfig, wrap_sentence_plain};
+use crate::sentence::SentenceSplitter;
+
+/// Insert sentence/wrap SoftBreaks into every prose Para/Plain.
+///
+/// `Header`, `CodeBlock`, `Table`, and `LineBlock` are left untouched.
+/// Lists, quotes, definition bodies, Div, and Figure keep their node
+/// kind; nested Para/Plain still get sentence breaks.
+pub fn reflow_pandoc(doc: &mut Pandoc, splitter: &dyn SentenceSplitter, config: &ReflowConfig) {
+    reflow_blocks(&mut doc.blocks, splitter, config, false);
+}
+
+fn reflow_blocks(
+    blocks: &mut [Block],
+    splitter: &dyn SentenceSplitter,
+    config: &ReflowConfig,
+    in_table: bool,
+) {
+    for block in blocks {
+        match block {
+            Block::Para(inlines) | Block::Plain(inlines) => {
+                if in_table || is_math_only_para(inlines) {
+                    continue;
+                }
+                *inlines = reflow_inlines(std::mem::take(inlines), splitter, config);
+            }
+            Block::Header(..) | Block::CodeBlock(..) | Block::RawBlock(..) | Block::Null => {}
+            Block::LineBlock(_) | Block::HorizontalRule => {}
+            Block::BlockQuote(inner) | Block::Div(_, inner) | Block::Figure(_, _, inner) => {
+                reflow_blocks(inner, splitter, config, in_table);
+            }
+            Block::BulletList(items) | Block::OrderedList(_, items) => {
+                for item in items {
+                    reflow_blocks(item, splitter, config, in_table);
+                }
+            }
+            Block::DefinitionList(defs) => {
+                for (_term, definitions) in defs {
+                    for def in definitions {
+                        reflow_blocks(def, splitter, config, in_table);
+                    }
+                }
+            }
+            Block::Table(_attr, _caption, _cols, head, bodies, foot) => {
+                let (_hattr, head_rows) = head;
+                for row in head_rows {
+                    reflow_table_row(row, splitter, config);
+                }
+                for body in bodies {
+                    let (_battr, _rhc, intermediate, body_rows) = body;
+                    for row in intermediate {
+                        reflow_table_row(row, splitter, config);
+                    }
+                    for row in body_rows {
+                        reflow_table_row(row, splitter, config);
+                    }
+                }
+                let (_fattr, foot_rows) = foot;
+                for row in foot_rows {
+                    reflow_table_row(row, splitter, config);
+                }
+            }
+        }
+    }
+}
+
+fn reflow_table_row(
+    _row: &mut pandoc_ast::Row,
+    _splitter: &dyn SentenceSplitter,
+    _config: &ReflowConfig,
+) {
+    // Table stays structure: cell Paras are not sentence-split.
+}
+
+fn reflow_inlines(
+    inlines: Vec<Inline>,
+    splitter: &dyn SentenceSplitter,
+    config: &ReflowConfig,
+) -> Vec<Inline> {
+    if inlines.is_empty() {
+        return inlines;
+    }
+    let masked = mask_protected(&inlines);
+    if masked.chars().all(|c| c.is_whitespace()) {
+        return inlines;
+    }
+    let breaks = break_offsets(&masked, splitter, config);
+    if breaks.is_empty() {
+        return inlines;
+    }
+    let mut out = Vec::with_capacity(inlines.len() + breaks.len());
+    let mut pos = 0usize;
+    let mut bi = 0usize;
+    insert_breaks(inlines, &mut pos, &breaks, &mut bi, &mut out);
+    while bi < breaks.len() && breaks[bi] == pos {
+        push_soft_break(&mut out);
+        bi += 1;
+    }
+    out
+}
+
+/// Flatten like [`inlines_to_string`], but Math/Code become `X` of the same
+/// width so periods inside them cannot end a sentence.
+fn mask_protected(inlines: &[Inline]) -> String {
+    let mut out = String::new();
+    mask_into(inlines, &mut out);
+    out
+}
+
+fn mask_into(inlines: &[Inline], out: &mut String) {
+    for inline in inlines {
+        match inline {
+            Inline::Str(s) => out.push_str(s),
+            Inline::Space | Inline::SoftBreak => out.push(' '),
+            Inline::LineBreak => out.push('\n'),
+            Inline::Code(_, code) => {
+                let n = 2 + code.len();
+                out.extend(std::iter::repeat_n('X', n));
+            }
+            Inline::Math(ty, body) => {
+                let n = format_math(ty, body).len();
+                out.extend(std::iter::repeat_n('X', n));
+            }
+            Inline::Emph(c)
+            | Inline::Strong(c)
+            | Inline::Underline(c)
+            | Inline::Strikeout(c)
+            | Inline::Superscript(c)
+            | Inline::Subscript(c)
+            | Inline::SmallCaps(c)
+            | Inline::Quoted(_, c)
+            | Inline::Span(_, c)
+            | Inline::Cite(_, c)
+            | Inline::Link(_, c, _)
+            | Inline::Image(_, c, _) => mask_into(c, out),
+            Inline::RawInline(_, raw) => out.push_str(raw),
+            Inline::Note(_) => {}
+        }
+    }
+}
+
+fn break_offsets(text: &str, splitter: &dyn SentenceSplitter, config: &ReflowConfig) -> Vec<usize> {
+    let sentences = splitter.split(text);
+    if sentences.len() < 2 && config.max_width == 0 && !config.clause_breaks {
+        return Vec::new();
+    }
+    let mut breaks = Vec::new();
+    let mut cur = 0usize;
+    let nsent = sentences.len();
+    for (i, sent) in sentences.iter().enumerate() {
+        let needle = sent.trim();
+        if needle.is_empty() {
+            continue;
+        }
+        let Some(rel) = text.get(cur..).and_then(|rest| rest.find(needle)) else {
+            continue;
+        };
+        let start = cur + rel;
+        let end = start + needle.len();
+        if config.max_width > 0 || config.clause_breaks {
+            let wrapped = wrap_sentence_plain(
+                needle,
+                config.max_width,
+                config.clause_breaks,
+                config.format,
+            );
+            let mut off = start;
+            let parts: Vec<&str> = wrapped.split('\n').collect();
+            for (j, part) in parts.iter().enumerate() {
+                let p = part.trim_start();
+                if !p.is_empty() {
+                    if let Some(r) = text.get(off..end).and_then(|rest| rest.find(p)) {
+                        off = off + r + p.len();
+                    } else {
+                        off = (off + p.len()).min(end);
+                    }
+                }
+                if j + 1 < parts.len() && off > start && off < end {
+                    breaks.push(off);
+                }
+            }
+        }
+        if i + 1 < nsent {
+            breaks.push(end);
+        }
+        cur = end;
+    }
+    breaks.sort_unstable();
+    breaks.dedup();
+    breaks
+}
+
+fn insert_breaks(
+    inlines: Vec<Inline>,
+    pos: &mut usize,
+    breaks: &[usize],
+    bi: &mut usize,
+    out: &mut Vec<Inline>,
+) {
+    for inline in inlines {
+        flush_breaks_at(*pos, breaks, bi, out);
+        match inline {
+            Inline::Str(s) => emit_str(s, pos, breaks, bi, out),
+            Inline::Space | Inline::SoftBreak => {
+                let start = *pos;
+                *pos += 1;
+                if *bi < breaks.len() && (breaks[*bi] == start || breaks[*bi] == *pos) {
+                    push_soft_break(out);
+                    *bi += 1;
+                    while *bi < breaks.len() && breaks[*bi] == *pos {
+                        *bi += 1;
+                    }
+                } else {
+                    out.push(Inline::Space);
+                }
+            }
+            Inline::LineBreak => {
+                *pos += 1;
+                out.push(Inline::LineBreak);
+            }
+            Inline::Code(attr, code) => {
+                let n = 2 + code.len();
+                emit_protected(Inline::Code(attr, code), n, pos, breaks, bi, out);
+            }
+            Inline::Math(ty, body) => {
+                let n = format_math(&ty, &body).len();
+                emit_protected(Inline::Math(ty, body), n, pos, breaks, bi, out);
+            }
+            Inline::Emph(c) => emit_container(c, pos, breaks, bi, out, Inline::Emph),
+            Inline::Strong(c) => emit_container(c, pos, breaks, bi, out, Inline::Strong),
+            Inline::Underline(c) => emit_container(c, pos, breaks, bi, out, Inline::Underline),
+            Inline::Strikeout(c) => emit_container(c, pos, breaks, bi, out, Inline::Strikeout),
+            Inline::Superscript(c) => emit_container(c, pos, breaks, bi, out, Inline::Superscript),
+            Inline::Subscript(c) => emit_container(c, pos, breaks, bi, out, Inline::Subscript),
+            Inline::SmallCaps(c) => emit_container(c, pos, breaks, bi, out, Inline::SmallCaps),
+            Inline::Quoted(q, c) => {
+                let mut inner = Vec::new();
+                insert_breaks(c, pos, breaks, bi, &mut inner);
+                out.push(Inline::Quoted(q, inner));
+            }
+            Inline::Span(attr, c) => {
+                let mut inner = Vec::new();
+                insert_breaks(c, pos, breaks, bi, &mut inner);
+                out.push(Inline::Span(attr, inner));
+            }
+            Inline::Cite(cite, c) => {
+                let mut inner = Vec::new();
+                insert_breaks(c, pos, breaks, bi, &mut inner);
+                out.push(Inline::Cite(cite, inner));
+            }
+            Inline::Link(attr, c, target) => {
+                let mut inner = Vec::new();
+                insert_breaks(c, pos, breaks, bi, &mut inner);
+                out.push(Inline::Link(attr, inner, target));
+            }
+            Inline::Image(attr, c, target) => {
+                let mut inner = Vec::new();
+                insert_breaks(c, pos, breaks, bi, &mut inner);
+                out.push(Inline::Image(attr, inner, target));
+            }
+            Inline::RawInline(fmt, raw) => {
+                emit_str_at(raw, pos, breaks, bi, out, |s| {
+                    Inline::RawInline(fmt.clone(), s)
+                });
+            }
+            Inline::Note(note) => out.push(Inline::Note(note)),
+        }
+    }
+}
+
+fn emit_container<F>(
+    children: Vec<Inline>,
+    pos: &mut usize,
+    breaks: &[usize],
+    bi: &mut usize,
+    out: &mut Vec<Inline>,
+    wrap: F,
+) where
+    F: FnOnce(Vec<Inline>) -> Inline,
+{
+    let mut inner = Vec::new();
+    insert_breaks(children, pos, breaks, bi, &mut inner);
+    out.push(wrap(inner));
+}
+
+fn emit_protected(
+    inline: Inline,
+    width: usize,
+    pos: &mut usize,
+    breaks: &[usize],
+    bi: &mut usize,
+    out: &mut Vec<Inline>,
+) {
+    let start = *pos;
+    let end = start + width;
+    while *bi < breaks.len() && breaks[*bi] > start && breaks[*bi] < end {
+        *bi += 1;
+    }
+    flush_breaks_at(start, breaks, bi, out);
+    out.push(inline);
+    *pos = end;
+    flush_breaks_at(end, breaks, bi, out);
+}
+
+fn emit_str(s: String, pos: &mut usize, breaks: &[usize], bi: &mut usize, out: &mut Vec<Inline>) {
+    emit_str_at(s, pos, breaks, bi, out, Inline::Str);
+}
+
+fn emit_str_at<F>(
+    s: String,
+    pos: &mut usize,
+    breaks: &[usize],
+    bi: &mut usize,
+    out: &mut Vec<Inline>,
+    wrap: F,
+) where
+    F: Fn(String) -> Inline,
+{
+    let start = *pos;
+    let len = s.len();
+    let end = start + len;
+    let mut last = 0usize;
+    while *bi < breaks.len() && breaks[*bi] < end {
+        let at = breaks[*bi];
+        if at < start {
+            *bi += 1;
+            continue;
+        }
+        let rel = at - start;
+        if rel > last {
+            if let Some(chunk) = s.get(last..rel) {
+                if !chunk.is_empty() {
+                    out.push(wrap(chunk.to_string()));
+                }
+            }
+        }
+        push_soft_break(out);
+        *bi += 1;
+        last = rel;
+        while last < len && s.as_bytes()[last].is_ascii_whitespace() {
+            last += 1;
+        }
+    }
+    if last < len {
+        out.push(wrap(s[last..].to_string()));
+    }
+    *pos = end;
+}
+
+fn flush_breaks_at(at: usize, breaks: &[usize], bi: &mut usize, out: &mut Vec<Inline>) {
+    while *bi < breaks.len() && breaks[*bi] == at {
+        push_soft_break(out);
+        *bi += 1;
+    }
+}
+
+fn push_soft_break(out: &mut Vec<Inline>) {
+    if matches!(out.last(), Some(Inline::Space | Inline::SoftBreak)) {
+        out.pop();
+    }
+    if !matches!(out.last(), Some(Inline::SoftBreak)) {
+        out.push(Inline::SoftBreak);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::format::Format;
+    use crate::sentence::unicode::UnicodeSentenceSplitter;
+    use pandoc_ast::Block;
+
+    fn flat(inlines: &[Inline]) -> String {
+        format!("{inlines:?}")
+    }
+
+    fn cfg() -> ReflowConfig<'static> {
+        ReflowConfig {
+            format: Format::Markdown,
+            ..ReflowConfig::default()
+        }
+    }
+
+    fn para_from(text: &str) -> Pandoc {
+        let json = regions_json_para(text);
+        serde_json::from_str(&json).expect("tiny pandoc")
+    }
+
+    fn regions_json_para(text: &str) -> String {
+        // Minimal pandoc JSON: one Para of a single Str.
+        format!(
+            r#"{{"pandoc-api-version":[1,23,1],"meta":{{}},"blocks":[{{"t":"Para","c":[{{"t":"Str","c":{}}}]}}]}}"#,
+            serde_json::to_string(text).unwrap()
+        )
+    }
+
+    #[test]
+    fn reflow_inserts_softbreak_between_sentences() {
+        let mut doc = para_from("Hello world. Second sentence.");
+        let splitter = UnicodeSentenceSplitter::new();
+        reflow_pandoc(&mut doc, &splitter, &cfg());
+        match &doc.blocks[0] {
+            Block::Para(inlines) => {
+                assert!(
+                    inlines.iter().any(|i| matches!(i, Inline::SoftBreak)),
+                    "expected SoftBreak in {inlines:?}"
+                );
+                let flat = flat(inlines);
+                assert!(flat.contains("Hello world."));
+                assert!(flat.contains("Second sentence."));
+            }
+            other => panic!("expected Para, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn reflow_leaves_header_and_codeblock() {
+        let json = include_str!("../../../tests/fixtures/pandoc_ast/mixed_minimal.json");
+        let mut doc: Pandoc = serde_json::from_str(json).expect("fixture");
+        let before: Vec<String> = doc
+            .blocks
+            .iter()
+            .filter_map(|b| match b {
+                Block::Header(l, _, ins) => Some(format!("H{l}:{}", flat(ins))),
+                Block::CodeBlock(_, c) => Some(format!("C:{c}")),
+                _ => None,
+            })
+            .collect();
+        let splitter = UnicodeSentenceSplitter::new();
+        reflow_pandoc(&mut doc, &splitter, &cfg());
+        let after: Vec<String> = doc
+            .blocks
+            .iter()
+            .filter_map(|b| match b {
+                Block::Header(l, _, ins) => Some(format!("H{l}:{}", flat(ins))),
+                Block::CodeBlock(_, c) => Some(format!("C:{c}")),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(before, after);
+        assert!(
+            doc.blocks.iter().any(|b| matches!(b, Block::Table(..))),
+            "table node must remain"
+        );
+    }
+}

--- a/src/parser/pandoc/write.rs
+++ b/src/parser/pandoc/write.rs
@@ -1,0 +1,60 @@
+//! Write a pandoc JSON AST through the installed pandoc writer.
+//!
+//! The FFI library is reader-only. Reconstruction of source bytes is
+//! impossible (no offsets) and is not attempted: `pandoc -f json -t <format>
+//! --wrap=preserve` owns emission. SoftBreaks inserted by AST reflow become
+//! sentence line breaks.
+
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use super::cli::CliError;
+
+/// Render `json` (a pandoc AST) as `format` via the CLI writer.
+pub fn write_via_cli(json: &str, format: &str) -> Result<String, CliError> {
+    let mut child = Command::new("pandoc")
+        .args(["-f", "json", "-t", format, "--wrap=preserve"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| CliError::Spawn(e.to_string()))?;
+
+    if let Some(ref mut stdin) = child.stdin {
+        stdin
+            .write_all(json.as_bytes())
+            .map_err(|e| CliError::Spawn(format!("write stdin: {e}")))?;
+    }
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| CliError::Spawn(e.to_string()))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CliError::Exit(format!(
+            "writer status {}: {stderr}",
+            output.status
+        )));
+    }
+
+    String::from_utf8(output.stdout)
+        .map_err(|e| CliError::InvalidAst(format!("writer stdout not UTF-8: {e}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parser::pandoc::cli::pandoc_cli_available;
+
+    #[test]
+    fn writer_empty_json_is_explicit_error_or_empty() {
+        if !pandoc_cli_available() {
+            return;
+        }
+        let err = write_via_cli("not-json", "markdown").unwrap_err();
+        match err {
+            CliError::Exit(_) | CliError::Spawn(_) | CliError::InvalidAst(_) => {}
+        }
+    }
+}

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -321,6 +321,22 @@ pub fn wrap_with_clause_breaks(sentence: &str, max_width: usize) -> String {
     )
 }
 
+/// Wrap one sentence with no hanging indent (pandoc AST reflow).
+pub(crate) fn wrap_sentence_plain(
+    sentence: &str,
+    max_width: usize,
+    clause_breaks: bool,
+    format: Format,
+) -> String {
+    wrap_prose(
+        sentence,
+        max_width,
+        clause_breaks,
+        format,
+        WrapLayout::default(),
+    )
+}
+
 #[derive(Default)]
 struct WrapLayout<'a> {
     /// Columns already occupied on the first emitted line (list marker).

--- a/tests/pandoc_ast_backend.rs
+++ b/tests/pandoc_ast_backend.rs
@@ -12,13 +12,22 @@ use snapper_fmt::parser::Region;
 use snapper_fmt::parser::pandoc::{
     PandocBackend, PandocParser, ffi_available, regions_from_pandoc_json,
 };
-use snapper_fmt::{FormatConfig, PandocCannotSplice, format_text};
+use snapper_fmt::{FormatConfig, format_text};
 
-fn assert_pandoc_refuses(input: &str, cfg: &FormatConfig) {
-    let err = format_text(input, cfg).expect_err("pandoc must refuse splice");
+/// Writer is CLI-only (`libsnapper_pandoc` has no writers).
+fn require_writer() -> bool {
+    if snapper_fmt::parser::pandoc::pandoc_available() {
+        true
+    } else {
+        eprintln!("skipping: pandoc CLI not on PATH (writer)");
+        false
+    }
+}
+
+fn assert_has_sentence_break(out: &str, first: &str, second_substr: &str) {
     assert!(
-        err.downcast_ref::<PandocCannotSplice>().is_some(),
-        "expected PandocCannotSplice, got {err:?}"
+        out.contains(&format!("{first}\n")) && out.contains(second_substr),
+        "expected sentence break after {first:?} before {second_substr:?}:\n{out}"
     );
 }
 
@@ -127,8 +136,7 @@ fn snapper_cli_ffi_bad_lib_is_explicit_error() {
 
 #[test]
 fn format_text_cli_backend_stable_across_two_runs_when_pandoc_present() {
-    if !snapper_fmt::parser::pandoc::pandoc_available() {
-        eprintln!("skipping: pandoc CLI not on PATH");
+    if !require_writer() {
         return;
     }
     let input = read_fixture("mixed.md");
@@ -139,7 +147,17 @@ fn format_text_cli_backend_stable_across_two_runs_when_pandoc_present() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    assert_pandoc_refuses(&input, &cfg);
+    let a = format_text(&input, &cfg).expect("pandoc write");
+    let b = format_text(&input, &cfg).expect("pandoc write 2");
+    assert_eq!(a, b, "writer must be deterministic");
+    assert_has_sentence_break(&a, "Hello world.", "Second sentence");
+    assert!(a.contains("```") && a.contains("print(1)"), "code:\n{a}");
+    assert!(
+        a.contains('a') && a.contains('b') && a.contains("---"),
+        "table cells stay structure:\n{a}"
+    );
+    assert!(a.contains("Title"), "header:\n{a}");
+    assert_ne!(a, input, "write-through is not a byte splice");
 }
 
 #[test]
@@ -173,6 +191,9 @@ fn format_text_ffi_live_stable_when_lib_present() {
         eprintln!("skipping live FFI: libsnapper_pandoc not loadable");
         return;
     }
+    if !require_writer() {
+        return;
+    }
     let input = read_fixture("mixed.md");
     let cfg = FormatConfig {
         format: Format::Markdown,
@@ -181,7 +202,10 @@ fn format_text_ffi_live_stable_when_lib_present() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    assert_pandoc_refuses(&input, &cfg);
+    let a = format_text(&input, &cfg).expect("ffi parse + cli write");
+    let b = format_text(&input, &cfg).expect("ffi parse + cli write 2");
+    assert_eq!(a, b);
+    assert_has_sentence_break(&a, "Hello world.", "Second sentence");
 }
 
 /// Pandoc parse first: Header node → Structure; title never Prose (no reflow).
@@ -220,18 +244,17 @@ fn numbered_heading_after_pandoc_parse_not_prose() {
     );
 }
 
-/// Pandoc has no source offsets, so format_text refuses rather than
-/// reconstruct (and rather than drop `###` from ATX lines).
+/// Pandoc writes the reflowed AST; the heading stays one Header (not prose).
 #[test]
-fn format_text_pandoc_refuses_numbered_heading() {
+fn format_text_pandoc_writes_numbered_heading() {
+    if !require_writer() {
+        return;
+    }
     let input = read_fixture("numbered_heading.md");
     let backend = if ffi_available() {
         PandocBackend::Ffi
-    } else if snapper_fmt::parser::pandoc::pandoc_available() {
-        PandocBackend::Cli
     } else {
-        eprintln!("skipping: neither FFI lib nor pandoc CLI available");
-        return;
+        PandocBackend::Cli
     };
     let cfg = FormatConfig {
         format: Format::Markdown,
@@ -240,7 +263,17 @@ fn format_text_pandoc_refuses_numbered_heading() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    assert_pandoc_refuses(&input, &cfg);
+    let out = format_text(&input, &cfg).expect("pandoc write");
+    assert_has_sentence_break(&out, "Hello world.", "Second sentence");
+    assert!(
+        out.contains("cargo binstall"),
+        "header title survives:\n{out}"
+    );
+    assert!(
+        !out.lines()
+            .any(|l| l.trim() == "1." || l.trim() == "### 1."),
+        "header must not be sentence-split:\n{out}"
+    );
     let native = format_text(
         &input,
         &FormatConfig {
@@ -262,14 +295,14 @@ fn format_text_pandoc_refuses_numbered_heading() {
 /// Math + code: display/inline math and CodeBlock not sentence-reflowed.
 #[test]
 fn format_text_pandoc_math_and_code_protected() {
+    if !require_writer() {
+        return;
+    }
     let input = read_fixture("math_code.md");
     let backend = if ffi_available() {
         PandocBackend::Ffi
-    } else if snapper_fmt::parser::pandoc::pandoc_available() {
-        PandocBackend::Cli
     } else {
-        eprintln!("skipping: no pandoc backend");
-        return;
+        PandocBackend::Cli
     };
     let cfg = FormatConfig {
         format: Format::Markdown,
@@ -278,7 +311,18 @@ fn format_text_pandoc_math_and_code_protected() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    assert_pandoc_refuses(&input, &cfg);
+    let pandoc_out = format_text(&input, &cfg).expect("pandoc write");
+    assert_has_sentence_break(&pandoc_out, "First sentence.", "Second sentence");
+    assert!(
+        pandoc_out.contains("```") && pandoc_out.contains("print(1.0)"),
+        "CodeBlock stays a fenced unit:\n{pandoc_out}"
+    );
+    assert!(
+        !pandoc_out
+            .lines()
+            .any(|l| l.trim() == "0)" || l.trim() == "0"),
+        "code not sentence-fragmented:\n{pandoc_out}"
+    );
     let run1 = format_text(
         &input,
         &FormatConfig {
@@ -324,16 +368,10 @@ fn format_text_pandoc_math_and_code_protected() {
 
 #[test]
 fn format_text_pandoc_latex_math_code_envs() {
-    if !snapper_fmt::parser::pandoc::pandoc_available() && !ffi_available() {
-        eprintln!("skipping: no pandoc backend");
+    if !require_writer() {
         return;
     }
-    // LaTeX readers are CLI-complete; FFI may not include latex the same way.
-    let backend = if snapper_fmt::parser::pandoc::pandoc_available() {
-        PandocBackend::Cli
-    } else {
-        PandocBackend::Ffi
-    };
+    let backend = PandocBackend::Cli;
     let input = read_fixture("math_code.tex");
     let cfg = FormatConfig {
         format: Format::Latex,
@@ -342,7 +380,18 @@ fn format_text_pandoc_latex_math_code_envs() {
         pandoc_format: Some("latex".into()),
         ..Default::default()
     };
-    assert_pandoc_refuses(&input, &cfg);
+    let pandoc_out = format_text(&input, &cfg).expect("pandoc latex write");
+    assert!(
+        pandoc_out.contains("Hello world.") && pandoc_out.contains("Second sentence"),
+        "latex prose present:\n{pandoc_out}"
+    );
+    assert_has_sentence_break(&pandoc_out, "Hello world.", "Second sentence");
+    assert!(
+        !pandoc_out
+            .lines()
+            .any(|l| l.trim() == "2." && !l.contains("mc")),
+        "math period must not orphan a bare '2.' prose line:\n{pandoc_out}"
+    );
     let out = format_text(
         &input,
         &FormatConfig {
@@ -369,15 +418,11 @@ fn format_text_pandoc_latex_math_code_envs() {
 
 #[test]
 fn format_text_pandoc_table_list_quote() {
-    let input = read_fixture("structure_blocks.md");
-    let backend = if snapper_fmt::parser::pandoc::pandoc_available() {
-        PandocBackend::Cli
-    } else if ffi_available() {
-        PandocBackend::Ffi
-    } else {
-        eprintln!("skipping: no pandoc backend");
+    if !require_writer() {
         return;
-    };
+    }
+    let input = read_fixture("structure_blocks.md");
+    let backend = PandocBackend::Cli;
     let cfg = FormatConfig {
         format: Format::Markdown,
         use_pandoc: true,
@@ -385,7 +430,19 @@ fn format_text_pandoc_table_list_quote() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    assert_pandoc_refuses(&input, &cfg);
+    let pandoc_out = format_text(&input, &cfg).expect("pandoc write");
+    assert!(
+        pandoc_out.contains('a')
+            && pandoc_out.contains('b')
+            && (pandoc_out.contains("---") || pandoc_out.contains('|')),
+        "table stays structure:\n{pandoc_out}"
+    );
+    assert!(
+        pandoc_out.contains("- ") || pandoc_out.lines().any(|l| l.starts_with('-')),
+        "bullet list stays structure:\n{pandoc_out}"
+    );
+    assert!(pandoc_out.contains('>'), "blockquote:\n{pandoc_out}");
+    assert_has_sentence_break(&pandoc_out, "Intro sentence.", "Second");
     let run1 = format_text(
         &input,
         &FormatConfig {
@@ -443,8 +500,7 @@ fn default_path_numbered_atx_source_line_not_split() {
 /// cannot land on its own line. Native pairing is meant to match this.
 #[test]
 fn pandoc_org_verbatim_inner_equals_stays_one_span() {
-    if !snapper_fmt::parser::pandoc::pandoc_available() {
-        eprintln!("skipping: pandoc CLI not on PATH");
+    if !require_writer() {
         return;
     }
     let input = "so =x = 1 -- note.= reflows while =s = \"x\"= does not.\n";
@@ -455,7 +511,13 @@ fn pandoc_org_verbatim_inner_equals_stays_one_span() {
         pandoc_format: Some("org".into()),
         ..Default::default()
     };
-    assert_pandoc_refuses(input, &cfg);
+    let pandoc_out = format_text(input, &cfg).expect("pandoc org write");
+    assert!(
+        !pandoc_out
+            .lines()
+            .any(|l| l.trim() == "=" || l.starts_with("= ")),
+        "pandoc path must not orphan a verbatim closer, got:\n{pandoc_out}"
+    );
     let out = format_text(
         input,
         &FormatConfig {
@@ -474,4 +536,59 @@ fn pandoc_org_verbatim_inner_equals_stays_one_span() {
         out.contains("x = 1") && out.contains("s ="),
         "both verbatim bodies must survive, got:\n{out}"
     );
+}
+
+/// `snapper --use-pandoc FILE` must exit 0 and emit sentence breaks.
+#[test]
+fn snapper_cli_use_pandoc_exits_0() {
+    if !require_writer() {
+        return;
+    }
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let input = fixture("mixed.md");
+    let out = std::process::Command::new(bin)
+        .args(["--use-pandoc", "--format", "markdown"])
+        .arg(&input)
+        .output()
+        .expect("spawn snapper");
+    assert!(
+        out.status.success(),
+        "snapper --use-pandoc must exit 0; stderr={} stdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("Hello world.\n") && stdout.contains("Second sentence"),
+        "CLI write must break sentences:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("```") || stdout.contains("print(1)"),
+        "CLI write keeps CodeBlock:\n{stdout}"
+    );
+}
+
+#[test]
+fn format_text_pandoc_definition_list_stays_structure() {
+    if !require_writer() {
+        return;
+    }
+    let input = "Term one\n\n:   First sentence. Second sentence.\n";
+    let cfg = FormatConfig {
+        format: Format::Markdown,
+        use_pandoc: true,
+        pandoc_backend: PandocBackend::Cli,
+        pandoc_format: Some("markdown".into()),
+        ..Default::default()
+    };
+    let out = format_text(input, &cfg).expect("pandoc write");
+    assert!(
+        out.to_lowercase().contains("term one"),
+        "definition term survives:\n{out}"
+    );
+    assert!(
+        out.contains("First sentence") && out.contains("Second sentence"),
+        "definition body prose present:\n{out}"
+    );
+    assert_has_sentence_break(&out, "First sentence.", "Second sentence");
 }

--- a/tests/pandoc_parity_speed.rs
+++ b/tests/pandoc_parity_speed.rs
@@ -97,17 +97,24 @@ fn parity_md_prose_reflow_and_structure() {
     };
     let input = read("pandoc_ast/math_code.md");
     let native = format_text(&input, &native_cfg(Format::Markdown)).expect("native");
-    let err = format_text(&input, &pandoc_cfg(Format::Markdown, backend, "markdown"))
-        .expect_err("pandoc must refuse splice");
-    assert!(
-        err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
-            .is_some(),
-        "{err:?}"
-    );
+    if !snapper_fmt::parser::pandoc::pandoc_available() {
+        eprintln!("skip pandoc write: CLI writer missing");
+        return;
+    }
+    let pandoc = format_text(&input, &pandoc_cfg(Format::Markdown, backend, "markdown"))
+        .expect("pandoc write");
 
     assert!(
         has_sentence_reflow(&native, "First sentence.", "Second sentence"),
         "native reflow:\n{native}"
+    );
+    assert!(
+        has_sentence_reflow(&pandoc, "First sentence.", "Second sentence"),
+        "pandoc reflow:\n{pandoc}"
+    );
+    assert!(
+        pandoc.contains("```") && pandoc.contains("print(1.0)"),
+        "pandoc code unit:\n{pandoc}"
     );
     assert!(
         native.contains("```python") && native.contains("print(1.0)"),
@@ -123,13 +130,12 @@ fn parity_org_multi_sentence() {
     };
     let input = read("sample.org");
     let native = format_text(&input, &native_cfg(Format::Org)).expect("native");
-    let err = format_text(&input, &pandoc_cfg(Format::Org, backend, "org"))
-        .expect_err("org pandoc must refuse splice");
-    assert!(
-        err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
-            .is_some()
-    );
-    let pandoc = native.clone();
+    if !snapper_fmt::parser::pandoc::pandoc_available() {
+        eprintln!("skip org pandoc write: CLI writer missing");
+        return;
+    }
+    let pandoc =
+        format_text(&input, &pandoc_cfg(Format::Org, backend, "org")).expect("org pandoc write");
 
     // Multi-sentence prose reflow (fixture: "This is the first paragraph... It has multiple...")
     assert!(
@@ -230,50 +236,44 @@ fn speed_library_native_vs_pandoc_report() {
     let mut lines = vec![format!("md_native_format_text_med_ms={n_md:.3}")];
 
     if snapper_fmt::parser::pandoc::pandoc_available() {
-        let err = format_text(
+        let t = time_format(
             &md,
             &pandoc_cfg(Format::Markdown, PandocBackend::Cli, "markdown"),
-        )
-        .expect_err("cli refuse");
-        assert!(
-            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
-                .is_some()
+            20,
+            3,
         );
-        lines.push("md_pandoc_cli=refused_no_splice".into());
+        lines.push(format!("md_pandoc_cli_format_text_med_ms={t:.3}"));
     }
-    if ffi_available() {
-        let err = format_text(
+    if ffi_available() && snapper_fmt::parser::pandoc::pandoc_available() {
+        let t = time_format(
             &md,
             &pandoc_cfg(Format::Markdown, PandocBackend::Ffi, "markdown"),
-        )
-        .expect_err("ffi refuse");
-        assert!(
-            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
-                .is_some()
+            20,
+            3,
         );
-        lines.push("md_pandoc_ffi=refused_no_splice".into());
+        lines.push(format!("md_pandoc_ffi_format_text_med_ms={t:.3}"));
     }
 
     let org = read("sample.org");
     let n_org = time_format(&org, &native_cfg(Format::Org), 40, 5);
     lines.push(format!("org_native_format_text_med_ms={n_org:.3}"));
     if snapper_fmt::parser::pandoc::pandoc_available() {
-        let err = format_text(&org, &pandoc_cfg(Format::Org, PandocBackend::Cli, "org"))
-            .expect_err("org cli refuse");
-        assert!(
-            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
-                .is_some()
+        let t = time_format(
+            &org,
+            &pandoc_cfg(Format::Org, PandocBackend::Cli, "org"),
+            20,
+            3,
         );
-        lines.push("org_pandoc_cli=refused_no_splice".into());
+        lines.push(format!("org_pandoc_cli_format_text_med_ms={t:.3}"));
     }
-    if ffi_available() {
-        let err = format_text(&org, &pandoc_cfg(Format::Org, PandocBackend::Ffi, "org"))
-            .expect_err("org ffi refuse");
-        assert!(
-            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
-                .is_some()
+    if ffi_available() && snapper_fmt::parser::pandoc::pandoc_available() {
+        let t = time_format(
+            &org,
+            &pandoc_cfg(Format::Org, PandocBackend::Ffi, "org"),
+            20,
+            3,
         );
-        lines.push("org_pandoc_ffi=refused_no_splice".into());
+        lines.push(format!("org_pandoc_ffi_format_text_med_ms={t:.3}"));
     }
 
     eprintln!("{}", lines.join("\n"));
@@ -284,14 +284,14 @@ fn speed_library_native_vs_pandoc_report() {
 
     if snapper_fmt::parser::pandoc::pandoc_available() {
         let tex = read("pandoc_ast/math_code.tex");
-        let err = format_text(
+        let out = format_text(
             &tex,
             &pandoc_cfg(Format::Latex, PandocBackend::Cli, "latex"),
         )
-        .expect_err("latex refuse");
+        .expect("latex write");
         assert!(
-            err.downcast_ref::<snapper_fmt::PandocCannotSplice>()
-                .is_some()
+            out.contains("Hello world.") && out.contains("Second sentence"),
+            "latex write:\n{out}"
         );
     }
 


### PR DESCRIPTION
`--use-pandoc` parsed, then returned `PandocCannotSplice` because the AST has no source offsets.

`format_text` now reflows `Para` / `Plain` in the AST and writes through `pandoc -f json --wrap=preserve`. Header, CodeBlock, Table, DefinitionList, and BulletList stay structure. Native path and the CLI default are unchanged.

This is snapper-f0ps. Comments/pragmas and the default flip are later tickets.
