### PR TITLE
test(pandoc): keep wasm and editors on native parsers

### DIFF
--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -101,3 +101,4 @@ The two paths are different pipelines, not two ways to fake the same source line
 - Use the native parser (omit =--use-pandoc=) to keep that text.
 - Round-trip is through the AST (not a perfect source-preserving rewrite of every markup character)
 - FFI library is optional; wasm/editor bundles do not embed GHC/pandoc
+- CLI pandoc versus editor native is the contract: the CLI may take =--use-pandoc=; VS Code, Obsidian, and Word stay on native parsers.

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -55,6 +55,8 @@ impl SnapperLsp {
             latex_structure_envs: project.latex_structure_envs(),
             latex_verbatim_commands: project.latex_verbatim_commands(),
             clause_breaks: project.clause_breaks.unwrap_or(false),
+            // VS Code / Helix LSP stay native even if the CLI default flips.
+            use_pandoc: false,
             ..Default::default()
         }
     }

--- a/src/parser/pandoc/mod.rs
+++ b/src/parser/pandoc/mod.rs
@@ -411,13 +411,79 @@ mod tests {
         );
     }
 
+    fn assert_no_use_pandoc_knob(label: &str, src: &str) {
+        let lower = src.to_ascii_lowercase();
+        assert!(
+            !lower.contains("set_use_pandoc"),
+            "{label} must not expose set_use_pandoc"
+        );
+        assert!(
+            !lower.contains("usepandoc"),
+            "{label} must not expose usePandoc"
+        );
+        assert!(
+            !src.contains("use_pandoc"),
+            "{label} must not set or forward use_pandoc"
+        );
+        assert!(
+            !src.contains("--use-pandoc"),
+            "{label} must not pass --use-pandoc"
+        );
+    }
+
+    fn repo_src(rel: &str) -> Option<String> {
+        std::fs::read_to_string(std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)).ok()
+    }
+
     #[test]
-    fn wasm_entry_stays_native() {
+    fn wasm_and_editor_config_cannot_set_use_pandoc() {
         let wasm = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/wasm.rs"));
         assert!(
             wasm.contains("use_pandoc: false"),
-            "wasm must keep use_pandoc false (snapper-ekc0 / this ticket)"
+            "wasm must hardcode use_pandoc false (snapper-ekc0)"
         );
+        assert_eq!(
+            wasm.matches("use_pandoc").count(),
+            1,
+            "wasm must have exactly one use_pandoc (hardcoded false, no setter)"
+        );
+        assert!(
+            !wasm.contains("set_use_pandoc"),
+            "WasmConfig must not grow a use_pandoc setter"
+        );
+
+        let lsp = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/src/lsp.rs"));
+        assert!(
+            lsp.contains("use_pandoc: false"),
+            "VS Code LSP must force native parsers"
+        );
+        assert!(!lsp.contains("use_pandoc: true"));
+        assert!(!lsp.contains("set_use_pandoc"));
+        assert!(!lsp.contains("--use-pandoc"));
+
+        // Editor / JS wrappers live in the git tree, not the crates.io tarball.
+        let extras = [
+            "packages/snapper-wasm/src/types.ts",
+            "packages/snapper-wasm/src/index.ts",
+            "editors/obsidian/src/formatter.ts",
+            "editors/obsidian/src/settings.ts",
+            "editors/word/src/shared/formatter.ts",
+            "editors/vscode/src/extension.ts",
+        ];
+        let mut seen = 0;
+        for rel in extras {
+            if let Some(src) = repo_src(rel) {
+                seen += 1;
+                assert_no_use_pandoc_knob(rel, &src);
+            }
+        }
+        if repo_src("editors/vscode/src/extension.ts").is_some() {
+            assert_eq!(
+                seen,
+                extras.len(),
+                "all editor sources readable in checkout"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
A later CLI default flip must not switch VS Code, Helix, Obsidian, or Word onto pandoc.

LSP `make_config` now hardcodes `use_pandoc: false`. WasmConfig still has no setter. A lock test covers wasm and the editor JS wrappers. The howto states the CLI versus editor contract.

This is snapper-ekc0. Default flip stays later.
