### PR TITLE
fix(pandoc): refuse comments and snapper pragmas instead of dropping them

### DIFF
--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -86,6 +86,6 @@ The two paths are different pipelines, not two ways to fake the same source line
 :CUSTOM_ID: limitations
 :END:
 
-- Pandoc strips comments, so =snapper:off= / =snapper:on= pragmas do not work on the pandoc path
+- Pandoc's reader deletes comments (RST =..= comments, HTML comments) and therefore =snapper:off= / =snapper:on=. =--use-pandoc= refuses with an explicit error instead of writing the stripped document and exiting 0. Use the native parser (omit =--use-pandoc=) to keep that text.
 - Round-trip is through the AST (not a perfect source-preserving rewrite of every markup character)
 - FFI library is optional; wasm/editor bundles do not embed GHC/pandoc

--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -86,6 +86,8 @@ The two paths are different pipelines, not two ways to fake the same source line
 :CUSTOM_ID: limitations
 :END:
 
-- Pandoc's reader deletes comments (RST =..= comments, HTML comments) and therefore =snapper:off= / =snapper:on=. =--use-pandoc= refuses with an explicit error instead of writing the stripped document and exiting 0. Use the native parser (omit =--use-pandoc=) to keep that text.
+- Pandoc's reader deletes comments (RST =..= comments, HTML comments) and therefore =snapper:off= / =snapper:on=.
+- =--use-pandoc= refuses with an explicit error instead of writing the stripped document and exiting 0.
+- Use the native parser (omit =--use-pandoc=) to keep that text.
 - Round-trip is through the AST (not a perfect source-preserving rewrite of every markup character)
 - FFI library is optional; wasm/editor bundles do not embed GHC/pandoc

--- a/docs/orgmode/howto/pragmas.org
+++ b/docs/orgmode/howto/pragmas.org
@@ -117,3 +117,7 @@ If the file ends without a =snapper:on=, the rest of the file passes through unc
 Pragmas take priority over all other parsing.
 Inside an off region, no sentence splitting, no format-aware parsing, and no abbreviation handling occurs.
 The pragma comment lines themselves always pass through as structure.
+
+=--use-pandoc= does not honor pragmas: pandoc's reader drops them (zero blocks).
+The write path refuses those files with an explicit error instead of deleting the markers.
+Use the native parser (omit =--use-pandoc=) when a file contains =snapper:off= / =snapper:on=.

--- a/docs/source/cli-reference.md
+++ b/docs/source/cli-reference.md
@@ -49,7 +49,7 @@ Semantic line break formatter
 * `--neural` — Use neural sentence detection (nnsplit LSTM model)
 * `--lang <LANG>` — Language for neural sentence detection (default: en). Available: en, de, fr, no, sv, zh, tr, ru, uk
 * `--model-path <MODEL_PATH>` — Path to custom ONNX model file for neural detection
