### PR TITLE
feat(pandoc): keep RST comments and snapper pragmas on write

### DIFF
--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -97,8 +97,8 @@ The two paths are different pipelines, not two ways to fake the same source line
 :END:
 
 - Pandoc's reader deletes comments (RST =..= comments, HTML comments) and therefore =snapper:off= / =snapper:on=.
-- =--use-pandoc= refuses with an explicit error instead of writing the stripped document and exiting 0.
-- Use the native parser (omit =--use-pandoc=) to keep that text.
+- =--use-pandoc= shields RST =..= comments and =snapper:off= / =snapper:on= so the written output still contains that text and exits 0.
+- Other HTML / Org / LaTeX comments that are not snapper pragmas may still be dropped.
 - Round-trip is through the AST (not a perfect source-preserving rewrite of every markup character)
 - FFI library is optional; wasm/editor bundles do not embed GHC/pandoc
 - CLI pandoc versus editor native is the contract: the CLI may take =--use-pandoc=; VS Code, Obsidian, and Word stay on native parsers.

--- a/docs/orgmode/howto/pragmas.org
+++ b/docs/orgmode/howto/pragmas.org
@@ -118,6 +118,6 @@ Pragmas take priority over all other parsing.
 Inside an off region, no sentence splitting, no format-aware parsing, and no abbreviation handling occurs.
 The pragma comment lines themselves always pass through as structure.
 
-=--use-pandoc= does not honor pragmas: pandoc's reader drops them (zero blocks).
-The write path refuses those files with an explicit error instead of deleting the markers.
-Use the native parser (omit =--use-pandoc=) when a file contains =snapper:off= / =snapper:on=.
+=--use-pandoc= keeps =snapper:off= / =snapper:on= in the written output (the reader would otherwise delete them).
+Off-region text is shielded so it is not reflowed.
+Native parsers remain the default.

--- a/docs/source/cli-reference.md
+++ b/docs/source/cli-reference.md
@@ -49,7 +49,7 @@ Semantic line break formatter
 * `--neural` — Use neural sentence detection (nnsplit LSTM model)
 * `--lang <LANG>` — Language for neural sentence detection (default: en). Available: en, de, fr, no, sv, zh, tr, ru, uk
 * `--model-path <MODEL_PATH>` — Path to custom ONNX model file for neural detection
