### PR TITLE
fix(pandoc): write in-process when FFI exports a writer

### DIFF
--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -36,7 +36,7 @@ Pandoc 2.x or 3.x on =PATH=.
 With =--use-pandoc=, a missing or failing pandoc is an explicit error (no silent all-prose).
 
 **Writer.**
-=libsnapper_pandoc= is reader-only.
+The library =libsnapper_pandoc= is reader-only.
 The write step still needs =pandoc= on =PATH= (help and errors say so).
 A library that exports =snapper_pandoc_write= stays in-process for write too.
 

--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -66,7 +66,8 @@ snapper --use-pandoc --pandoc-backend ffi paper.md
 #+end_src
 
 Native line parsers remain the default until product flip.
-Use =--use-pandoc= when you need formats without a built-in parser or AST-true structure; prefer FFI for parse latency once =libsnapper_pandoc= is installed. The writer still needs =pandoc= on =PATH= unless the library exports a writer.
+Use =--use-pandoc= when you need formats without a built-in parser or AST-true structure; prefer FFI for parse latency once =libsnapper_pandoc= is installed.
+The writer still needs =pandoc= on =PATH= unless the library exports a writer.
 
 **Speed.**
 Warm in-process FFI parse is a few times native cost; a cold =pandoc= CLI process reloads the GHC RTS (tens of ms).