-* `--use-pandoc` — Use pandoc as parser backend (universal format support)
+* `--use-pandoc` — Use pandoc as parser backend (universal format support). Refuses when the source has comments or `snapper:off` / `snapper:on` that pandoc's reader would delete
 * `--pandoc-backend <BACKEND>` — Pandoc AST source when `--use-pandoc` is set: `auto` (prefer in-process FFI, else CLI), `ffi` (`libsnapper_pandoc`), or `cli` (`pandoc` subprocess). Default: `auto`. `ffi` fails explicitly if the library is missing
 
   Default value: `auto`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,6 +94,8 @@ pub struct Cli {
     pub model_path: Option<PathBuf>,
 
     /// Use pandoc as parser backend (universal format support).
+    /// Refuses when the source has comments or `snapper:off` / `snapper:on`
+    /// that pandoc's reader would delete.
     #[arg(long)]
     pub use_pandoc: bool,
 

--- a/src/parser/pandoc/mod.rs
+++ b/src/parser/pandoc/mod.rs
@@ -100,6 +100,11 @@ pub enum PandocError {
     Cli(#[from] cli::CliError),
     #[error("pandoc AST cache/classify: {0}")]
     Ast(String),
+    /// Pandoc's reader deletes comments (RST `..`, HTML) and therefore
+    /// `snapper:off` / `snapper:on`. Write-through must not exit 0 after
+    /// that deletion.
+    #[error("pandoc path would drop {0}; omit --use-pandoc to keep comments and snapper pragmas")]
+    DropsComments(String),
 }
 
 /// Parse input with the selected backend and classify via the pandoc AST.
@@ -155,10 +160,55 @@ pub fn json_with_backend(
     Ok(json)
 }
 
+/// Why write-through would delete comments or pragmas. `None` if the
+/// source has none of those constructs. Does not invoke pandoc.
+pub fn dropped_comment_kind(input: &str, format: &str) -> Option<&'static str> {
+    if input
+        .lines()
+        .any(|line| crate::parser::check_pragma(line).is_some())
+    {
+        return Some("snapper:off/on");
+    }
+    if is_rst_pandoc_format(format) && crate::parser::rst::source_has_dropped_rst_comments(input) {
+        return Some("RST comment");
+    }
+    None
+}
+
+fn is_rst_pandoc_format(format: &str) -> bool {
+    let base = format.split(['+', '-']).next().unwrap_or(format);
+    matches!(base, "rst" | "rest")
+}
+
+/// Writer-side backstop: a detector miss must still not exit 0 after a drop.
+fn refuse_if_comments_missing(input: &str, format: &str, output: &str) -> Result<(), PandocError> {
+    for token in ["snapper:off", "snapper:on"] {
+        if input.contains(token) && !output.contains(token) {
+            return Err(PandocError::DropsComments("snapper:off/on".into()));
+        }
+    }
+    if is_rst_pandoc_format(format) {
+        for line in input.lines() {
+            let trimmed = line.trim_start();
+            if !crate::parser::rst::is_rst_dropped_comment_opener(trimmed) {
+                continue;
+            }
+            let payload = trimmed.strip_prefix("..").unwrap_or("").trim();
+            if !payload.is_empty() && !output.contains(payload) {
+                return Err(PandocError::DropsComments("RST comment".into()));
+            }
+        }
+    }
+    Ok(())
+}
+
 /// Parse → reflow Para/Plain → write through pandoc's writer.
 ///
 /// Not a splice of the original bytes. The writer needs a `pandoc` binary
 /// even when parse used FFI (`libsnapper_pandoc` has no writers).
+///
+/// Refuses when the source has RST `..` comments or `snapper:off` /
+/// `snapper:on` that pandoc's reader would delete (empty AST, exit 0).
 pub fn format_via_pandoc(
     input: &str,
     format: &str,
@@ -166,13 +216,18 @@ pub fn format_via_pandoc(
     splitter: &dyn crate::sentence::SentenceSplitter,
     reflow_config: &crate::reflow::ReflowConfig,
 ) -> Result<String, PandocError> {
+    if let Some(kind) = dropped_comment_kind(input, format) {
+        return Err(PandocError::DropsComments(kind.to_string()));
+    }
     let json = json_with_backend(input, format, backend)?;
     let mut doc: pandoc_ast::Pandoc =
         serde_json::from_str(&json).map_err(|e| PandocError::Ast(e.to_string()))?;
     reflow_pandoc(&mut doc, splitter, reflow_config);
     let out_json =
         serde_json::to_string(&doc).map_err(|e| PandocError::Ast(format!("serialize AST: {e}")))?;
-    write_via_cli(&out_json, format).map_err(PandocError::from)
+    let written = write_via_cli(&out_json, format).map_err(PandocError::from)?;
+    refuse_if_comments_missing(input, format, &written)?;
+    Ok(written)
 }
 
 /// Parser that uses pandoc for universal format support.
@@ -293,5 +348,69 @@ mod tests {
             msg.contains("unavailable") || msg.contains("FFI") || msg.contains("library"),
             "expected explicit FFI unavailability, got: {msg}"
         );
+    }
+
+    #[test]
+    fn dropped_comment_kind_rst_bare_dotdot() {
+        assert_eq!(
+            dropped_comment_kind("..\n   Secret.\n", "rst"),
+            Some("RST comment")
+        );
+        assert_eq!(
+            dropped_comment_kind(".. This is a comment.\n", "rst"),
+            Some("RST comment")
+        );
+        assert_eq!(dropped_comment_kind("Hello world.\n", "rst"), None);
+        assert_eq!(dropped_comment_kind(".. note::\n   Body.\n", "rst"), None);
+        assert_eq!(dropped_comment_kind(".. _label:\n", "rst"), None);
+    }
+
+    #[test]
+    fn dropped_comment_kind_pragmas_any_format() {
+        assert_eq!(
+            dropped_comment_kind("Hello.\n<!-- snapper:off -->\nKeep.\n", "markdown"),
+            Some("snapper:off/on")
+        );
+        assert_eq!(
+            dropped_comment_kind("Hello.\nsnapper:off\nKeep.\n", "rst"),
+            Some("snapper:off/on")
+        );
+        assert_eq!(
+            dropped_comment_kind("# snapper:off\nKeep.\n", "org"),
+            Some("snapper:off/on")
+        );
+        assert_eq!(dropped_comment_kind("Hello world.\n", "markdown"), None);
+    }
+
+    #[test]
+    fn format_via_pandoc_rst_comment_is_explicit_error() {
+        let err = format_via_pandoc(
+            "..\n   First sentence.\n   Second sentence.\n",
+            "rst",
+            PandocBackend::Cli,
+            &crate::sentence::unicode::UnicodeSentenceSplitter::new(),
+            &crate::reflow::ReflowConfig::default(),
+        )
+        .unwrap_err();
+        match err {
+            PandocError::DropsComments(kind) => assert!(kind.contains("RST")),
+            other => panic!("expected DropsComments, got {other}"),
+        }
+    }
+
+    #[test]
+    fn format_via_pandoc_pragma_is_explicit_error() {
+        let err = format_via_pandoc(
+            "Hello world. Second.\n<!-- snapper:off -->\nKeep this.\n<!-- snapper:on -->\n",
+            "markdown",
+            PandocBackend::Cli,
+            &crate::sentence::unicode::UnicodeSentenceSplitter::new(),
+            &crate::reflow::ReflowConfig::default(),
+        )
+        .unwrap_err();
+        match err {
+            PandocError::DropsComments(kind) => assert!(kind.contains("snapper")),
+            other => panic!("expected DropsComments, got {other}"),
+        }
     }
 }

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -363,11 +363,32 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
 
 /// True when `trimmed` is an RST comment opener, not a `.. name::` directive.
 /// Bare `..` (no trailing space) is a valid opener; so is `.. text`.