-* `--use-pandoc` — Use pandoc as parser backend (universal format support). Refuses when the source has comments or `snapper:off` / `snapper:on` that pandoc's reader would delete. Parse may use in-process FFI; the writer still needs `pandoc` on PATH (`libsnapper_pandoc` is reader-only) unless that library exports a writer. Without FFI, both parse and write use the `pandoc` CLI (explicit error if missing)
+* `--use-pandoc` — Use pandoc as parser backend (universal format support). RST `..` comments and `snapper:off` / `snapper:on` are written through so the output still contains that text. Parse may use in-process FFI; the writer still needs `pandoc` on PATH (`libsnapper_pandoc` is reader-only) unless that library exports a writer. Without FFI, both parse and write use the `pandoc` CLI (explicit error if missing)
 * `--pandoc-backend <BACKEND>` — Pandoc AST source when `--use-pandoc` is set: `auto` (prefer in-process FFI, else CLI), `ffi` (`libsnapper_pandoc`), or `cli` (`pandoc` subprocess). Default: `auto`. `ffi` fails explicitly if the library is missing. The writer still needs `pandoc` on PATH (no silent spawn surprise)
 
   Default value: `auto`

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -94,8 +94,8 @@ pub struct Cli {
     pub model_path: Option<PathBuf>,
 
     /// Use pandoc as parser backend (universal format support).
-    /// Refuses when the source has comments or `snapper:off` / `snapper:on`
-    /// that pandoc's reader would delete.
+    /// RST `..` comments and `snapper:off` / `snapper:on` are written
+    /// through so the output still contains that text.
     /// Parse may use in-process FFI; the writer still needs `pandoc` on PATH
     /// (`libsnapper_pandoc` is reader-only) unless that library exports a
     /// writer. Without FFI, both parse and write use the `pandoc` CLI

--- a/src/parser/pandoc/mod.rs
+++ b/src/parser/pandoc/mod.rs
@@ -28,6 +28,7 @@ pub mod cache;
 pub mod cli;
 pub mod ffi;
 pub mod reflow;
+mod shield;
 pub mod write;
 
 use std::path::Path;
@@ -105,9 +106,8 @@ pub enum PandocError {
     Cli(#[from] cli::CliError),
     #[error("pandoc AST cache/classify: {0}")]
     Ast(String),
-    /// Pandoc's reader deletes comments (RST `..`, HTML) and therefore
-    /// `snapper:off` / `snapper:on`. Write-through must not exit 0 after
-    /// that deletion.
+    /// Backstop: write-through deleted an RST `..` comment or a
+    /// `snapper:off` / `snapper:on` that the shield failed to restore.
     #[error("pandoc path would drop {0}; omit --use-pandoc to keep comments and snapper pragmas")]
     DropsComments(String),
 }
@@ -174,15 +174,12 @@ pub fn dropped_comment_kind(input: &str, format: &str) -> Option<&'static str> {
     {
         return Some("snapper:off/on");
     }
-    if is_rst_pandoc_format(format) && crate::parser::rst::source_has_dropped_rst_comments(input) {
+    if shield::is_rst_pandoc_format(format)
+        && crate::parser::rst::source_has_dropped_rst_comments(input)
+    {
         return Some("RST comment");
     }
     None
-}
-
-fn is_rst_pandoc_format(format: &str) -> bool {
-    let base = format.split(['+', '-']).next().unwrap_or(format);
-    matches!(base, "rst" | "rest")
 }
 
 /// Writer-side backstop: a detector miss must still not exit 0 after a drop.
@@ -192,15 +189,34 @@ fn refuse_if_comments_missing(input: &str, format: &str, output: &str) -> Result
             return Err(PandocError::DropsComments("snapper:off/on".into()));
         }
     }