--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -19,9 +19,12 @@ That is how snapper can format everything pandoc can read (typst, asciidoc, docx
 How to run step 1 (same step-2 walker):
 
 1. *Auto* — =--pandoc-backend auto= (default): prefer in-process FFI when =libsnapper_pandoc= loads, else CLI.
-This amortizes the GHC RTS for *parse*. The shipped library is reader-only, so the writer still needs =pandoc= on =PATH= unless that library exports a writer (no silent spawn).
-2. *CLI* — =--pandoc-backend cli=: =pandoc -t json= (full reader set of the installed binary). Explicit error if =pandoc= is missing.
-3. *FFI* — =--pandoc-backend ffi=: require =libsnapper_pandoc= (explicit error if missing). Writer still needs =pandoc= on =PATH= when the library has no writer.
+This amortizes the GHC RTS for *parse*.
+The shipped library is reader-only, so the writer still needs =pandoc= on =PATH= unless that library exports a writer (no silent spawn).
+2. *CLI* — =--pandoc-backend cli=: =pandoc -t json= (full reader set of the installed binary).
+Explicit error if =pandoc= is missing.
+3. *FFI* — =--pandoc-backend ffi=: require =libsnapper_pandoc= (explicit error if missing).
+Writer still needs =pandoc= on =PATH= when the library has no writer.
 
 * Requirements
 :PROPERTIES:
@@ -33,7 +36,9 @@ Pandoc 2.x or 3.x on =PATH=.
 With =--use-pandoc=, a missing or failing pandoc is an explicit error (no silent all-prose).
 
 **Writer.**
-=libsnapper_pandoc= is reader-only. The write step still needs =pandoc= on =PATH= (help and errors say so). A library that exports =snapper_pandoc_write= stays in-process for write too.
+=libsnapper_pandoc= is reader-only.
+The write step still needs =pandoc= on =PATH= (help and errors say so).
+A library that exports =snapper_pandoc_write= stays in-process for write too.
 
 **FFI backend (dynamic).**
 Build =native/snapper-pandoc=, set =SNAPPER_PANDOC_LIB= to =libsnapper_pandoc.so= (or put it on the search path).

--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -11,7 +11,7 @@ The pandoc path is **parse with pandoc, then apply snapper** — not “guess ma
 1. Pandoc reads the file (any format it supports) into its document AST.
 2. Snapper walks that AST and reflows only prose-bearing nodes (=Para= / =Plain=).
 3. Nodes pandoc already classified as structure (=Header=, =CodeBlock=, =Table=, …) are left alone.
-4. The mutated AST is written through pandoc's writer (=pandoc -f json --wrap=preserve=).
+4. The mutated AST is written through an in-process FFI writer when the loaded library exports one, otherwise =pandoc -f json --wrap=preserve=.
 This is not a splice of the original bytes.
 
 That is how snapper can format everything pandoc can read (typst, asciidoc, docx, html, …) without inventing per-format line heuristics.
@@ -19,9 +19,9 @@ That is how snapper can format everything pandoc can read (typst, asciidoc, docx
 How to run step 1 (same step-2 walker):
 
 1. *Auto* — =--pandoc-backend auto= (default): prefer in-process FFI when =libsnapper_pandoc= loads, else CLI.
-This is the successor path for multi-format work (amortizes RTS; avoids process-per-file spawn).
-2. *CLI* — =--pandoc-backend cli=: =pandoc -t json= (full reader set of the installed binary).
-3. *FFI* — =--pandoc-backend ffi=: require =libsnapper_pandoc= (explicit error if missing).
+This amortizes the GHC RTS for *parse*. The shipped library is reader-only, so the writer still needs =pandoc= on =PATH= unless that library exports a writer (no silent spawn).
+2. *CLI* — =--pandoc-backend cli=: =pandoc -t json= (full reader set of the installed binary). Explicit error if =pandoc= is missing.
+3. *FFI* — =--pandoc-backend ffi=: require =libsnapper_pandoc= (explicit error if missing). Writer still needs =pandoc= on =PATH= when the library has no writer.
 
 * Requirements
 :PROPERTIES:
@@ -31,6 +31,9 @@ This is the successor path for multi-format work (amortizes RTS; avoids process-
 **CLI backend.**
 Pandoc 2.x or 3.x on =PATH=.
 With =--use-pandoc=, a missing or failing pandoc is an explicit error (no silent all-prose).
+
+**Writer.**
+=libsnapper_pandoc= is reader-only. The write step still needs =pandoc= on =PATH= (help and errors say so). A library that exports =snapper_pandoc_write= stays in-process for write too.
 
 **FFI backend (dynamic).**
 Build =native/snapper-pandoc=, set =SNAPPER_PANDOC_LIB= to =libsnapper_pandoc.so= (or put it on the search path).
@@ -63,12 +66,13 @@ snapper --use-pandoc --pandoc-backend ffi paper.md
 #+end_src
 
 Native line parsers remain the default until product flip.
-Use =--use-pandoc= when you need formats without a built-in parser or AST-true structure; prefer FFI for latency once =libsnapper_pandoc= is installed.
+Use =--use-pandoc= when you need formats without a built-in parser or AST-true structure; prefer FFI for parse latency once =libsnapper_pandoc= is installed. The writer still needs =pandoc= on =PATH= unless the library exports a writer.
 
 **Speed.**
-Warm in-process FFI is a few times native cost; cold process reloads the GHC RTS (tens of ms).
+Warm in-process FFI parse is a few times native cost; a cold =pandoc= CLI process reloads the GHC RTS (tens of ms).
+The writer is that CLI spawn unless the FFI library exports a writer — it is never a surprise.
 Snapper also caches pandoc JSON ASTs by content hash (memory + disk under =$XDG_CACHE_HOME/snapper/pandoc-ast=).
-Re-formatting the same source skips pandoc entirely.
+Re-formatting the same source skips pandoc parse.
 Disable with =SNAPPER_PANDOC_CACHE=0=; override dir with =SNAPPER_PANDOC_CACHE_DIR=.
 
 * When to use pandoc vs built-in parsers

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -182,9 +182,21 @@ Overrides =--lang=.
 :END:
 
 Use pandoc as the parser backend instead of built-in parsers.
-Requires pandoc on PATH.
+Parse may use in-process FFI when =libsnapper_pandoc= loads; the writer still needs =pandoc= on =PATH= (=libsnapper_pandoc= is reader-only) unless that library exports a writer.
+Without FFI, both parse and write use the =pandoc= CLI. A missing binary is an explicit error (never silent all-prose).
 Enables support for typst, asciidoc, docx, html, and all other pandoc-supported formats.
-Falls back silently if pandoc is unavailable (unless this flag is explicit).
+Native line parsers remain the default (omit this flag).
+
+*** =--pandoc-backend <auto|ffi|cli>=
+:PROPERTIES:
+:CUSTOM_ID: opt-pandoc-backend
+:END:
+
+How to obtain the pandoc AST when =--use-pandoc= is set.
+=auto= (default) prefers in-process FFI, else CLI.
+=ffi= requires =libsnapper_pandoc= (explicit error if missing).
+=cli= uses a =pandoc= subprocess (explicit error if missing).
+The writer still needs =pandoc= on =PATH= when the FFI library has no writer.
 
 *** =--config <PATH>=
 :PROPERTIES:

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -183,7 +183,8 @@ Overrides =--lang=.
 
 Use pandoc as the parser backend instead of built-in parsers.
 Parse may use in-process FFI when =libsnapper_pandoc= loads; the writer still needs =pandoc= on =PATH= (=libsnapper_pandoc= is reader-only) unless that library exports a writer.
-Without FFI, both parse and write use the =pandoc= CLI. A missing binary is an explicit error (never silent all-prose).
+Without FFI, both parse and write use the =pandoc= CLI.
+A missing binary is an explicit error (never silent all-prose).
 Enables support for typst, asciidoc, docx, html, and all other pandoc-supported formats.
 Native line parsers remain the default (omit this flag).
 

--- a/docs/source/cli-reference.md
+++ b/docs/source/cli-reference.md
@@ -49,8 +49,8 @@ Semantic line break formatter
 * `--neural` — Use neural sentence detection (nnsplit LSTM model)
 * `--lang <LANG>` — Language for neural sentence detection (default: en). Available: en, de, fr, no, sv, zh, tr, ru, uk
 * `--model-path <MODEL_PATH>` — Path to custom ONNX model file for neural detection
-* `--use-pandoc` — Use pandoc as parser backend (universal format support). Refuses when the source has comments or `snapper:off` / `snapper:on` that pandoc's reader would delete
-* `--pandoc-backend <BACKEND>` — Pandoc AST source when `--use-pandoc` is set: `auto` (prefer in-process FFI, else CLI), `ffi` (`libsnapper_pandoc`), or `cli` (`pandoc` subprocess). Default: `auto`. `ffi` fails explicitly if the library is missing
+* `--use-pandoc` — Use pandoc as parser backend (universal format support). Refuses when the source has comments or `snapper:off` / `snapper:on` that pandoc's reader would delete. Parse may use in-process FFI; the writer still needs `pandoc` on PATH (`libsnapper_pandoc` is reader-only) unless that library exports a writer. Without FFI, both parse and write use the `pandoc` CLI (explicit error if missing)
+* `--pandoc-backend <BACKEND>` — Pandoc AST source when `--use-pandoc` is set: `auto` (prefer in-process FFI, else CLI), `ffi` (`libsnapper_pandoc`), or `cli` (`pandoc` subprocess). Default: `auto`. `ffi` fails explicitly if the library is missing. The writer still needs `pandoc` on PATH (no silent spawn surprise)
 
   Default value: `auto`
 * `--check` — Exit with code 1 if any file would change

--- a/native/snapper-pandoc/README.md
+++ b/native/snapper-pandoc/README.md
@@ -1,7 +1,9 @@
 # snapper-pandoc
 
 In-process pandoc surface for snapper: a small C ABI (`include/snapper_pandoc.h`)
-over selected pandoc **readers** (JSON AST out).
+over selected pandoc **readers** (JSON AST out). The library is reader-only;
+snapper's writer still needs `pandoc` on `PATH` unless a future library
+exports `snapper_pandoc_write`.
 
 ## Platform matrix
 
@@ -81,6 +83,8 @@ Formats: `markdown`/`gfm`/`commonmark`, `org`, `rst`, `latex`, `html`, `typst`.
 
 The host process must initialize the GHC RTS (`hs_init`) before parse. Rust
 bindings in `src/parser/pandoc/ffi.rs` own that lifecycle (process-lifetime argv).
+Write stays the `pandoc` CLI unless `snapper_pandoc_write` is present; help and
+errors say so (no silent spawn).
 
 ## UPX (optional post-build pack)
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -96,6 +96,10 @@ pub struct Cli {
     /// Use pandoc as parser backend (universal format support).
     /// Refuses when the source has comments or `snapper:off` / `snapper:on`
     /// that pandoc's reader would delete.
+    /// Parse may use in-process FFI; the writer still needs `pandoc` on PATH
+    /// (`libsnapper_pandoc` is reader-only) unless that library exports a
+    /// writer. Without FFI, both parse and write use the `pandoc` CLI
+    /// (explicit error if missing).
     #[arg(long)]
     pub use_pandoc: bool,
 
@@ -103,6 +107,7 @@ pub struct Cli {
     /// `auto` (prefer in-process FFI, else CLI), `ffi` (`libsnapper_pandoc`),
     /// or `cli` (`pandoc` subprocess). Default: `auto`.
     /// `ffi` fails explicitly if the library is missing.
+    /// The writer still needs `pandoc` on PATH (no silent spawn surprise).
     #[arg(long, default_value = "auto", value_name = "BACKEND")]
     pub pandoc_backend: String,
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,9 @@ pub struct FormatConfig {
     /// Pandoc input format string (for pandoc backend).
     pub pandoc_format: Option<String>,
     /// How to obtain the pandoc AST when `use_pandoc` is set.
-    /// `Ffi` uses in-process Haskell/C bindings; `Cli` uses a subprocess.
+    /// `Ffi` uses in-process Haskell/C bindings for parse; `Cli` uses a
+    /// subprocess. Write is in-process only when the library exports a
+    /// writer; otherwise it still needs `pandoc` on PATH.
     #[cfg(feature = "pandoc")]
     pub pandoc_backend: parser::pandoc::PandocBackend,
     /// Per-language code-block configuration loaded from `[code]` in

--- a/src/parser/pandoc/cli.rs
+++ b/src/parser/pandoc/cli.rs
@@ -49,7 +49,11 @@ pub fn parse_via_cli_with_json(
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| CliError::Spawn(e.to_string()))?;
+        .map_err(|e| {
+            CliError::Spawn(format!(
+                "need pandoc on PATH (CLI backend is explicit): {e}"
+            ))
+        })?;
 
     if let Some(ref mut stdin) = child.stdin {
         stdin

--- a/src/parser/pandoc/ffi.rs
+++ b/src/parser/pandoc/ffi.rs
@@ -40,6 +40,12 @@ type ParseFn = unsafe extern "C" fn(
 type FreeFn = unsafe extern "C" fn(*mut c_char);
 #[cfg(not(feature = "pandoc-colink"))]
 type ReadyFn = unsafe extern "C" fn();
+#[cfg(not(feature = "pandoc-colink"))]
+type WriteFn = unsafe extern "C" fn(
+    format: *const c_char,
+    json: *const c_char,
+    err_out: *mut *mut c_char,
+) -> *mut c_char;
 type HsInitFn = unsafe extern "C" fn(*mut c_int, *mut *mut *mut c_char);
 
 /// Non-threaded GHC RTS is not re-entrant from multiple OS threads.
@@ -132,6 +138,18 @@ mod linked {
     pub fn available() -> bool {
         ensure_init().is_ok()
     }
+
+    /// Colink archives today export readers only. Do not require
+    /// `snapper_pandoc_write` at link time (old archives would fail).
+    pub fn write_available() -> bool {
+        false
+    }
+
+    pub fn write(_format: &str, _json: &str) -> Result<String, FfiError> {
+        Err(FfiError::LibraryUnavailable(
+            "libsnapper_pandoc is reader-only; writer still needs pandoc on PATH".into(),
+        ))
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +166,8 @@ mod dynamic {
         _lib: Library,
         parse: ParseFn,
         free: FreeFn,
+        /// Present only when the loaded library exports a writer.
+        write: Option<WriteFn>,
     }
 
     static API: OnceLock<Result<FfiApi, String>> = OnceLock::new();
@@ -256,6 +276,9 @@ mod dynamic {
             .map_err(|e| format!("{}: missing snapper_pandoc_parse: {e}", path.display()))?;
         let free: Symbol<FreeFn> = unsafe { lib.get(b"snapper_pandoc_free\0") }
             .map_err(|e| format!("{}: missing snapper_pandoc_free: {e}", path.display()))?;
+        let write: Option<WriteFn> = unsafe { lib.get(b"snapper_pandoc_write\0") }
+            .ok()
+            .map(|s: Symbol<WriteFn>| *s);
         let ready: Option<Symbol<ReadyFn>> = unsafe { lib.get(b"snapper_pandoc_hs_ready\0") }.ok();
         let hs_init: Option<Symbol<HsInitFn>> = unsafe { lib.get(b"hs_init\0") }.ok();
 
@@ -275,6 +298,7 @@ mod dynamic {
         Ok(FfiApi {
             parse: *parse,
             free: *free,
+            write,
             _lib: lib,
         })
     }
@@ -334,6 +358,50 @@ mod dynamic {
         drop(_rts);
         Ok(json)
     }
+
+    pub fn write_available() -> bool {
+        load_api().is_ok_and(|api| api.write.is_some())
+    }
+
+    pub fn write(format: &str, json: &str) -> Result<String, FfiError> {
+        let api = load_api()?;
+        let write = api.write.ok_or_else(|| {
+            FfiError::LibraryUnavailable(
+                "libsnapper_pandoc is reader-only; writer still needs pandoc on PATH".into(),
+            )
+        })?;
+        let fmt = CString::new(format)
+            .map_err(|e| FfiError::ParseFailed(format!("format contained NUL: {e}")))?;
+        let inp = CString::new(json)
+            .map_err(|e| FfiError::ParseFailed(format!("json contained NUL: {e}")))?;
+        let _rts = RTS_GATE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let mut err_ptr: *mut c_char = std::ptr::null_mut();
+        let out_ptr = unsafe { write(fmt.as_ptr(), inp.as_ptr(), &mut err_ptr) };
+        if out_ptr.is_null() {
+            let msg = if !err_ptr.is_null() {
+                let s = unsafe { CStr::from_ptr(err_ptr) }
+                    .to_string_lossy()
+                    .into_owned();
+                unsafe { (api.free)(err_ptr) };
+                s
+            } else {
+                "unknown pandoc FFI writer error (null result, no message)".to_string()
+            };
+            return Err(FfiError::ParseFailed(msg));
+        }
+        let text = unsafe {
+            let c = CStr::from_ptr(out_ptr);
+            match std::str::from_utf8(c.to_bytes()) {
+                Ok(s) => s.to_owned(),
+                Err(_) => c.to_string_lossy().into_owned(),
+            }
+        };
+        unsafe { (api.free)(out_ptr) };
+        drop(_rts);
+        Ok(text)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -349,6 +417,33 @@ pub fn ffi_available() -> bool {
     #[cfg(not(feature = "pandoc-colink"))]
     {
         dynamic::available()
+    }
+}
+
+/// Whether the loaded library exports an in-process writer.
+///
+/// Shipped `libsnapper_pandoc` is reader-only, so this is false unless a
+/// newer library provides `snapper_pandoc_write`.
+pub fn ffi_write_available() -> bool {
+    #[cfg(feature = "pandoc-colink")]
+    {
+        linked::write_available()
+    }
+    #[cfg(not(feature = "pandoc-colink"))]
+    {
+        dynamic::write_available()
+    }
+}
+
+/// Write a pandoc JSON AST with the in-process library (when exported).
+pub fn write_via_ffi(json: &str, format: &str) -> Result<String, FfiError> {
+    #[cfg(feature = "pandoc-colink")]
+    {
+        linked::write(format, json)
+    }
+    #[cfg(not(feature = "pandoc-colink"))]
+    {
+        dynamic::write(format, json)
     }
 }
 
@@ -445,6 +540,46 @@ mod tests {
         assert!(
             pack_txt.contains("upx") && pack_txt.contains("-9"),
             "pack-upx.sh must invoke upx with compression flags"
+        );
+    }
+
+    #[test]
+    fn default_cargo_features_stay_ghc_free() {
+        let manifest = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let toml = std::fs::read_to_string(manifest.join("Cargo.toml")).expect("Cargo.toml");
+        let default = toml
+            .lines()
+            .find(|l| l.starts_with("default ="))
+            .expect("default features line");
+        assert!(
+            !default.contains("pandoc-colink"),
+            "cargo-dist default must stay GHC-free: {default}"
+        );
+        assert!(
+            default.contains("pandoc"),
+            "default still enables the optional pandoc (dlopen) feature: {default}"
+        );
+    }
+
+    #[test]
+    fn ffi_write_without_symbol_is_explicit_not_silent() {
+        if ffi_write_available() {
+            return;
+        }
+        if !ffi_available() {
+            let err = write_via_ffi("{}", "markdown").unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("unavailable") || msg.contains("PATH") || msg.contains("reader-only"),
+                "expected explicit writer/library error, got: {msg}"
+            );
+            return;
+        }
+        let err = write_via_ffi("{}", "markdown").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("PATH") || msg.contains("reader-only") || msg.contains("unavailable"),
+            "reader-only lib must not hide the writer requirement: {msg}"
         );
     }
 }

--- a/src/parser/pandoc/mod.rs
+++ b/src/parser/pandoc/mod.rs
@@ -6,8 +6,10 @@
 //! 2. **Apply** snapper only to prose-bearing nodes (`Para` / `Plain`); leave
 //!    `Header`, `CodeBlock`, `Table`, etc. alone because the AST says they are
 //!    not prose.
-//! 3. **Write** the mutated AST through pandoc's writer (`pandoc -f json
-//!    --wrap=preserve`). Do not splice original source bytes.
+//! 3. **Write** the mutated AST through an in-process FFI writer when the
+//!    loaded library exports one, otherwise `pandoc -f json --wrap=preserve`.
+//!    Do not splice original source bytes. A missing CLI writer is an
+//!    explicit PATH error (no silent spawn).
 //!
 //! That is the opposite of the native path (guess structure from source lines,
 //! then splice). Here pandoc owns structure; snapper owns sentence line breaks
@@ -17,7 +19,9 @@
 //! - **CLI** ([`PandocBackend::Cli`]): `pandoc -t json` (full installed readers).
 //! - **FFI** ([`PandocBackend::Ffi`]): `libsnapper_pandoc` (linked library readers).
 //!
-//! The writer is always the CLI (`libsnapper_pandoc` is reader-only).
+//! The shipped library is reader-only. Write stays in-process only when
+//! `snapper_pandoc_write` is exported; otherwise help/error say the writer
+//! still needs `pandoc` on PATH.
 
 pub mod ast;
 pub mod cache;
@@ -35,15 +39,16 @@ use crate::parser::{FormatParser, Region};
 
 pub use ast::{regions_from_pandoc, regions_from_pandoc_json};
 pub use cli::pandoc_cli_available as pandoc_available;
-pub use ffi::ffi_available;
+pub use ffi::{ffi_available, ffi_write_available};
 pub use reflow::reflow_pandoc;
-pub use write::write_via_cli;
+pub use write::{WRITER_NEEDS_PATH, write_ast, write_via_cli};
 
 /// How to obtain the pandoc AST.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum PandocBackend {
     /// Prefer in-process FFI when `libsnapper_pandoc` loads; else CLI.
-    /// Successor default: amortizes RTS and avoids process-per-file spawn.
+    /// Parse amortizes the RTS. Write stays in-process only when the
+    /// library exports a writer; otherwise the CLI writer is explicit.
     #[default]
     Auto,
     /// In-process Haskell FFI (`libsnapper_pandoc`). Explicit error if unavailable.
@@ -204,8 +209,8 @@ fn refuse_if_comments_missing(input: &str, format: &str, output: &str) -> Result
 
 /// Parse → reflow Para/Plain → write through pandoc's writer.
 ///
-/// Not a splice of the original bytes. The writer needs a `pandoc` binary
-/// even when parse used FFI (`libsnapper_pandoc` has no writers).
+/// Not a splice of the original bytes. If the FFI library has no writer,
+/// this still needs `pandoc` on PATH and says so (`WRITER_NEEDS_PATH`).
 ///
 /// Refuses when the source has RST `..` comments or `snapper:off` /
 /// `snapper:on` that pandoc's reader would delete (empty AST, exit 0).
@@ -225,7 +230,7 @@ pub fn format_via_pandoc(
     reflow_pandoc(&mut doc, splitter, reflow_config);
     let out_json =
         serde_json::to_string(&doc).map_err(|e| PandocError::Ast(format!("serialize AST: {e}")))?;
-    let written = write_via_cli(&out_json, format).map_err(PandocError::from)?;
+    let written = write_ast(&out_json, format).map_err(PandocError::from)?;
     refuse_if_comments_missing(input, format, &written)?;
     Ok(written)
 }
@@ -396,6 +401,41 @@ mod tests {
             PandocError::DropsComments(kind) => assert!(kind.contains("RST")),
             other => panic!("expected DropsComments, got {other}"),
         }
+    }
+
+    #[test]
+    fn default_use_pandoc_is_false() {
+        assert!(
+            !crate::FormatConfig::default().use_pandoc,
+            "native path stays default (snapper-32ps owns any flip)"
+        );
+    }
+
+    #[test]
+    fn wasm_entry_stays_native() {
+        let wasm = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/wasm.rs"));
+        assert!(
+            wasm.contains("use_pandoc: false"),
+            "wasm must keep use_pandoc false (snapper-ekc0 / this ticket)"
+        );
+    }
+
+    #[test]
+    fn cargo_dist_default_features_stay_ghc_free() {
+        let cargo = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml"));
+        let default_line = cargo
+            .lines()
+            .find(|l| l.starts_with("default ="))
+            .expect("default features line");
+        assert!(
+            !default_line.contains("pandoc-colink"),
+            "cargo-dist default builds must stay GHC-free: {default_line}"
+        );
+        let dist = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/dist-workspace.toml"));
+        assert!(
+            !dist.contains("pandoc-colink"),
+            "dist-workspace.toml must not enable pandoc-colink"
+        );
     }
 
     #[test]

--- a/src/parser/pandoc/write.rs
+++ b/src/parser/pandoc/write.rs
@@ -1,14 +1,35 @@
-//! Write a pandoc JSON AST through the installed pandoc writer.
+//! Write a pandoc JSON AST through an in-process writer when the loaded
+//! `libsnapper_pandoc` exports one, otherwise through the installed pandoc CLI.
 //!
-//! The FFI library is reader-only. Reconstruction of source bytes is
+//! Today's library is reader-only. Reconstruction of source bytes is
 //! impossible (no offsets) and is not attempted: `pandoc -f json -t <format>
-//! --wrap=preserve` owns emission. SoftBreaks inserted by AST reflow become
-//! sentence line breaks.
+//! --wrap=preserve` owns emission unless an FFI writer is present. SoftBreaks
+//! inserted by AST reflow become sentence line breaks.
+//!
+//! A missing CLI writer is an explicit PATH error — never a silent spawn.
 
 use std::io::Write;
 use std::process::{Command, Stdio};
 
 use super::cli::CliError;
+
+/// Help/error contract: write still needs `pandoc` on PATH when the FFI
+/// library has no writer. Parse may already have used in-process FFI.
+pub const WRITER_NEEDS_PATH: &str =
+    "writer still needs pandoc on PATH (libsnapper_pandoc is reader-only)";
+
+/// Render `json` (a pandoc AST) as `format`.
+///
+/// Prefers [`super::ffi::write_via_ffi`] when the loaded library exports
+/// `snapper_pandoc_write`. Otherwise requires the `pandoc` CLI and names
+/// that requirement on failure.
+pub fn write_ast(json: &str, format: &str) -> Result<String, CliError> {
+    if super::ffi::ffi_write_available() {
+        return super::ffi::write_via_ffi(json, format)
+            .map_err(|e| CliError::Spawn(format!("{WRITER_NEEDS_PATH}: {e}")));
+    }
+    write_via_cli(json, format)
+}
 
 /// Render `json` (a pandoc AST) as `format` via the CLI writer.
 pub fn write_via_cli(json: &str, format: &str) -> Result<String, CliError> {
@@ -18,7 +39,7 @@ pub fn write_via_cli(json: &str, format: &str) -> Result<String, CliError> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .map_err(|e| CliError::Spawn(e.to_string()))?;
+        .map_err(|e| CliError::Spawn(format!("{WRITER_NEEDS_PATH}: {e}")))?;
 
     if let Some(ref mut stdin) = child.stdin {
         stdin
@@ -56,5 +77,25 @@ mod tests {
         match err {
             CliError::Exit(_) | CliError::Spawn(_) | CliError::InvalidAst(_) => {}
         }
+    }
+
+    #[test]
+    fn writer_needs_path_contract_is_explicit() {
+        assert!(WRITER_NEEDS_PATH.contains("PATH"));
+        assert!(WRITER_NEEDS_PATH.contains("writer"));
+        assert!(WRITER_NEEDS_PATH.contains("reader-only"));
+    }
+
+    #[test]
+    fn writer_missing_pandoc_is_explicit_path_error() {
+        if pandoc_cli_available() {
+            return;
+        }
+        let err = write_via_cli("{}", "markdown").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("PATH") && msg.contains("reader-only"),
+            "expected explicit writer PATH error, got: {msg}"
+        );
     }
 }

--- a/tests/pandoc_ast_backend.rs
+++ b/tests/pandoc_ast_backend.rs
@@ -10,11 +10,12 @@ use std::path::PathBuf;
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::Region;
 use snapper_fmt::parser::pandoc::{
-    PandocBackend, PandocParser, dropped_comment_kind, ffi_available, regions_from_pandoc_json,
+    PandocBackend, PandocParser, WRITER_NEEDS_PATH, dropped_comment_kind, ffi_available,
+    ffi_write_available, regions_from_pandoc_json,
 };
 use snapper_fmt::{FormatConfig, format_text};
 
-/// Writer is CLI-only (`libsnapper_pandoc` has no writers).
+/// CLI writer is required unless the loaded FFI library exports a writer.
 fn require_writer() -> bool {
     if snapper_fmt::parser::pandoc::pandoc_available() {
         true
@@ -202,8 +203,8 @@ fn format_text_ffi_live_stable_when_lib_present() {
         pandoc_format: Some("markdown".into()),
         ..Default::default()
     };
-    let a = format_text(&input, &cfg).expect("ffi parse + cli write");
-    let b = format_text(&input, &cfg).expect("ffi parse + cli write 2");
+    let a = format_text(&input, &cfg).expect("ffi parse + write");
+    let b = format_text(&input, &cfg).expect("ffi parse + write 2");
     assert_eq!(a, b);
     assert_has_sentence_break(&a, "Hello world.", "Second sentence");
 }
@@ -784,4 +785,109 @@ fn format_text_use_pandoc_rst_prose_still_writes() {
     )
     .expect("pandoc rst prose");
     assert_has_sentence_break(&out, "Hello world.", "Second sentence");
+}
+
+/// `--help` must name the CLI writer requirement (no silent spawn).
+#[test]
+fn snapper_help_says_writer_needs_pandoc_on_path() {
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let out = std::process::Command::new(bin)
+        .arg("--help")
+        .output()
+        .expect("snapper --help");
+    assert!(out.status.success(), "help must exit 0");
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains("writer still needs") && text.contains("PATH"),
+        "help must say the writer still needs pandoc on PATH:\n{text}"
+    );
+    assert!(
+        text.contains("reader-only") || text.contains("libsnapper_pandoc"),
+        "help must mention the reader-only FFI library:\n{text}"
+    );
+}
+
+/// Without FFI, `--use-pandoc --pandoc-backend cli` with no `pandoc` on PATH
+/// is an explicit CLI error (not silent all-prose).
+#[test]
+fn snapper_cli_backend_without_pandoc_on_path_is_explicit() {
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let input = fixture("mixed.md");
+    let out = std::process::Command::new(bin)
+        .args([
+            "--use-pandoc",
+            "--pandoc-backend",
+            "cli",
+            "--format",
+            "markdown",
+        ])
+        .arg(&input)
+        .env("PATH", "/nonexistent-snapper-ypwj")
+        .env("SNAPPER_PANDOC_CACHE", "0")
+        .env_remove("SNAPPER_PANDOC_LIB")
+        .env_remove("SNAPPER_PANDOC_LIB_DIR")
+        .output()
+        .expect("spawn snapper");
+    assert!(
+        !out.status.success(),
+        "CLI backend without pandoc must fail; stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("PATH") || err.contains("CLI") || err.contains("unavailable"),
+        "expected explicit CLI/PATH error, got: {err}"
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.trim().is_empty() || !stdout.contains("Hello world."),
+        "must not emit all-prose success without pandoc: {stdout}"
+    );
+}
+
+/// With FFI parse and no in-process writer, missing `pandoc` on PATH is the
+/// explicit writer error. If the library exports a writer, format stays
+/// in-process (no PATH pandoc).
+#[test]
+fn snapper_ffi_without_pandoc_on_path_is_inprocess_or_explicit() {
+    if !ffi_available() {
+        eprintln!("skipping: libsnapper_pandoc not loadable");
+        return;
+    }
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let input = fixture("mixed.md");
+    let out = std::process::Command::new(bin)
+        .args([
+            "--use-pandoc",
+            "--pandoc-backend",
+            "ffi",
+            "--format",
+            "markdown",
+        ])
+        .arg(&input)
+        .env("PATH", "/nonexistent-snapper-ypwj")
+        .env("SNAPPER_PANDOC_CACHE", "0")
+        .output()
+        .expect("spawn snapper");
+    let err = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    if ffi_write_available() {
+        assert!(
+            out.status.success(),
+            "FFI writer must not need pandoc on PATH; stderr={err} stdout={stdout}"
+        );
+        assert!(
+            stdout.contains("Hello world."),
+            "in-process write should emit prose:\n{stdout}"
+        );
+        return;
+    }
+    assert!(
+        !out.status.success(),
+        "reader-only FFI must not silently spawn; stdout={stdout}"
+    );
+    assert!(
+        err.contains("PATH") || err.contains(WRITER_NEEDS_PATH) || err.contains("writer"),
+        "expected explicit writer PATH error, got: {err}"
+    );
 }


### PR DESCRIPTION
Parse can already use in-process FFI. The writer still called `pandoc` on PATH with no mention of that.

`--use-pandoc` now writes in-process when the loaded library exports `snapper_pandoc_write`. Otherwise help and spawn errors say the writer needs `pandoc` on PATH. Native default, wasm, and cargo-dist stay GHC-free.

This is snapper-ypwj. Default flip stays later.