-fn is_rst_comment_opener(trimmed: &str) -> bool {
+pub(crate) fn is_rst_comment_opener(trimmed: &str) -> bool {
     if trimmed.contains("::") {
         return false;
     }
     trimmed == ".." || trimmed.starts_with(".. ") || trimmed.starts_with("..\t")
+}
+
+/// Comment openers pandoc's RST reader drops (zero blocks). Hyperlink
+/// targets (`.. _name:`) and footnotes (`.. [1]`) start with `..` but
+/// survive the reader, so they are not a drop.
+pub(crate) fn is_rst_dropped_comment_opener(trimmed: &str) -> bool {
+    if !is_rst_comment_opener(trimmed) {
+        return false;
+    }
+    let after = trimmed.strip_prefix("..").unwrap_or("").trim_start();
+    if after.is_empty() {
+        return true;
+    }
+    !after.starts_with('_') && !after.starts_with('[')
+}
+
+/// Source has an RST `..` comment that `pandoc -f rst` would delete.
+pub(crate) fn source_has_dropped_rst_comments(input: &str) -> bool {
+    input
+        .lines()
+        .any(|line| is_rst_dropped_comment_opener(line.trim_start()))
 }
 
 /// Byte length of a compact RST list opener on `line`, including the
@@ -803,6 +824,21 @@ mod tests {
         assert!(!is_rst_comment_opener(".. note::"));
         assert!(!is_rst_comment_opener("..."));
         assert!(!is_rst_comment_opener("Hello"));
+    }
+
+    #[test]
+    fn dropped_comment_excludes_targets_and_footnotes() {
+        assert!(is_rst_dropped_comment_opener(".."));
+        assert!(is_rst_dropped_comment_opener(".. This is a comment."));
+        assert!(source_has_dropped_rst_comments(
+            "..\n   First sentence.\n   Second sentence.\n"
+        ));
+        assert!(!is_rst_dropped_comment_opener(".. _label:"));
+        assert!(!is_rst_dropped_comment_opener(".. [1]"));
+        assert!(!is_rst_dropped_comment_opener(".. note::"));
+        assert!(!source_has_dropped_rst_comments(
+            "Hello world. Second sentence.\n\n.. _label:\n\n.. note::\n   Body.\n"
+        ));
     }
 
     #[test]

--- a/tests/fixtures/pandoc_ast/rst_comment.rst
+++ b/tests/fixtures/pandoc_ast/rst_comment.rst
@@ -1,0 +1,6 @@
+Hello world. Second sentence.
+
+..
+   This comment must not vanish.
+
+.. This is a recognized comment.

--- a/tests/fixtures/pandoc_ast/snapper_off.md
+++ b/tests/fixtures/pandoc_ast/snapper_off.md
@@ -1,0 +1,5 @@
+Hello world. Second sentence.
+<!-- snapper:off -->
+Keep this. Exactly here.
+<!-- snapper:on -->
+After. Two.

--- a/tests/fixtures/pandoc_ast/snapper_off.rst
+++ b/tests/fixtures/pandoc_ast/snapper_off.rst
@@ -1,0 +1,5 @@
+Hello world. Second sentence.
+snapper:off
+Keep this. Exactly here.
+snapper:on
+After. Two.

--- a/tests/pandoc_ast_backend.rs
+++ b/tests/pandoc_ast_backend.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::Region;
 use snapper_fmt::parser::pandoc::{
-    PandocBackend, PandocParser, ffi_available, regions_from_pandoc_json,
+    PandocBackend, PandocParser, dropped_comment_kind, ffi_available, regions_from_pandoc_json,
 };
 use snapper_fmt::{FormatConfig, format_text};
 
@@ -591,4 +591,197 @@ fn format_text_pandoc_definition_list_stays_structure() {
         "definition body prose present:\n{out}"
     );
     assert_has_sentence_break(&out, "First sentence.", "Second sentence");
+}
+
+/// `--use-pandoc` must not delete RST `..` comments and exit 0.
+#[test]
+fn format_text_use_pandoc_rst_comment_is_explicit_error() {
+    let input = read_fixture("rst_comment.rst");
+    assert!(
+        dropped_comment_kind(&input, "rst").is_some(),
+        "fixture must be a dropped RST comment"
+    );
+    let err = format_text(
+        &input,
+        &FormatConfig {
+            format: Format::Rst,
+            use_pandoc: true,
+            pandoc_backend: PandocBackend::Cli,
+            pandoc_format: Some("rst".into()),
+            ..Default::default()
+        },
+    )
+    .expect_err("pandoc path must refuse RST comments");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("drop") || msg.contains("comment") || msg.contains("pragma"),
+        "expected explicit drop error, got: {msg}"
+    );
+}
+
+/// `--use-pandoc` must not delete `snapper:off` and exit 0.
+#[test]
+fn format_text_use_pandoc_snapper_off_is_explicit_error() {
+    let input = read_fixture("snapper_off.md");
+    let err = format_text(
+        &input,
+        &FormatConfig {
+            format: Format::Markdown,
+            use_pandoc: true,
+            pandoc_backend: PandocBackend::Cli,
+            pandoc_format: Some("markdown".into()),
+            ..Default::default()
+        },
+    )
+    .expect_err("pandoc path must refuse snapper:off");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("snapper") || msg.contains("drop") || msg.contains("pragma"),
+        "expected explicit drop error, got: {msg}"
+    );
+}
+
+#[test]
+fn format_text_use_pandoc_rst_snapper_off_is_explicit_error() {
+    let input = read_fixture("snapper_off.rst");
+    let err = format_text(
+        &input,
+        &FormatConfig {
+            format: Format::Rst,
+            use_pandoc: true,
+            pandoc_backend: PandocBackend::Cli,
+            pandoc_format: Some("rst".into()),
+            ..Default::default()
+        },
+    )
+    .expect_err("pandoc path must refuse RST snapper:off");
+    let msg = format!("{err:#}");
+    assert!(
+        msg.contains("snapper") || msg.contains("drop") || msg.contains("pragma"),
+        "expected explicit drop error, got: {msg}"
+    );
+}
+
+/// Native path still keeps comments and pragmas (this ticket does not change it).
+#[test]
+fn native_path_keeps_rst_comment_and_snapper_off() {
+    let rst = read_fixture("rst_comment.rst");
+    let rst_out = format_text(
+        &rst,
+        &FormatConfig {
+            format: Format::Rst,
+            use_pandoc: false,
+            ..Default::default()
+        },
+    )
+    .expect("native rst");
+    assert!(
+        rst_out.contains("This comment must not vanish."),
+        "native must keep RST comment body:\n{rst_out}"
+    );
+    assert!(
+        rst_out.contains(".. This is a recognized comment."),
+        "native must keep recognized RST comment:\n{rst_out}"
+    );
+
+    let md = read_fixture("snapper_off.md");
+    let md_out = format_text(
+        &md,
+        &FormatConfig {
+            format: Format::Markdown,
+            use_pandoc: false,
+            ..Default::default()
+        },
+    )
+    .expect("native md");
+    assert!(
+        md_out.contains("<!-- snapper:off -->") && md_out.contains("Keep this. Exactly here."),
+        "native must keep markdown snapper:off:\n{md_out}"
+    );
+
+    let rst_off = read_fixture("snapper_off.rst");
+    let rst_off_out = format_text(
+        &rst_off,
+        &FormatConfig {
+            format: Format::Rst,
+            use_pandoc: false,
+            ..Default::default()
+        },
+    )
+    .expect("native rst pragma");
+    assert!(
+        rst_off_out.contains("snapper:off") && rst_off_out.contains("Keep this. Exactly here."),
+        "native must keep RST snapper:off:\n{rst_off_out}"
+    );
+}
+
+/// CLI `--use-pandoc` on the RST comment fixture must not exit 0 after a drop.
+#[test]
+fn snapper_cli_use_pandoc_rst_comment_is_nonzero() {
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let input = fixture("rst_comment.rst");
+    let out = std::process::Command::new(bin)
+        .args(["--use-pandoc", "--format", "rst"])
+        .arg(&input)
+        .output()
+        .expect("spawn snapper");
+    assert!(
+        !out.status.success(),
+        "CLI must refuse RST comments; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("drop") || err.contains("comment") || err.contains("pragma"),
+        "expected explicit drop error on stderr, got: {err}"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.trim().is_empty() || stdout.contains("This comment must not vanish."),
+        "must not emit comment-stripped success output: {stdout}"
+    );
+}
+
+#[test]
+fn snapper_cli_use_pandoc_snapper_off_is_nonzero() {
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let input = fixture("snapper_off.md");
+    let out = std::process::Command::new(bin)
+        .args(["--use-pandoc", "--format", "markdown"])
+        .arg(&input)
+        .output()
+        .expect("spawn snapper");
+    assert!(
+        !out.status.success(),
+        "CLI must refuse snapper:off; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("snapper") || err.contains("drop") || err.contains("pragma"),
+        "expected explicit drop error on stderr, got: {err}"
+    );
+}
+
+/// Prose-only RST (no comments) still writes through when pandoc is present.
+#[test]
+fn format_text_use_pandoc_rst_prose_still_writes() {
+    if !require_writer() {
+        return;
+    }
+    let input = "Hello world. Second sentence.\n";
+    let out = format_text(
+        input,
+        &FormatConfig {
+            format: Format::Rst,
+            use_pandoc: true,
+            pandoc_backend: PandocBackend::Cli,
+            pandoc_format: Some("rst".into()),
+            ..Default::default()
+        },
+    )
+    .expect("pandoc rst prose");
+    assert_has_sentence_break(&out, "Hello world.", "Second sentence");
 }


### PR DESCRIPTION
Pandoc's reader deletes RST `..` comments and `snapper:off` / `snapper:on`. After the write path, that would have been a silent strip.

`--use-pandoc` now refuses with an explicit error instead of writing the stripped document. Native (omit the flag) still keeps the text. Default is unchanged.

This is snapper-wqdh. Default flip stays later.