-    if is_rst_pandoc_format(format) {
-        for line in input.lines() {
-            let trimmed = line.trim_start();
+    if shield::is_rst_pandoc_format(format) {
+        let lines: Vec<&str> = input.lines().collect();
+        let mut i = 0;
+        while i < lines.len() {
+            let trimmed = lines[i].trim_start();
             if !crate::parser::rst::is_rst_dropped_comment_opener(trimmed) {
+                i += 1;
                 continue;
             }
             let payload = trimmed.strip_prefix("..").unwrap_or("").trim();
             if !payload.is_empty() && !output.contains(payload) {
                 return Err(PandocError::DropsComments("RST comment".into()));
+            }
+            let leading = lines[i].len() - trimmed.len();
+            let comment_indent = leading + 1;
+            i += 1;
+            while i < lines.len() {
+                let body = lines[i];
+                let lead = body.len() - body.trim_start().len();
+                if body.trim().is_empty() || lead >= comment_indent {
+                    let body_txt = body.trim();
+                    if !body_txt.is_empty() && !output.contains(body_txt) {
+                        return Err(PandocError::DropsComments("RST comment".into()));
+                    }
+                    i += 1;
+                    continue;
+                }
+                break;
             }
         }
     }
@@ -212,8 +228,9 @@ fn refuse_if_comments_missing(input: &str, format: &str, output: &str) -> Result
 /// Not a splice of the original bytes. If the FFI library has no writer,
 /// this still needs `pandoc` on PATH and says so (`WRITER_NEEDS_PATH`).
 ///
-/// Refuses when the source has RST `..` comments or `snapper:off` /
-/// `snapper:on` that pandoc's reader would delete (empty AST, exit 0).
+/// RST `..` comments and `snapper:off` / `snapper:on` are shielded
+/// across the reader so the written output still contains that text.
+/// A restore miss is still `DropsComments` (fail-closed backstop).
 pub fn format_via_pandoc(
     input: &str,
     format: &str,
@@ -221,16 +238,15 @@ pub fn format_via_pandoc(
     splitter: &dyn crate::sentence::SentenceSplitter,
     reflow_config: &crate::reflow::ReflowConfig,
 ) -> Result<String, PandocError> {
-    if let Some(kind) = dropped_comment_kind(input, format) {
-        return Err(PandocError::DropsComments(kind.to_string()));
-    }
-    let json = json_with_backend(input, format, backend)?;
+    let shield = shield::Shield::apply(input, format);
+    let json = json_with_backend(&shield.source, format, backend)?;
     let mut doc: pandoc_ast::Pandoc =
         serde_json::from_str(&json).map_err(|e| PandocError::Ast(e.to_string()))?;
     reflow_pandoc(&mut doc, splitter, reflow_config);
     let out_json =
         serde_json::to_string(&doc).map_err(|e| PandocError::Ast(format!("serialize AST: {e}")))?;
     let written = write_ast(&out_json, format).map_err(PandocError::from)?;
+    let written = shield.restore(&written);
     refuse_if_comments_missing(input, format, &written)?;
     Ok(written)
 }
@@ -388,19 +404,23 @@ mod tests {
     }
 
     #[test]
-    fn format_via_pandoc_rst_comment_is_explicit_error() {
-        let err = format_via_pandoc(
-            "..\n   First sentence.\n   Second sentence.\n",
+    fn format_via_pandoc_rst_comment_is_preserved() {
+        if !pandoc_available() && !ffi_write_available() {
+            return;
+        }
+        let input = "..\n   First sentence.\n   Second sentence.\n";
+        let out = format_via_pandoc(
+            input,
             "rst",
             PandocBackend::Cli,
             &crate::sentence::unicode::UnicodeSentenceSplitter::new(),
             &crate::reflow::ReflowConfig::default(),
         )
-        .unwrap_err();
-        match err {
-            PandocError::DropsComments(kind) => assert!(kind.contains("RST")),
-            other => panic!("expected DropsComments, got {other}"),
-        }
+        .expect("pandoc path must keep RST comments");
+        assert!(
+            out.contains("First sentence.") && out.contains("Second sentence."),
+            "RST comment body must survive:\n{out}"
+        );
     }
 
     #[test]
@@ -505,17 +525,73 @@ mod tests {
     }
 
     #[test]
-    fn format_via_pandoc_pragma_is_explicit_error() {
-        let err = format_via_pandoc(
-            "Hello world. Second.\n<!-- snapper:off -->\nKeep this.\n<!-- snapper:on -->\n",
+    fn format_via_pandoc_pragma_is_preserved() {
+        if !pandoc_available() && !ffi_write_available() {
+            return;
+        }
+        let input = "Hello world. Second.\n<!-- snapper:off -->\nKeep this.\n<!-- snapper:on -->\n";
+        let out = format_via_pandoc(
+            input,
             "markdown",
             PandocBackend::Cli,
             &crate::sentence::unicode::UnicodeSentenceSplitter::new(),
             &crate::reflow::ReflowConfig::default(),
         )
+        .expect("pandoc path must keep snapper:off/on");
+        assert!(
+            out.contains("<!-- snapper:off -->") && out.contains("<!-- snapper:on -->"),
+            "pragma markers must survive:\n{out}"
+        );
+        assert!(
+            out.contains("Keep this."),
+            "off-region body must survive:\n{out}"
+        );
+    }
+
+    #[test]
+    fn format_via_pandoc_org_pragma_is_preserved() {
+        if !pandoc_available() && !ffi_write_available() {
+            return;
+        }
+        let input = "Hello world. Second.\n# snapper:off\nKeep this. Exactly here.\n# snapper:on\nAfter. Two.\n";
+        let out = format_via_pandoc(
+            input,
+            "org",
+            PandocBackend::Cli,
+            &crate::sentence::unicode::UnicodeSentenceSplitter::new(),
+            &crate::reflow::ReflowConfig::default(),
+        )
+        .expect("pandoc path must keep org snapper:off/on");
+        assert!(
+            out.contains("snapper:off") && out.contains("snapper:on"),
+            "org pragmas must survive:\n{out}"
+        );
+        assert!(
+            out.contains("Keep this. Exactly here."),
+            "org off-region body must survive:\n{out}"
+        );
+    }
+
+    #[test]
+    fn refuse_if_comments_missing_catches_restore_miss() {
+        let err = refuse_if_comments_missing(
+            "Hello.\n<!-- snapper:off -->\nKeep.\n",
+            "markdown",
+            "Hello.\nKeep.\n",
+        )
         .unwrap_err();
         match err {
             PandocError::DropsComments(kind) => assert!(kind.contains("snapper")),
+            other => panic!("expected DropsComments, got {other}"),
+        }
+        let err = refuse_if_comments_missing(
+            "..\n   This comment must not vanish.\n",
+            "rst",
+            "Hello world.\n",
+        )
+        .unwrap_err();
+        match err {
+            PandocError::DropsComments(kind) => assert!(kind.contains("RST")),
             other => panic!("expected DropsComments, got {other}"),
         }
     }

--- a/src/parser/pandoc/shield.rs
+++ b/src/parser/pandoc/shield.rs
@@ -1,0 +1,354 @@
+//! Keep RST comments and snapper pragmas through pandoc write-through.
+//!
+//! Pandoc's readers delete RST `..` comments and comment-shaped
+//! `snapper:off` / `snapper:on` (org `#`, latex `%`, html `<!-- -->`).
+//! Replace each span with a unique sentinel paragraph, write, then put
+//! the original text back. Off-region bodies travel inside the sentinel
+//! so they are not reflowed.
+
+use std::ops::Range;
+
+use crate::parser::iter_lines;
+
+const SENTINEL_PREFIX: &str = "SNAPPERKEEP";
+
+/// Shielded source plus the map used to restore original text.
+#[derive(Debug, Clone)]
+pub(crate) struct Shield {
+    pub source: String,
+    tokens: Vec<(String, String)>,
+}
+
+impl Shield {
+    /// Identity when the source has nothing the reader would drop.
+    pub(crate) fn apply(input: &str, format: &str) -> Self {
+        let spans = collect_spans(input, format);
+        if spans.is_empty() {
+            return Self {
+                source: input.to_string(),
+                tokens: Vec::new(),
+            };
+        }
+        let mut source = input.to_string();
+        let mut tokens = Vec::with_capacity(spans.len());
+        for (i, span) in spans.into_iter().enumerate().rev() {
+            let raw = &input[span.start..span.end];
+            let (orig, had_nl) = strip_one_trailing_newline(raw);
+            let sentinel = unique_sentinel(input, i, &tokens);
+            let repl = if had_nl {
+                format!("{sentinel}\n")
+            } else {
+                sentinel.clone()
+            };
+            source.replace_range(span.start..span.end, &repl);
+            tokens.push((sentinel, orig.to_string()));
+        }
+        tokens.reverse();
+        Self { source, tokens }
+    }
+
+    pub(crate) fn restore(&self, written: &str) -> String {
+        let mut out = written.to_string();
+        for (sentinel, original) in &self.tokens {
+            out = out.replace(sentinel, original);
+        }
+        out
+    }
+}
+
+pub(crate) fn is_rst_pandoc_format(format: &str) -> bool {
+    let base = format.split(['+', '-']).next().unwrap_or(format);
+    matches!(base, "rst" | "rest")
+}
+
+fn strip_one_trailing_newline(s: &str) -> (&str, bool) {
+    if let Some(stripped) = s.strip_suffix("\r\n") {
+        (stripped, true)
+    } else if let Some(stripped) = s.strip_suffix('\n') {
+        (stripped, true)
+    } else {
+        (s, false)
+    }
+}
+
+fn unique_sentinel(input: &str, index: usize, existing: &[(String, String)]) -> String {
+    for nonce in 0u32.. {
+        let candidate = format!("{SENTINEL_PREFIX}{index:04}N{nonce:08x}");
+        if input.contains(&candidate) {
+            continue;
+        }
+        if existing.iter().any(|(s, _)| s == &candidate) {
+            continue;
+        }
+        return candidate;
+    }
+    unreachable!("u32 nonce space exhausted");
+}
+
+fn overlaps(a: &Range<usize>, b: &Range<usize>) -> bool {
+    a.start < b.end && b.start < a.end
+}
+
+fn collect_spans(input: &str, format: &str) -> Vec<Range<usize>> {
+    let mut spans = pragma_spans(input);
+    if is_rst_pandoc_format(format) {
+        for span in rst_comment_spans(input) {
+            if !spans.iter().any(|p| overlaps(p, &span)) {
+                spans.push(span);
+            }
+        }
+    }
+    spans.sort_by_key(|s| s.start);
+    spans
+}
+
+/// File-level `snapper:off` … `snapper:on` (or off-to-EOF). Skips fenced
+/// / verbatim / org-src bodies so in-code markers stay in the block.
+fn pragma_spans(input: &str) -> Vec<Range<usize>> {
+    let lines = iter_lines(input);
+    let mut spans = Vec::new();
+    let mut off_start: Option<usize> = None;
+    let mut in_code = false;
+    let mut fence_mark: Option<String> = None;
+    let mut rst_code_indent: Option<usize> = None;
+
+    for line in &lines {
+        if toggle_code(
+            line.text,
+            &mut in_code,
+            &mut fence_mark,
+            &mut rst_code_indent,
+        ) {
+            continue;
+        }
+        if in_code {
+            continue;
+        }
+        match crate::parser::check_pragma(line.text) {
+            Some(false) => {
+                if off_start.is_none() {
+                    off_start = Some(line.start);
+                }
+            }
+            Some(true) => {
+                let start = off_start.take().unwrap_or(line.start);
+                spans.push(start..line.end);
+            }
+            None => {}
+        }
+    }
+    if let Some(start) = off_start {
+        spans.push(start..input.len());
+    }
+    spans
+}
+
+fn rst_comment_spans(input: &str) -> Vec<Range<usize>> {
+    let lines = iter_lines(input);
+    let mut spans = Vec::new();
+    let mut i = 0;
+    let mut in_code = false;
+    let mut fence_mark: Option<String> = None;
+    let mut rst_code_indent: Option<usize> = None;
+
+    while i < lines.len() {
+        let line = lines[i];
+        if toggle_code(
+            line.text,
+            &mut in_code,
+            &mut fence_mark,
+            &mut rst_code_indent,
+        ) {
+            i += 1;
+            continue;
+        }
+        if in_code {
+            i += 1;
+            continue;
+        }
+        let trimmed = line.text.trim_start();
+        if crate::parser::rst::is_rst_dropped_comment_opener(trimmed) {
+            let leading = line.text.len() - trimmed.len();
+            let comment_indent = leading + 1;
+            let mut j = i + 1;
+            while j < lines.len() {
+                let body = lines[j].text;
+                let lead = body.len() - body.trim_start().len();
+                if body.trim().is_empty() || lead >= comment_indent {
+                    j += 1;
+                    continue;
+                }
+                break;
+            }
+            let end = lines[j.saturating_sub(1)].end;
+            spans.push(line.start..end);
+            i = j;
+            continue;
+        }
+        i += 1;
+    }
+    spans
+}
+
+/// Returns true when this line opened or closed a code/verbatim region.
+fn toggle_code(
+    text: &str,
+    in_code: &mut bool,
+    fence_mark: &mut Option<String>,
+    rst_code_indent: &mut Option<usize>,
+) -> bool {
+    let trimmed = text.trim_start();
+    let leading = text.len() - trimmed.len();
+
+    if let Some(indent) = *rst_code_indent {
+        if text.trim().is_empty() || leading >= indent {
+            return false;
+        }
+        *rst_code_indent = None;
+        *in_code = false;
+        // Fall through: this line may be a new opener or a comment.
+    }
+
+    if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+        let mark = if trimmed.starts_with("```") {
+            "```"
+        } else {
+            "~~~"
+        };
+        if !*in_code {
+            *in_code = true;
+            *fence_mark = Some(mark.to_string());
+            return true;
+        }
+        if fence_mark.as_deref() == Some(mark) {
+            *in_code = false;
+            *fence_mark = None;
+            return true;
+        }
+        return false;
+    }
+
+    let lower = trimmed.to_ascii_lowercase();
+    if !*in_code {
+        if lower.starts_with("#+begin_src")
+            || lower.starts_with("#+begin_example")
+            || lower.starts_with("#+begin_export")
+            || lower.starts_with("\\begin{verbatim}")
+            || lower.starts_with("\\begin{lstlisting}")
+            || lower.starts_with("\\begin{minted}")
+        {
+            *in_code = true;
+            *fence_mark = Some(lower.chars().take(24).collect());
+            return true;
+        }
+        if lower.starts_with(".. code-block::")
+            || lower.starts_with(".. sourcecode::")
+            || lower.starts_with(".. code::")
+        {
+            *in_code = true;
+            *rst_code_indent = Some(leading + 3);
+            return true;
+        }
+        return false;
+    }
+
+    if lower.starts_with("#+end_src")
+        || lower.starts_with("#+end_example")
+        || lower.starts_with("#+end_export")
+        || lower.starts_with("\\end{verbatim}")
+        || lower.starts_with("\\end{lstlisting}")
+        || lower.starts_with("\\end{minted}")
+    {
+        *in_code = false;
+        *fence_mark = None;
+        return true;
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn identity_when_nothing_to_shield() {
+        let s = Shield::apply("Hello world.\n", "rst");
+        assert_eq!(s.source, "Hello world.\n");
+        assert!(s.tokens.is_empty());
+        assert_eq!(s.restore("Hello world.\n"), "Hello world.\n");
+    }
+
+    #[test]
+    fn rst_comment_span_covers_bare_dotdot_body() {
+        let input = "Hello.\n\n..\n   Secret.\n\nBye.\n";
+        let spans = rst_comment_spans(input);
+        assert_eq!(spans.len(), 1);
+        assert!(input[spans[0].clone()].contains(".."));
+        assert!(input[spans[0].clone()].contains("Secret."));
+        assert!(!input[spans[0].clone()].contains("Bye."));
+    }
+
+    #[test]
+    fn rst_recognized_comment_is_a_span() {
+        let input = ".. This is a comment.\n";
+        let spans = rst_comment_spans(input);
+        assert_eq!(spans.len(), 1);
+        assert!(input[spans[0].clone()].contains("This is a comment."));
+    }
+
+    #[test]
+    fn rst_targets_and_directives_are_not_comment_spans() {
+        assert!(rst_comment_spans(".. _label:\n").is_empty());
+        assert!(rst_comment_spans(".. note::\n   Body.\n").is_empty());
+        assert!(rst_comment_spans(".. [1] cite\n").is_empty());
+    }
+
+    #[test]
+    fn pragma_span_covers_off_region() {
+        let input =
+            "Hello.\n<!-- snapper:off -->\nKeep this. Exactly here.\n<!-- snapper:on -->\nAfter.\n";
+        let spans = pragma_spans(input);
+        assert_eq!(spans.len(), 1);
+        let chunk = &input[spans[0].clone()];
+        assert!(chunk.contains("<!-- snapper:off -->"));
+        assert!(chunk.contains("Keep this. Exactly here."));
+        assert!(chunk.contains("<!-- snapper:on -->"));
+        assert!(!chunk.contains("After."));
+    }
+
+    #[test]
+    fn pragma_inside_markdown_fence_is_ignored() {
+        let input = "```\n<!-- snapper:off -->\ncode\n<!-- snapper:on -->\n```\n";
+        assert!(pragma_spans(input).is_empty());
+    }
+
+    #[test]
+    fn shield_restore_roundtrip_rst_comments() {
+        let input =
+            "Hello world. Second.\n\n..\n   This comment must not vanish.\n\n.. recognized.\n";
+        let s = Shield::apply(input, "rst");
+        assert!(s.source.contains(SENTINEL_PREFIX));
+        assert!(!s.source.contains("This comment must not vanish."));
+        assert_eq!(s.restore(&s.source), input);
+    }
+
+    #[test]
+    fn shield_restore_roundtrip_markdown_pragma() {
+        let input =
+            "Hello.\n<!-- snapper:off -->\nKeep this. Exactly here.\n<!-- snapper:on -->\nAfter.\n";
+        let s = Shield::apply(input, "markdown");
+        assert!(s.source.contains(SENTINEL_PREFIX));
+        assert!(!s.source.contains("snapper:off"));
+        assert_eq!(s.restore(&s.source), input);
+    }
+
+    #[test]
+    fn restore_from_written_paragraph() {
+        let input = ".. Secret payload.\n";
+        let s = Shield::apply(input, "rst");
+        let written = format!("Intro.\n{}\nOutro.\n", s.tokens[0].0);
+        let out = s.restore(&written);
+        assert!(out.contains(".. Secret payload."));
+        assert!(!out.contains(SENTINEL_PREFIX));
+    }
+}

--- a/tests/pandoc_ast_backend.rs
+++ b/tests/pandoc_ast_backend.rs
@@ -594,15 +594,18 @@ fn format_text_pandoc_definition_list_stays_structure() {
     assert_has_sentence_break(&out, "First sentence.", "Second sentence");
 }
 
-/// `--use-pandoc` must not delete RST `..` comments and exit 0.
+/// `--use-pandoc` must keep RST `..` comments and exit 0.
 #[test]
-fn format_text_use_pandoc_rst_comment_is_explicit_error() {
+fn format_text_use_pandoc_rst_comment_is_preserved() {
+    if !require_writer() {
+        return;
+    }
     let input = read_fixture("rst_comment.rst");
     assert!(
         dropped_comment_kind(&input, "rst").is_some(),
         "fixture must be a dropped RST comment"
     );
-    let err = format_text(
+    let out = format_text(
         &input,
         &FormatConfig {
             format: Format::Rst,
@@ -612,19 +615,26 @@ fn format_text_use_pandoc_rst_comment_is_explicit_error() {
             ..Default::default()
         },
     )
-    .expect_err("pandoc path must refuse RST comments");
-    let msg = format!("{err:#}");
+    .expect("pandoc path must keep RST comments");
     assert!(
-        msg.contains("drop") || msg.contains("comment") || msg.contains("pragma"),
-        "expected explicit drop error, got: {msg}"
+        out.contains("This comment must not vanish."),
+        "RST comment body must survive:\n{out}"
     );
+    assert!(
+        out.contains(".. This is a recognized comment."),
+        "recognized RST comment must survive:\n{out}"
+    );
+    assert_has_sentence_break(&out, "Hello world.", "Second sentence");
 }
 
-/// `--use-pandoc` must not delete `snapper:off` and exit 0.
+/// `--use-pandoc` must keep `snapper:off` and exit 0.
 #[test]
-fn format_text_use_pandoc_snapper_off_is_explicit_error() {
+fn format_text_use_pandoc_snapper_off_is_preserved() {
+    if !require_writer() {
+        return;
+    }
     let input = read_fixture("snapper_off.md");
-    let err = format_text(
+    let out = format_text(
         &input,
         &FormatConfig {
             format: Format::Markdown,
@@ -634,18 +644,25 @@ fn format_text_use_pandoc_snapper_off_is_explicit_error() {
             ..Default::default()
         },
     )
-    .expect_err("pandoc path must refuse snapper:off");
-    let msg = format!("{err:#}");
+    .expect("pandoc path must keep snapper:off");
     assert!(
-        msg.contains("snapper") || msg.contains("drop") || msg.contains("pragma"),
-        "expected explicit drop error, got: {msg}"
+        out.contains("<!-- snapper:off -->") && out.contains("<!-- snapper:on -->"),
+        "markdown pragmas must survive:\n{out}"
     );
+    assert!(
+        out.contains("Keep this. Exactly here."),
+        "off-region body must not be reflowed away:\n{out}"
+    );
+    assert_has_sentence_break(&out, "Hello world.", "Second sentence");
 }
 
 #[test]
-fn format_text_use_pandoc_rst_snapper_off_is_explicit_error() {
+fn format_text_use_pandoc_rst_snapper_off_is_preserved() {
+    if !require_writer() {
+        return;
+    }
     let input = read_fixture("snapper_off.rst");
-    let err = format_text(
+    let out = format_text(
         &input,
         &FormatConfig {
             format: Format::Rst,
@@ -655,11 +672,14 @@ fn format_text_use_pandoc_rst_snapper_off_is_explicit_error() {
             ..Default::default()
         },
     )
-    .expect_err("pandoc path must refuse RST snapper:off");
-    let msg = format!("{err:#}");
+    .expect("pandoc path must keep RST snapper:off");
     assert!(
-        msg.contains("snapper") || msg.contains("drop") || msg.contains("pragma"),
-        "expected explicit drop error, got: {msg}"
+        out.contains("snapper:off") && out.contains("snapper:on"),
+        "RST pragmas must survive:\n{out}"
+    );
+    assert!(
+        out.contains("Keep this. Exactly here."),
+        "RST off-region body must survive:\n{out}"
     );
 }
 
@@ -716,9 +736,12 @@ fn native_path_keeps_rst_comment_and_snapper_off() {
     );
 }
 
-/// CLI `--use-pandoc` on the RST comment fixture must not exit 0 after a drop.
+/// CLI `--use-pandoc` on the RST comment fixture must exit 0 and keep the text.
 #[test]
-fn snapper_cli_use_pandoc_rst_comment_is_nonzero() {
+fn snapper_cli_use_pandoc_rst_comment_exits_0() {
+    if !require_writer() {
+        return;
+    }
     let bin = env!("CARGO_BIN_EXE_snapper");
     let input = fixture("rst_comment.rst");
     let out = std::process::Command::new(bin)
@@ -727,25 +750,23 @@ fn snapper_cli_use_pandoc_rst_comment_is_nonzero() {
         .output()
         .expect("spawn snapper");
     assert!(
-        !out.status.success(),
-        "CLI must refuse RST comments; stdout={} stderr={}",
+        out.status.success(),
+        "CLI must keep RST comments; stdout={} stderr={}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
-    let err = String::from_utf8_lossy(&out.stderr);
-    assert!(
-        err.contains("drop") || err.contains("comment") || err.contains("pragma"),
-        "expected explicit drop error on stderr, got: {err}"
-    );
     let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        stdout.trim().is_empty() || stdout.contains("This comment must not vanish."),
-        "must not emit comment-stripped success output: {stdout}"
+        stdout.contains("This comment must not vanish."),
+        "CLI output must keep RST comment body: {stdout}"
     );
 }
 
 #[test]
-fn snapper_cli_use_pandoc_snapper_off_is_nonzero() {
+fn snapper_cli_use_pandoc_snapper_off_exits_0() {
+    if !require_writer() {
+        return;
+    }
     let bin = env!("CARGO_BIN_EXE_snapper");
     let input = fixture("snapper_off.md");
     let out = std::process::Command::new(bin)
@@ -754,15 +775,15 @@ fn snapper_cli_use_pandoc_snapper_off_is_nonzero() {
         .output()
         .expect("spawn snapper");
     assert!(
-        !out.status.success(),
-        "CLI must refuse snapper:off; stdout={} stderr={}",
+        out.status.success(),
+        "CLI must keep snapper:off; stdout={} stderr={}",
         String::from_utf8_lossy(&out.stdout),
         String::from_utf8_lossy(&out.stderr)
     );
-    let err = String::from_utf8_lossy(&out.stderr);
+    let stdout = String::from_utf8_lossy(&out.stdout);
     assert!(
-        err.contains("snapper") || err.contains("drop") || err.contains("pragma"),
-        "expected explicit drop error on stderr, got: {err}"
+        stdout.contains("<!-- snapper:off -->") && stdout.contains("Keep this. Exactly here."),
+        "CLI output must keep snapper:off: {stdout}"
     );
 }
 


### PR DESCRIPTION
Pandoc's reader deletes RST `..` comments and comment-shaped `snapper:off` / `snapper:on`. `--use-pandoc` used to refuse those files.

Those spans are now shielded across the reader and put back after write. Output still contains the text and the command exits 0. A restore miss is still a hard error. Native path and the CLI default stay unchanged.

This is snapper-5po9. Default flip stays later.
