### PR TITLE
feat(cli): default to pandoc when a writer is available

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Dogfood snapper --check on docs and examples
         run: |
           cargo build --quiet --bin snapper
-          ./target/debug/snapper --check --format org readme_src.org docs/orgmode/**/*.org examples/paper.org
-          ./target/debug/snapper --check --format plaintext examples/basic.txt
-          ./target/debug/snapper --check --format markdown examples/paper.md
-          ./target/debug/snapper --check --format latex examples/paper.tex
+          ./target/debug/snapper --native --check --format org readme_src.org docs/orgmode/**/*.org examples/paper.org
+          ./target/debug/snapper --native --check --format plaintext examples/basic.txt
+          ./target/debug/snapper --native --check --format markdown examples/paper.md
+          ./target/debug/snapper --native --check --format latex examples/paper.tex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 ## Unreleased (main)
-#### Features
-- (**cli**) default uses pandoc (auto FFI then CLI) when an FFI writer or `pandoc` on PATH is available; `--native` keeps today's line parsers; `--use-pandoc` still errors if the backend is missing. Editors, wasm, and LSP stay native
 #### Bug Fixes
 - (**sentence**) a period immediately before markup closers only starts a new sentence when the next token is a capital letter (or a quote then a capital), so plaintext `.`` "` is not split
 - (**rst**) list continuation paragraphs after a blank keep their hanging indent, so a two-space second sentence is not outdented to column 0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 ## Unreleased (main)
+#### Features
+- (**cli**) default uses pandoc (auto FFI then CLI) when an FFI writer or `pandoc` on PATH is available; `--native` keeps today's line parsers; `--use-pandoc` still errors if the backend is missing. Editors, wasm, and LSP stay native
 #### Bug Fixes
 - (**sentence**) a period immediately before markup closers only starts a new sentence when the next token is a capital letter (or a quote then a capital), so plaintext `.`` "` is not split
 - (**rst**) list continuation paragraphs after a blank keep their hanging indent, so a two-space second sentence is not outdented to column 0

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ Pipe through stdin (for editor integration):
 
     cat draft.org | snapper --format org
 
+The CLI uses pandoc (auto FFI, then CLI) when an FFI writer or `pandoc` on `PATH` is available.
+Otherwise it keeps the native line parsers (no error).
+Pass `--native` to force today's parsers.
+Pass `--use-pandoc` to require pandoc (error if missing).
+Editors, wasm, and LSP stay native.
 Check formatting without modifying (for CI):
 
     snapper --check paper.org paper.tex notes.md
@@ -137,7 +142,6 @@ With the default unlimited width this inserts a newline after every such mark th
 
 With `--max-width` set, overflowing sentences prefer those marks.
 A one-clause sentence stays one line.
-
 Preview changes as a unified diff before committing:
 
     snapper --diff paper.org
@@ -244,7 +248,7 @@ Configuration guide (org source in-tree): `docs/orgmode/howto/mcp-integration.or
 ## Emacs (Apheleia)
 
     (with-eval-after-load 'apheleia
-      (push '(snapper . ("snapper" "--format" "org")) apheleia-formatters)
+      (push '(snapper . ("snapper" "--native" "--format" "org")) apheleia-formatters)
       (push '(org-mode . snapper) apheleia-mode-alist))
 
 
@@ -342,14 +346,14 @@ Drop a `.snapperrc.toml` in your project root:
     format = "org"
     max_width = 0
     clause_breaks = false
-
+    
     [latex]
     verbatim_envs = ["Verbatim"]
     structure_envs = ["algorithm", "comment"]
     verbatim_commands = ["Verb"]
 
-`snapper` walks up from the current directory to find it.
 Missing `[latex]` keys keep the built-in minted/lstlisting/verbatim, equation/figure, and verb/lstinline lists.
+`snapper` walks up from the current directory to find it.
 
 
 <a id="documentation"></a>

--- a/docs/locale/is/LC_MESSAGES/cli-reference.po
+++ b/docs/locale/is/LC_MESSAGES/cli-reference.po
@@ -165,11 +165,27 @@ msgid ""
 "detection"
 msgstr ""
 
-#: ../../source/cli-reference.md:49
-msgid "`--use-pandoc` — Use pandoc as parser backend (universal format support)"
+#: ../../source/cli-reference.md:52
+msgid ""
+"`--use-pandoc` — Force the pandoc path (auto FFI then CLI). Errors if FFI "
+"and `pandoc` on PATH are both missing (no silent all-prose). The default "
+"(omit this flag) already uses pandoc when an FFI writer or `pandoc` on "
+"PATH is available. RST `..` comments and `snapper:off` / `snapper:on` "
+"are written through so the output still contains that text. Parse may "
+"use in-process FFI; the writer still needs `pandoc` on PATH "
+"(`libsnapper_pandoc` is reader-only) unless that library exports a writer"
 msgstr ""
 
-#: ../../source/cli-reference.md:50
+#: ../../source/cli-reference.md:53
+msgid ""
+"`--native` — Force today's native line parsers "
+"(markdown/org/rst/latex/plaintext). The default (omit this flag) uses "
+"pandoc when an FFI writer or `pandoc` on PATH is available; otherwise it "
+"keeps these parsers (no error, no silent all-prose). Editors, wasm, and "
+"LSP stay native"
+msgstr ""
+
+#: ../../source/cli-reference.md:57
 msgid "`--check` — Exit with code 1 if any file would change"
 msgstr ""
 

--- a/docs/locale/is/LC_MESSAGES/howto/pandoc-backend.po
+++ b/docs/locale/is/LC_MESSAGES/howto/pandoc-backend.po
@@ -50,53 +50,43 @@ msgstr ""
 msgid "Pandoc 2.x or 3.x must be installed and on your PATH. Verify with:"
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:25
+#: ../../source/howto/pandoc-backend.rst:46
 msgid ""
-"When pandoc is not available, snapper falls back to its built-in parsers "
-"silently. If you explicitly pass ``--use-pandoc`` and pandoc is missing, "
-"snapper reports an error."
+"The CLI default uses pandoc when an FFI writer or ``pandoc`` on ``PATH`` "
+"is available. Otherwise it keeps the native line parsers (no error, no "
+"silent all-prose). With ``--use-pandoc``, a missing or failing pandoc is "
+"an explicit error (no silent all-prose). Pass ``--native`` to force "
+"today's line parsers."
 msgstr ""
 
 #: ../../source/howto/pandoc-backend.rst:29
 msgid "Usage"
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:45
+#: ../../source/howto/pandoc-backend.rst:92
 msgid ""
-"Format auto-detects from the file extension. Override with ``-f`` when "
-"needed."
+"The CLI default uses pandoc (auto FFI, then CLI) when an in-process "
+"writer or ``pandoc`` on ``PATH`` is available. Otherwise it keeps the "
+"native line parsers (no error, no silent all-prose). Pass ``--native`` to "
+"force today's line parsers. Pass ``--use-pandoc`` to require the pandoc "
+"path (explicit error if FFI and ``pandoc`` are missing). The writer still "
+"needs ``pandoc`` on ``PATH`` unless the library exports a writer."
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:49
+#: ../../source/howto/pandoc-backend.rst:107
 msgid "When to use pandoc vs built-in parsers"
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:51
+#: ../../source/howto/pandoc-backend.rst:110
 msgid ""
-"The built-in parsers (Org, LaTeX, Markdown, RST) handle their formats "
-"well and run faster since they avoid spawning a subprocess. Use the "
-"pandoc backend when:"
+"****Pandoc**** (CLI default when available): structure from pandoc’s "
+"model and coverage of formats without a built-in parser."
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:54
+#: ../../source/howto/pandoc-backend.rst:112
 msgid ""
-"Working with typst, asciidoc, docx, html, or other formats without a "
-"built-in parser"
-msgstr ""
-
-#: ../../source/howto/pandoc-backend.rst:56
-msgid "You want consistent parsing across many formats in one project"
-msgstr ""
-
-#: ../../source/howto/pandoc-backend.rst:58
-msgid "The built-in parser mishandles an edge case that pandoc gets right"
-msgstr ""
-
-#: ../../source/howto/pandoc-backend.rst:60
-msgid ""
-"The built-in parsers preserve more source-level structure (pragmas, "
-"inline tokens). The pandoc backend strips format-specific markup since it"
-" works through the abstract AST."
+"****Built-in**** (``--native``): fast, source-oriented parsers for Org / "
+"LaTeX / Markdown / RST (e.g. full ATX lines as structure)."
 msgstr ""
 
 #: ../../source/howto/pandoc-backend.rst:64

--- a/docs/locale/is/LC_MESSAGES/howto/pragmas.po
+++ b/docs/locale/is/LC_MESSAGES/howto/pragmas.po
@@ -118,3 +118,11 @@ msgstr ""
 "fer engin setningaskipting, engin sniðmeðvituð þáttun og engin "
 "meðhöndlun skammstafana fram. Forskriftaathugasemdarlínurnar sjálfar "
 "fara alltaf í gegn sem bygging."
+
+#: ../../source/howto/pragmas.rst:128
+msgid ""
+"The pandoc path keeps ``snapper:off`` / ``snapper:on`` in the written "
+"output (the reader would otherwise delete them). Off-region text is "
+"shielded so it is not reflowed. Pass ``--native`` to force today's line "
+"parsers."
+msgstr ""

--- a/docs/locale/is/LC_MESSAGES/reference/cli.po
+++ b/docs/locale/is/LC_MESSAGES/reference/cli.po
@@ -209,15 +209,31 @@ msgstr ""
 msgid "``--use-pandoc``"
 msgstr ""
 
-#: ../../source/reference/cli.rst:116
+#: ../../source/reference/cli.rst:185
 msgid ""
-"Use pandoc as the parser backend instead of built-in parsers. Requires "
-"pandoc on PATH. Enables support for typst, asciidoc, docx, html, and all "
-"other pandoc-supported formats. Falls back silently if pandoc is "
-"unavailable (unless this flag is explicit)."
+"Require the pandoc path (auto FFI, then CLI). Parse may use in-process "
+"FFI when ``libsnapper_pandoc`` loads; the writer still needs ``pandoc`` "
+"on ``PATH`` (``libsnapper_pandoc`` is reader-only) unless that library "
+"exports a writer. Without FFI, both parse and write use the ``pandoc`` "
+"CLI. A missing binary is an explicit error (never silent all-prose). "
+"Enables support for typst, asciidoc, docx, html, and all other pandoc-"
+"supported formats. The default (omit this flag) already uses pandoc when "
+"an FFI writer or ``pandoc`` on ``PATH`` is available."
 msgstr ""
 
-#: ../../source/reference/cli.rst:122
+#: ../../source/reference/cli.rst:194
+msgid "``--native``"
+msgstr ""
+
+#: ../../source/reference/cli.rst:197
+msgid ""
+"Force today's native line parsers (markdown / org / rst / latex / "
+"plaintext). Conflicts with ``--use-pandoc``. Use this when you want "
+"source-oriented splice instead of the pandoc writer. Editors, wasm, and "
+"LSP stay native even without this flag."
+msgstr ""
+
+#: ../../source/reference/cli.rst:214
 msgid "``--config <PATH>``"
 msgstr "``--config <PATH>``"
 

--- a/docs/locale/is/LC_MESSAGES/tutorials/quickstart.po
+++ b/docs/locale/is/LC_MESSAGES/tutorials/quickstart.po
@@ -78,7 +78,15 @@ msgstr "Sníða á staðnum:"
 msgid "Pipe through stdin (for editor integration):"
 msgstr "Sigta í gegnum stdin (fyrir samþættingu við ritil):"
 
-#: ../../source/tutorials/quickstart.rst:69
+#: ../../source/tutorials/quickstart.rst:82
+msgid ""
+"The CLI uses pandoc (auto FFI, then CLI) when an FFI writer or ``pandoc`` "
+"on ``PATH`` is available. Otherwise it keeps the native line parsers (no "
+"error). Pass ``--native`` to force today's parsers. Pass ``--use-pandoc`` "
+"to require pandoc (error if missing). Editors, wasm, and LSP stay native."
+msgstr ""
+
+#: ../../source/tutorials/quickstart.rst:90
 msgid "What it does"
 msgstr "Hvað gerir það"
 

--- a/docs/locale/pl/LC_MESSAGES/cli-reference.po
+++ b/docs/locale/pl/LC_MESSAGES/cli-reference.po
@@ -166,11 +166,27 @@ msgid ""
 "detection"
 msgstr ""
 
-#: ../../source/cli-reference.md:49
-msgid "`--use-pandoc` — Use pandoc as parser backend (universal format support)"
+#: ../../source/cli-reference.md:52
+msgid ""
+"`--use-pandoc` — Force the pandoc path (auto FFI then CLI). Errors if FFI "
+"and `pandoc` on PATH are both missing (no silent all-prose). The default "
+"(omit this flag) already uses pandoc when an FFI writer or `pandoc` on "
+"PATH is available. RST `..` comments and `snapper:off` / `snapper:on` "
+"are written through so the output still contains that text. Parse may "
+"use in-process FFI; the writer still needs `pandoc` on PATH "
+"(`libsnapper_pandoc` is reader-only) unless that library exports a writer"
 msgstr ""
 
-#: ../../source/cli-reference.md:50
+#: ../../source/cli-reference.md:53
+msgid ""
+"`--native` — Force today's native line parsers "
+"(markdown/org/rst/latex/plaintext). The default (omit this flag) uses "
+"pandoc when an FFI writer or `pandoc` on PATH is available; otherwise it "
+"keeps these parsers (no error, no silent all-prose). Editors, wasm, and "
+"LSP stay native"
+msgstr ""
+
+#: ../../source/cli-reference.md:57
 msgid "`--check` — Exit with code 1 if any file would change"
 msgstr ""
 

--- a/docs/locale/pl/LC_MESSAGES/howto/pandoc-backend.po
+++ b/docs/locale/pl/LC_MESSAGES/howto/pandoc-backend.po
@@ -51,53 +51,43 @@ msgstr ""
 msgid "Pandoc 2.x or 3.x must be installed and on your PATH. Verify with:"
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:25
+#: ../../source/howto/pandoc-backend.rst:46
 msgid ""
-"When pandoc is not available, snapper falls back to its built-in parsers "
-"silently. If you explicitly pass ``--use-pandoc`` and pandoc is missing, "
-"snapper reports an error."
+"The CLI default uses pandoc when an FFI writer or ``pandoc`` on ``PATH`` "
+"is available. Otherwise it keeps the native line parsers (no error, no "
+"silent all-prose). With ``--use-pandoc``, a missing or failing pandoc is "
+"an explicit error (no silent all-prose). Pass ``--native`` to force "
+"today's line parsers."
 msgstr ""
 
 #: ../../source/howto/pandoc-backend.rst:29
 msgid "Usage"
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:45
+#: ../../source/howto/pandoc-backend.rst:92
 msgid ""
-"Format auto-detects from the file extension. Override with ``-f`` when "
-"needed."
+"The CLI default uses pandoc (auto FFI, then CLI) when an in-process "
+"writer or ``pandoc`` on ``PATH`` is available. Otherwise it keeps the "
+"native line parsers (no error, no silent all-prose). Pass ``--native`` to "
+"force today's line parsers. Pass ``--use-pandoc`` to require the pandoc "
+"path (explicit error if FFI and ``pandoc`` are missing). The writer still "
+"needs ``pandoc`` on ``PATH`` unless the library exports a writer."
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:49
+#: ../../source/howto/pandoc-backend.rst:107
 msgid "When to use pandoc vs built-in parsers"
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:51
+#: ../../source/howto/pandoc-backend.rst:110
 msgid ""
-"The built-in parsers (Org, LaTeX, Markdown, RST) handle their formats "
-"well and run faster since they avoid spawning a subprocess. Use the "
-"pandoc backend when:"
+"****Pandoc**** (CLI default when available): structure from pandoc’s "
+"model and coverage of formats without a built-in parser."
 msgstr ""
 
-#: ../../source/howto/pandoc-backend.rst:54
+#: ../../source/howto/pandoc-backend.rst:112
 msgid ""
-"Working with typst, asciidoc, docx, html, or other formats without a "
-"built-in parser"
-msgstr ""
-
-#: ../../source/howto/pandoc-backend.rst:56
-msgid "You want consistent parsing across many formats in one project"
-msgstr ""
-
-#: ../../source/howto/pandoc-backend.rst:58
-msgid "The built-in parser mishandles an edge case that pandoc gets right"
-msgstr ""
-
-#: ../../source/howto/pandoc-backend.rst:60
-msgid ""
-"The built-in parsers preserve more source-level structure (pragmas, "
-"inline tokens). The pandoc backend strips format-specific markup since it"
-" works through the abstract AST."
+"****Built-in**** (``--native``): fast, source-oriented parsers for Org / "
+"LaTeX / Markdown / RST (e.g. full ATX lines as structure)."
 msgstr ""
 
 #: ../../source/howto/pandoc-backend.rst:64

--- a/docs/locale/pl/LC_MESSAGES/howto/pragmas.po
+++ b/docs/locale/pl/LC_MESSAGES/howto/pragmas.po
@@ -120,3 +120,11 @@ msgstr ""
 "Wewnątrz regionu wyłączonego nie następuje podział zdań, parser "
 "rozpoznający format ani obsługa skrótów. Same linie komentarzy pragm "
 "zawsze przechodzą jako struktura."
+
+#: ../../source/howto/pragmas.rst:128
+msgid ""
+"The pandoc path keeps ``snapper:off`` / ``snapper:on`` in the written "
+"output (the reader would otherwise delete them). Off-region text is "
+"shielded so it is not reflowed. Pass ``--native`` to force today's line "
+"parsers."
+msgstr ""

--- a/docs/locale/pl/LC_MESSAGES/reference/cli.po
+++ b/docs/locale/pl/LC_MESSAGES/reference/cli.po
@@ -215,15 +215,31 @@ msgstr ""
 msgid "``--use-pandoc``"
 msgstr ""
 
-#: ../../source/reference/cli.rst:116
+#: ../../source/reference/cli.rst:185
 msgid ""
-"Use pandoc as the parser backend instead of built-in parsers. Requires "
-"pandoc on PATH. Enables support for typst, asciidoc, docx, html, and all "
-"other pandoc-supported formats. Falls back silently if pandoc is "
-"unavailable (unless this flag is explicit)."
+"Require the pandoc path (auto FFI, then CLI). Parse may use in-process "
+"FFI when ``libsnapper_pandoc`` loads; the writer still needs ``pandoc`` "
+"on ``PATH`` (``libsnapper_pandoc`` is reader-only) unless that library "
+"exports a writer. Without FFI, both parse and write use the ``pandoc`` "
+"CLI. A missing binary is an explicit error (never silent all-prose). "
+"Enables support for typst, asciidoc, docx, html, and all other pandoc-"
+"supported formats. The default (omit this flag) already uses pandoc when "
+"an FFI writer or ``pandoc`` on ``PATH`` is available."
 msgstr ""
 
-#: ../../source/reference/cli.rst:122
+#: ../../source/reference/cli.rst:194
+msgid "``--native``"
+msgstr ""
+
+#: ../../source/reference/cli.rst:197
+msgid ""
+"Force today's native line parsers (markdown / org / rst / latex / "
+"plaintext). Conflicts with ``--use-pandoc``. Use this when you want "
+"source-oriented splice instead of the pandoc writer. Editors, wasm, and "
+"LSP stay native even without this flag."
+msgstr ""
+
+#: ../../source/reference/cli.rst:214
 msgid "``--config <PATH>``"
 msgstr "``--config <ŚCIEŻKA>``"
 

--- a/docs/locale/pl/LC_MESSAGES/tutorials/quickstart.po
+++ b/docs/locale/pl/LC_MESSAGES/tutorials/quickstart.po
@@ -79,7 +79,15 @@ msgstr "Sformatuj w miejscu:"
 msgid "Pipe through stdin (for editor integration):"
 msgstr "Prześlij przez stdin (dla integracji z edytorem):"
 
-#: ../../source/tutorials/quickstart.rst:69
+#: ../../source/tutorials/quickstart.rst:82
+msgid ""
+"The CLI uses pandoc (auto FFI, then CLI) when an FFI writer or ``pandoc`` "
+"on ``PATH`` is available. Otherwise it keeps the native line parsers (no "
+"error). Pass ``--native`` to force today's parsers. Pass ``--use-pandoc`` "
+"to require pandoc (error if missing). Editors, wasm, and LSP stay native."
+msgstr ""
+
+#: ../../source/tutorials/quickstart.rst:90
 msgid "What it does"
 msgstr "Co robi"
 

--- a/docs/orgmode/howto/editor-integration.org
+++ b/docs/orgmode/howto/editor-integration.org
@@ -10,7 +10,7 @@
 
 #+begin_src elisp
 (with-eval-after-load 'apheleia
-  (push '(snapper . ("snapper" "--format" "org")) apheleia-formatters)
+  (push '(snapper . ("snapper" "--native" "--format" "org")) apheleia-formatters)
   (push '(org-mode . snapper) apheleia-mode-alist)
   ;; Add for other formats:
   (push '(latex-mode . snapper) apheleia-mode-alist)
@@ -27,9 +27,9 @@ The =--format= flag auto-detects from the file extension, so you can omit it if 
 Use =formatprg= to pipe through snapper:
 
 #+begin_src vim
-autocmd FileType org setlocal formatprg=snapper\ --format\ org
-autocmd FileType tex setlocal formatprg=snapper\ --format\ latex
-autocmd FileType markdown setlocal formatprg=snapper\ --format\ markdown
+autocmd FileType org setlocal formatprg=snapper\ --native\ --format\ org
+autocmd FileType tex setlocal formatprg=snapper\ --native\ --format\ latex
+autocmd FileType markdown setlocal formatprg=snapper\ --native\ --format\ markdown
 #+end_src
 
 Then =gq= to reformat selected text, or =gggqG= to reformat the entire buffer.
@@ -41,7 +41,7 @@ require("conform").setup({
   formatters = {
     snapper = {
       command = "snapper",
-      args = { "--format", "$FILETYPE" },
+      args = { "--native", "--format", "$FILETYPE" },
       stdin = true,
     },
   },
@@ -103,7 +103,7 @@ Use the "Run on Save" extension with a custom command:
     "commands": [
       {
         "match": "\\.(org|tex|md|rst)$",
-        "cmd": "snapper --in-place ${file}"
+        "cmd": "snapper --native --in-place ${file}"
       }
     ]
   }
@@ -249,5 +249,5 @@ Snapper reads stdin and writes stdout by default.
 Any editor that supports piping through an external program works:
 
 #+begin_src bash
-cat paper.org | snapper --format org
+cat paper.org | snapper --native --format org
 #+end_src

--- a/docs/orgmode/howto/pandoc-backend.org
+++ b/docs/orgmode/howto/pandoc-backend.org
@@ -33,7 +33,10 @@ Writer still needs =pandoc= on =PATH= when the library has no writer.
 
 **CLI backend.**
 Pandoc 2.x or 3.x on =PATH=.
+The CLI default uses pandoc when an FFI writer or =pandoc= on =PATH= is available.
+Otherwise it keeps the native line parsers (no error, no silent all-prose).
 With =--use-pandoc=, a missing or failing pandoc is an explicit error (no silent all-prose).
+Pass =--native= to force today's line parsers.
 
 **Writer.**
 The library =libsnapper_pandoc= is reader-only.
@@ -63,15 +66,21 @@ See =native/snapper-pandoc/README.md=.
 :END:
 
 #+begin_src bash
-# Pandoc parses; snapper reflows prose from the AST (auto = FFI if available)
+# Default: pandoc when FFI or pandoc on PATH is available
+snapper paper.md
+snapper --pandoc-backend auto paper.md
+snapper --pandoc-backend cli guide.adoc
+snapper --pandoc-backend ffi paper.md
+# Require pandoc (error if missing)
 snapper --use-pandoc paper.typ
-snapper --use-pandoc --pandoc-backend auto paper.md
-snapper --use-pandoc --pandoc-backend cli guide.adoc
-snapper --use-pandoc --pandoc-backend ffi paper.md
+# Force today's line parsers
+snapper --native paper.md
 #+end_src
 
-Native line parsers remain the default until product flip.
-Use =--use-pandoc= when you need formats without a built-in parser or AST-true structure; prefer FFI for parse latency once =libsnapper_pandoc= is installed.
+The CLI default uses pandoc (auto FFI, then CLI) when an in-process writer or =pandoc= on =PATH= is available.
+Otherwise it keeps the native line parsers (no error, no silent all-prose).
+Pass =--native= to force today's line parsers.
+Pass =--use-pandoc= to require the pandoc path (explicit error if FFI and =pandoc= are missing).
 The writer still needs =pandoc= on =PATH= unless the library exports a writer.
 
 **Speed.**
@@ -86,8 +95,8 @@ Disable with =SNAPPER_PANDOC_CACHE=0=; override dir with =SNAPPER_PANDOC_CACHE_D
 :CUSTOM_ID: when-to-use
 :END:
 
-- **Built-in** (default): fast, source-oriented parsers for Org / LaTeX / Markdown / RST (e.g. full ATX lines as structure).
-- **Pandoc**: you want structure from pandoc’s model and coverage of formats without a built-in parser.
+- **Pandoc** (CLI default when available): structure from pandoc’s model and coverage of formats without a built-in parser.
+- **Built-in** (=--native=): fast, source-oriented parsers for Org / LaTeX / Markdown / RST (e.g. full ATX lines as structure).
 
 The two paths are different pipelines, not two ways to fake the same source lines.
 
@@ -101,4 +110,4 @@ The two paths are different pipelines, not two ways to fake the same source line
 - Other HTML / Org / LaTeX comments that are not snapper pragmas may still be dropped.
 - Round-trip is through the AST (not a perfect source-preserving rewrite of every markup character)
 - FFI library is optional; wasm/editor bundles do not embed GHC/pandoc
-- CLI pandoc versus editor native is the contract: the CLI may take =--use-pandoc=; VS Code, Obsidian, and Word stay on native parsers.
+- CLI pandoc versus editor native is the contract: the CLI default may use pandoc; VS Code, Obsidian, Word, wasm, and LSP stay on native parsers.

--- a/docs/orgmode/howto/pragmas.org
+++ b/docs/orgmode/howto/pragmas.org
@@ -118,6 +118,6 @@ Pragmas take priority over all other parsing.
 Inside an off region, no sentence splitting, no format-aware parsing, and no abbreviation handling occurs.
 The pragma comment lines themselves always pass through as structure.
 
-=--use-pandoc= keeps =snapper:off= / =snapper:on= in the written output (the reader would otherwise delete them).
+The pandoc path keeps =snapper:off= / =snapper:on= in the written output (the reader would otherwise delete them).
 Off-region text is shielded so it is not reflowed.
-Native parsers remain the default.
+Pass =--native= to force today's line parsers.

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -181,19 +181,29 @@ Overrides =--lang=.
 :CUSTOM_ID: opt-use-pandoc
 :END:
 
-Use pandoc as the parser backend instead of built-in parsers.
+Require the pandoc path (auto FFI, then CLI).
 Parse may use in-process FFI when =libsnapper_pandoc= loads; the writer still needs =pandoc= on =PATH= (=libsnapper_pandoc= is reader-only) unless that library exports a writer.
 Without FFI, both parse and write use the =pandoc= CLI.
 A missing binary is an explicit error (never silent all-prose).
 Enables support for typst, asciidoc, docx, html, and all other pandoc-supported formats.
-Native line parsers remain the default (omit this flag).
+The default (omit this flag) already uses pandoc when an FFI writer or =pandoc= on =PATH= is available.
+
+*** =--native=
+:PROPERTIES:
+:CUSTOM_ID: opt-native
+:END:
+
+Force today's native line parsers (markdown / org / rst / latex / plaintext).
+Conflicts with =--use-pandoc=.
+Use this when you want source-oriented splice instead of the pandoc writer.
+Editors, wasm, and LSP stay native even without this flag.
 
 *** =--pandoc-backend <auto|ffi|cli>=
 :PROPERTIES:
 :CUSTOM_ID: opt-pandoc-backend
 :END:
 
-How to obtain the pandoc AST when =--use-pandoc= is set.
+How to obtain the pandoc AST when the pandoc path is used.
 =auto= (default) prefers in-process FFI, else CLI.
 =ffi= requires =libsnapper_pandoc= (explicit error if missing).
 =cli= uses a =pandoc= subprocess (explicit error if missing).

--- a/docs/orgmode/tutorials/quickstart.org
+++ b/docs/orgmode/tutorials/quickstart.org
@@ -79,6 +79,12 @@ Pipe through stdin (for editor integration):
 cat draft.org | snapper --format org
 #+end_src
 
+The CLI uses pandoc (auto FFI, then CLI) when an FFI writer or =pandoc= on =PATH= is available.
+Otherwise it keeps the native line parsers (no error).
+Pass =--native= to force today's parsers.
+Pass =--use-pandoc= to require pandoc (error if missing).
+Editors, wasm, and LSP stay native.
+
 ** What it does
 :PROPERTIES:
 :CUSTOM_ID: what-it-does
@@ -252,7 +258,7 @@ Provides format-on-save, range formatting, diagnostics, and code actions out of 
 See the [[https://github.com/TurtleTech-ehf/snapper/tree/main/editors/nvim][snapper.nvim plugin]] for full LSP integration, or use =formatprg=:
 
 #+begin_src vim
-autocmd FileType org setlocal formatprg=snapper\ --format\ org
+autocmd FileType org setlocal formatprg=snapper\ --native\ --format\ org
 #+end_src
 
 *** Emacs (Apheleia)
@@ -262,7 +268,7 @@ autocmd FileType org setlocal formatprg=snapper\ --format\ org
 
 #+begin_src elisp
 (with-eval-after-load 'apheleia
-  (push '(snapper . ("snapper" "--format" "org")) apheleia-formatters)
+  (push '(snapper . ("snapper" "--native" "--format" "org")) apheleia-formatters)
   (push '(org-mode . snapper) apheleia-mode-alist))
 #+end_src
 

--- a/docs/source/cli-reference.md
+++ b/docs/source/cli-reference.md
@@ -49,8 +49,9 @@ Semantic line break formatter
 * `--neural` — Use neural sentence detection (nnsplit LSTM model)
 * `--lang <LANG>` — Language for neural sentence detection (default: en). Available: en, de, fr, no, sv, zh, tr, ru, uk
 * `--model-path <MODEL_PATH>` — Path to custom ONNX model file for neural detection
-* `--use-pandoc` — Use pandoc as parser backend (universal format support). RST `..` comments and `snapper:off` / `snapper:on` are written through so the output still contains that text. Parse may use in-process FFI; the writer still needs `pandoc` on PATH (`libsnapper_pandoc` is reader-only) unless that library exports a writer. Without FFI, both parse and write use the `pandoc` CLI (explicit error if missing)
-* `--pandoc-backend <BACKEND>` — Pandoc AST source when `--use-pandoc` is set: `auto` (prefer in-process FFI, else CLI), `ffi` (`libsnapper_pandoc`), or `cli` (`pandoc` subprocess). Default: `auto`. `ffi` fails explicitly if the library is missing. The writer still needs `pandoc` on PATH (no silent spawn surprise)
+* `--use-pandoc` — Force the pandoc path (auto FFI then CLI). Errors if FFI and `pandoc` on PATH are both missing (no silent all-prose). The default (omit this flag) already uses pandoc when an FFI writer or `pandoc` on PATH is available. RST `..` comments and `snapper:off` / `snapper:on` are written through so the output still contains that text. Parse may use in-process FFI; the writer still needs `pandoc` on PATH (`libsnapper_pandoc` is reader-only) unless that library exports a writer
+* `--native` — Force today's native line parsers (markdown/org/rst/latex/plaintext). The default (omit this flag) uses pandoc when an FFI writer or `pandoc` on PATH is available; otherwise it keeps these parsers (no error, no silent all-prose). Editors, wasm, and LSP stay native
+* `--pandoc-backend <BACKEND>` — Pandoc AST source when the pandoc path is used: `auto` (prefer in-process FFI, else CLI), `ffi` (`libsnapper_pandoc`), or `cli` (`pandoc` subprocess). Default: `auto`. `ffi` fails explicitly if the library is missing. The writer still needs `pandoc` on PATH (no silent spawn surprise)
 
   Default value: `auto`
 * `--check` — Exit with code 1 if any file would change

--- a/editors/nvim/ftplugin/markdown.lua
+++ b/editors/nvim/ftplugin/markdown.lua
@@ -1,4 +1,4 @@
-vim.bo.formatprg = "snapper --format markdown"
+vim.bo.formatprg = "snapper --native --format markdown"
 
 local ok, _ = pcall(require, "snapper")
 if ok then

--- a/editors/nvim/ftplugin/org.lua
+++ b/editors/nvim/ftplugin/org.lua
@@ -1,4 +1,4 @@
-vim.bo.formatprg = "snapper --format org"
+vim.bo.formatprg = "snapper --native --format org"
 
 local ok, _ = pcall(require, "snapper")
 if ok then

--- a/editors/nvim/ftplugin/rst.lua
+++ b/editors/nvim/ftplugin/rst.lua
@@ -1,4 +1,4 @@
-vim.bo.formatprg = "snapper --format rst"
+vim.bo.formatprg = "snapper --native --format rst"
 
 local ok, _ = pcall(require, "snapper")
 if ok then

--- a/editors/nvim/ftplugin/tex.lua
+++ b/editors/nvim/ftplugin/tex.lua
@@ -1,4 +1,4 @@
-vim.bo.formatprg = "snapper --format latex"
+vim.bo.formatprg = "snapper --native --format latex"
 
 local ok, _ = pcall(require, "snapper")
 if ok then

--- a/editors/nvim/lua/snapper/conform.lua
+++ b/editors/nvim/lua/snapper/conform.lua
@@ -9,7 +9,7 @@ function M.setup(config)
   -- Register formatter
   conform.formatters.snapper = {
     command = config.cmd,
-    args = { "--stdin-filepath", "$FILENAME" },
+    args = { "--native", "--stdin-filepath", "$FILENAME" },
     stdin = true,
     cwd = require("conform.util").root_file({ ".snapperrc.toml" }),
   }

--- a/editors/nvim/lua/snapper/init.lua
+++ b/editors/nvim/lua/snapper/init.lua
@@ -51,7 +51,7 @@ function M.create_commands()
       return
     end
     vim.cmd("silent update")
-    local output = vim.fn.system({ M.config.cmd, "--check", filename })
+    local output = vim.fn.system({ M.config.cmd, "--native", "--check", filename })
     if vim.v.shell_error == 0 then
       vim.notify("[snapper] File is already formatted", vim.log.levels.INFO)
     else

--- a/editors/vim/autoload/snapper.vim
+++ b/editors/vim/autoload/snapper.vim
@@ -12,7 +12,7 @@ function! snapper#check()
     return
   endif
 
-  let l:output = system('snapper --check ' . shellescape(expand('%')))
+  let l:output = system('snapper --native --check ' . shellescape(expand('%')))
   if v:shell_error == 0
     echo 'Snapper: file is already formatted'
   else

--- a/editors/vim/doc/snapper.txt
+++ b/editors/vim/doc/snapper.txt
@@ -66,11 +66,11 @@ COMMANDS                                      *snapper-commands*
 INTEGRATION                                  *snapper-integration*
 
 The plugin automatically sets formatprg for supported filetypes:
-- org: snapper --format org
-- tex: snapper --format latex
-- markdown: snapper --format markdown
-- rst: snapper --format rst
-- plaintex: snapper --format plaintex
+- org: snapper --native --format org
+- tex: snapper --native --format latex
+- markdown: snapper --native --format markdown
+- rst: snapper --native --format rst
+- plaintex: snapper --native --format plaintex
 
 This enables formatting with gq operator in normal mode.
 

--- a/editors/vim/plugin/snapper.vim
+++ b/editors/vim/plugin/snapper.vim
@@ -8,7 +8,7 @@ endif
 let g:loaded_snapper = 1
 
 " Commands
-command! -range=% SnapperFormat <line1>,<line2>!snapper --stdin-filepath %:S
+command! -range=% SnapperFormat <line1>,<line2>!snapper --native --stdin-filepath %:S
 command! SnapperCheck call snapper#check()
 command! SnapperRestart call snapper#restart()
 command! SnapperInfo call snapper#info()
@@ -16,9 +16,9 @@ command! SnapperInfo call snapper#info()
 " Auto-detect filetype for formatprg
 augroup snapper
   autocmd!
-  autocmd FileType org setlocal formatprg=snapper\ --format\ org
-  autocmd FileType tex setlocal formatprg=snapper\ --format\ latex
-  autocmd FileType markdown setlocal formatprg=snapper\ --format\ markdown
-  autocmd FileType rst setlocal formatprg=snapper\ --format\ rst
-  autocmd FileType plaintex setlocal formatprg=snapper\ --format\ plaintex
+  autocmd FileType org setlocal formatprg=snapper\ --native\ --format\ org
+  autocmd FileType tex setlocal formatprg=snapper\ --native\ --format\ latex
+  autocmd FileType markdown setlocal formatprg=snapper\ --native\ --format\ markdown
+  autocmd FileType rst setlocal formatprg=snapper\ --native\ --format\ rst
+  autocmd FileType plaintex setlocal formatprg=snapper\ --native\ --format\ plaintex
 augroup END

--- a/editors/vscode/README.md
+++ b/editors/vscode/README.md
@@ -26,7 +26,8 @@ To format on save, add to your `settings.json`:
 
 ## Features
 
-- **Format on save** via the built-in LSP server
+- **Format on save** via the built-in LSP server (native line parsers; the extension does not follow the CLI pandoc default)
+- **Check / diff** via `snapper --native` so the CLI default cannot flip editor output
 - **Range formatting** -- format just the selected text
 - **Diagnostics** -- flags lines with multiple sentences as hints
 - **Quick fixes** -- code actions to split multi-sentence lines

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -241,7 +241,7 @@ export function activate(context: ExtensionContext): void {
             const filePath = editor.document.uri.fsPath;
             const snapperPath = getSnapperPath();
             try {
-                await execFileAsync(snapperPath, ["--check", filePath], {
+                await execFileAsync(snapperPath, ["--native", "--check", filePath], {
                     timeout: 30000,
                 });
                 window.showInformationMessage("File is already formatted.");
@@ -279,7 +279,7 @@ export function activate(context: ExtensionContext): void {
             try {
                 const { stdout } = await execFileAsync(
                     snapperPath,
-                    ["--diff", filePath],
+                    ["--native", "--diff", filePath],
                     {
                         timeout: 30000,
                     },

--- a/pixi.toml
+++ b/pixi.toml
@@ -11,7 +11,7 @@ rust = ">=1.85"
 check = { cmd = "cargo fmt --check && cargo clippy -- -D warnings && cargo test" }
 build = { cmd = "cargo build --release" }
 test = { cmd = "cargo test" }
-dogfood = { cmd = "cargo run --quiet -- --check --format org readme_src.org docs/orgmode/**/*.org examples/paper.org && cargo run --quiet -- --check --format plaintext examples/basic.txt && cargo run --quiet -- --check --format markdown examples/paper.md && cargo run --quiet -- --check --format latex examples/paper.tex", description = "Verify all docs pass snapper --check", depends-on = ["build"] }
+dogfood = { cmd = "cargo run --quiet -- --native --check --format org readme_src.org docs/orgmode/**/*.org examples/paper.org && cargo run --quiet -- --native --check --format plaintext examples/basic.txt && cargo run --quiet -- --native --check --format markdown examples/paper.md && cargo run --quiet -- --native --check --format latex examples/paper.tex", description = "Verify all docs pass snapper --check", depends-on = ["build"] }
 nvim-test = { cmd = "bash scripts/run_nvim_tests.sh", description = "Run Neovim plugin tests with plenary.nvim" }
 
 [feature.docs.dependencies]

--- a/readme_src.org
+++ b/readme_src.org
@@ -87,6 +87,11 @@ Pipe through stdin (for editor integration):
 #+begin_src bash
 cat draft.org | snapper --format org
 #+end_src
+The CLI uses pandoc (auto FFI, then CLI) when an FFI writer or =pandoc= on =PATH= is available.
+Otherwise it keeps the native line parsers (no error).
+Pass =--native= to force today's parsers.
+Pass =--use-pandoc= to require pandoc (error if missing).
+Editors, wasm, and LSP stay native.
 Check formatting without modifying (for CI):
 #+begin_src bash
 snapper --check paper.org paper.tex notes.md
@@ -163,7 +168,7 @@ Configuration guide (org source in-tree): =docs/orgmode/howto/mcp-integration.or
 :END:
 #+begin_src elisp
 (with-eval-after-load 'apheleia
-  (push '(snapper . ("snapper" "--format" "org")) apheleia-formatters)
+  (push '(snapper . ("snapper" "--native" "--format" "org")) apheleia-formatters)
   (push '(org-mode . snapper) apheleia-mode-alist))
 #+end_src
 ** VS Code

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -93,17 +93,26 @@ pub struct Cli {
     #[arg(long)]
     pub model_path: Option<PathBuf>,
 
-    /// Use pandoc as parser backend (universal format support).
+    /// Force the pandoc path (auto FFI then CLI).
+    /// Errors if FFI and `pandoc` on PATH are both missing (no silent
+    /// all-prose). The default (omit this flag) already uses pandoc when
+    /// an FFI writer or `pandoc` on PATH is available.
     /// RST `..` comments and `snapper:off` / `snapper:on` are written
     /// through so the output still contains that text.
     /// Parse may use in-process FFI; the writer still needs `pandoc` on PATH
     /// (`libsnapper_pandoc` is reader-only) unless that library exports a
-    /// writer. Without FFI, both parse and write use the `pandoc` CLI
-    /// (explicit error if missing).
-    #[arg(long)]
+    /// writer.
+    #[arg(long, conflicts_with = "native")]
     pub use_pandoc: bool,
 
-    /// Pandoc AST source when `--use-pandoc` is set:
+    /// Force today's native line parsers (markdown/org/rst/latex/plaintext).
+    /// The default (omit this flag) uses pandoc when an FFI writer or
+    /// `pandoc` on PATH is available; otherwise it keeps these parsers
+    /// (no error, no silent all-prose). Editors, wasm, and LSP stay native.
+    #[arg(long, conflicts_with = "use_pandoc")]
+    pub native: bool,
+
+    /// Pandoc AST source when the pandoc path is used:
     /// `auto` (prefer in-process FFI, else CLI), `ffi` (`libsnapper_pandoc`),
     /// or `cli` (`pandoc` subprocess). Default: `auto`.
     /// `ffi` fails explicitly if the library is missing.
@@ -207,6 +216,37 @@ pub enum Commands {
     },
 }
 
+impl Cli {
+    /// Whether this invocation should take the pandoc write path.
+    ///
+    /// `--native` forces today's line parsers. `--use-pandoc` requires
+    /// pandoc (error if missing). With neither flag, use pandoc when an
+    /// FFI writer or `pandoc` on PATH is available, else native.
+    pub fn resolve_use_pandoc(&self) -> bool {
+        if self.native {
+            false
+        } else if self.use_pandoc {
+            true
+        } else {
+            Self::default_use_pandoc()
+        }
+    }
+
+    /// CLI default (no `--native` / `--use-pandoc`): pandoc when the
+    /// write path can complete, else native. Library/wasm/LSP stay
+    /// `FormatConfig::default().use_pandoc == false`.
+    pub fn default_use_pandoc() -> bool {
+        #[cfg(feature = "pandoc")]
+        {
+            crate::parser::pandoc::pandoc_default_available()
+        }
+        #[cfg(not(feature = "pandoc"))]
+        {
+            false
+        }
+    }
+}
+
 /// Parse a range string "START:END" into (start, end) 1-indexed inclusive.
 pub fn parse_range(s: &str) -> Option<(usize, usize)> {
     let parts: Vec<&str> = s.split(':').collect();
@@ -224,6 +264,7 @@ pub fn parse_range(s: &str) -> Option<(usize, usize)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use clap::Parser;
 
     #[test]
     fn parse_range_valid() {
@@ -252,5 +293,39 @@ mod tests {
         assert_eq!(parse_range("a:b"), None);
         assert_eq!(parse_range(":5"), None);
         assert_eq!(parse_range("5:"), None);
+    }
+
+    #[test]
+    fn resolve_use_pandoc_native_wins() {
+        let cli = Cli::parse_from(["snapper", "--native"]);
+        assert!(cli.native);
+        assert!(!cli.use_pandoc);
+        assert!(!cli.resolve_use_pandoc());
+    }
+
+    #[test]
+    fn resolve_use_pandoc_explicit_flag() {
+        let cli = Cli::parse_from(["snapper", "--use-pandoc"]);
+        assert!(cli.use_pandoc);
+        assert!(!cli.native);
+        assert!(cli.resolve_use_pandoc());
+    }
+
+    #[test]
+    fn resolve_use_pandoc_default_matches_runtime() {
+        let cli = Cli::parse_from(["snapper"]);
+        assert!(!cli.native);
+        assert!(!cli.use_pandoc);
+        assert_eq!(cli.resolve_use_pandoc(), Cli::default_use_pandoc());
+    }
+
+    #[test]
+    fn native_conflicts_with_use_pandoc() {
+        let err = Cli::try_parse_from(["snapper", "--native", "--use-pandoc"]).unwrap_err();
+        let text = err.to_string();
+        assert!(
+            text.contains("cannot be used with") || text.contains("conflict"),
+            "expected clap conflict, got: {text}"
+        );
     }
 }

--- a/src/init.rs
+++ b/src/init.rs
@@ -146,7 +146,7 @@ fn generate_precommit() -> String {
 /// Generate Apheleia elisp snippet.
 fn generate_apheleia(formats: &[&str]) -> String {
     let mut s = String::from(";; Add to your Emacs config:\n(with-eval-after-load 'apheleia\n");
-    s.push_str("  (push '(snapper . (\"snapper\")) apheleia-formatters)\n");
+    s.push_str("  (push '(snapper . (\"snapper\" \"--native\")) apheleia-formatters)\n");
     for fmt in formats {
         let mode = match *fmt {
             "org" => "org-mode",

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,7 +104,12 @@ fn run() -> Result<()> {
             }
             Commands::Watch { patterns, format } => {
                 let fmt = format.map(Format::from_arg);
-                return snapper_fmt::watch::run_watch(patterns, fmt, cli.config.as_deref());
+                return snapper_fmt::watch::run_watch(
+                    patterns,
+                    fmt,
+                    cli.config.as_deref(),
+                    cli.resolve_use_pandoc(),
+                );
             }
         }
     }
@@ -404,7 +409,7 @@ fn build_format_config(
         latex_verbatim_envs: project_config.latex_verbatim_envs(),
         latex_structure_envs: project_config.latex_structure_envs(),
         latex_verbatim_commands: project_config.latex_verbatim_commands(),
-        use_pandoc: cli.use_pandoc,
+        use_pandoc: cli.resolve_use_pandoc(),
         #[cfg(feature = "pandoc")]
         pandoc_backend: cli
             .pandoc_backend

--- a/src/parser/pandoc/mod.rs
+++ b/src/parser/pandoc/mod.rs
@@ -108,8 +108,16 @@ pub enum PandocError {
     Ast(String),
     /// Backstop: write-through deleted an RST `..` comment or a
     /// `snapper:off` / `snapper:on` that the shield failed to restore.
-    #[error("pandoc path would drop {0}; omit --use-pandoc to keep comments and snapper pragmas")]
+    #[error("pandoc path would drop {0}; pass --native to keep comments and snapper pragmas")]
     DropsComments(String),
+}
+
+/// Whether the CLI default can run the pandoc path without erroring.
+///
+/// True when an in-process FFI writer is loaded or `pandoc` is on PATH.
+/// Reader-only FFI without PATH is not enough (write would fail).
+pub fn pandoc_default_available() -> bool {
+    ffi_write_available() || pandoc_available()
 }
 
 /// Parse input with the selected backend and classify via the pandoc AST.
@@ -427,7 +435,7 @@ mod tests {
     fn default_use_pandoc_is_false() {
         assert!(
             !crate::FormatConfig::default().use_pandoc,
-            "native path stays default (snapper-32ps owns any flip)"
+            "library/wasm/LSP stay native; CLI default is snapper-32ps"
         );
     }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -14,6 +14,7 @@ pub fn run_watch(
     patterns: &[String],
     format_override: Option<Format>,
     config_path: Option<&std::path::Path>,
+    use_pandoc: bool,
 ) -> Result<()> {
     let project_config = ProjectConfig::resolve(config_path).unwrap_or_default();
 
@@ -82,7 +83,7 @@ pub fn run_watch(
                     last_format.insert(canonical.clone(), now);
 
                     // Format
-                    match format_file_in_place(path, format_override, &project_config) {
+                    match format_file_in_place(path, format_override, &project_config, use_pandoc) {
                         Err(e) => eprintln!("  error formatting {}: {e}", path.display()),
                         Ok(true) => {
                             eprintln!("  formatted: {}", path.display());
@@ -106,6 +107,7 @@ fn format_file_in_place(
     path: &std::path::Path,
     format_override: Option<Format>,
     project_config: &ProjectConfig,
+    use_pandoc: bool,
 ) -> Result<bool> {
     if project_config.is_ignored(path) {
         return Ok(false);
@@ -132,6 +134,7 @@ fn format_file_in_place(
         latex_structure_envs: project_config.latex_structure_envs(),
         latex_verbatim_commands: project_config.latex_verbatim_commands(),
         clause_breaks: project_config.clause_breaks.unwrap_or(false),
+        use_pandoc,
         ..Default::default()
     };
 

--- a/tests/check_line_diagnostics.rs
+++ b/tests/check_line_diagnostics.rs
@@ -16,6 +16,7 @@ fn write_txt(dir: &Path, name: &str, body: &str) -> String {
 
 fn check_json(path: &str, extra: &[&str]) -> (bool, serde_json::Value, String) {
     let mut args = vec![
+        "--native",
         "--check",
         "--output-format",
         "json",
@@ -153,6 +154,7 @@ fn check_sarif_includes_start_line_and_kind() {
     let path = write_txt(dir.path(), "fused.txt", "Hello world. This is a test.\n");
     let output = snapper_binary()
         .args([
+            "--native",
             "--check",
             "--output-format",
             "sarif",
@@ -188,6 +190,7 @@ fn check_sarif_includes_start_line_and_kind() {
 fn check_json_fmt(path: &str, format: &str) -> (bool, serde_json::Value) {
     let output = snapper_binary()
         .args([
+            "--native",
             "--check",
             "--output-format",
             "json",
@@ -253,11 +256,11 @@ fn would_reformat_matches_cli_check_identity() {
     let clean = write_txt(dir.path(), "clean.txt", "Hello world.\nThis is a test.\n");
 
     let dirty_out = snapper_binary()
-        .args(["--check", "--format", "plaintext", &dirty])
+        .args(["--native", "--check", "--format", "plaintext", &dirty])
         .output()
         .unwrap();
     let clean_out = snapper_binary()
-        .args(["--check", "--format", "plaintext", &clean])
+        .args(["--native", "--check", "--format", "plaintext", &clean])
         .output()
         .unwrap();
     assert!(!dirty_out.status.success());
@@ -269,6 +272,7 @@ fn would_reformat_matches_cli_check_identity() {
 
     let clean_json_run = snapper_binary()
         .args([
+            "--native",
             "--check",
             "--output-format",
             "json",
@@ -292,7 +296,7 @@ fn would_reformat_matches_cli_check_identity() {
 
 fn pipe_check(input: &str, extra: &[&str]) -> (bool, String, String) {
     let mut cmd = snapper_binary();
-    let mut args = vec!["--check", "--format", "plaintext"];
+    let mut args = vec!["--native", "--check", "--format", "plaintext"];
     args.extend_from_slice(extra);
     cmd.args(&args)
         .stdin(std::process::Stdio::piped())
@@ -362,6 +366,7 @@ fn strict_long_does_not_fail_structure_equation() {
     fs::write(&path, body).unwrap();
     let output = snapper_binary()
         .args([
+            "--native",
             "--check",
             "--strict-long",
             "--output-format",
@@ -398,6 +403,7 @@ fn sarif_uri_is_repo_relative_or_file_with_workdir() {
     let output = snapper_binary()
         .current_dir(dir.path())
         .args([
+            "--native",
             "--check",
             "--output-format",
             "sarif",

--- a/tests/code_block_format.rs
+++ b/tests/code_block_format.rs
@@ -52,7 +52,7 @@ fn fixture_with_formatter(argv: &[&str]) -> TempDir {
 fn run_snapper(input: &str, dir: &Path, extra_args: &[&str]) -> std::process::Output {
     let mut cmd = snapper_binary();
     cmd.current_dir(dir);
-    cmd.args(["--format", "markdown", "--format-code"]);
+    cmd.args(["--native", "--format", "markdown", "--format-code"]);
     cmd.args(extra_args);
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
@@ -73,7 +73,7 @@ fn run_snapper(input: &str, dir: &Path, extra_args: &[&str]) -> std::process::Ou
 fn run_snapper_no_format(input: &str, dir: &Path) -> std::process::Output {
     let mut cmd = snapper_binary();
     cmd.current_dir(dir);
-    cmd.args(["--format", "markdown"]);
+    cmd.args(["--native", "--format", "markdown"]);
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -8,7 +8,7 @@ fn snapper_binary() -> Command {
 
 fn run_format(format: &str, input_path: &str) -> String {
     let output = snapper_binary()
-        .args(["--format", format, input_path])
+        .args(["--native", "--format", format, input_path])
         .output()
         .expect("failed to run snapper");
     assert!(
@@ -21,6 +21,7 @@ fn run_format(format: &str, input_path: &str) -> String {
 
 fn pipe_stdin(input: &str, args: &[&str]) -> std::process::Output {
     let mut cmd = snapper_binary();
+    cmd.arg("--native");
     cmd.args(args)
         .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -40,6 +41,7 @@ fn pipe_stdin(input: &str, args: &[&str]) -> std::process::Output {
 
 fn pipe_stdin_in_dir(input: &str, args: &[&str], dir: &Path) -> std::process::Output {
     let mut cmd = snapper_binary();
+    cmd.arg("--native");
     cmd.args(args)
         .current_dir(dir)
         .stdin(std::process::Stdio::piped())
@@ -182,7 +184,13 @@ fn idempotent_markdown() {
 #[test]
 fn check_mode_passes_on_formatted() {
     let output = snapper_binary()
-        .args(["--check", "--format", "org", &fixture_path("expected.org")])
+        .args([
+            "--native",
+            "--check",
+            "--format",
+            "org",
+            &fixture_path("expected.org"),
+        ])
         .output()
         .expect("failed to run snapper");
     assert!(
@@ -194,7 +202,13 @@ fn check_mode_passes_on_formatted() {
 #[test]
 fn check_mode_fails_on_unformatted() {
     let output = snapper_binary()
-        .args(["--check", "--format", "org", &fixture_path("sample.org")])
+        .args([
+            "--native",
+            "--check",
+            "--format",
+            "org",
+            &fixture_path("sample.org"),
+        ])
         .output()
         .expect("failed to run snapper");
     assert!(
@@ -318,6 +332,7 @@ fn range_preserves_outside_lines_exactly() {
     .unwrap();
     let output = snapper_binary()
         .args([
+            "--native",
             "--format",
             "plaintext",
             "--range",
@@ -338,6 +353,7 @@ fn range_preserves_outside_lines_exactly() {
 fn check_json_output() {
     let output = snapper_binary()
         .args([
+            "--native",
             "--check",
             "--output-format",
             "json",
@@ -359,6 +375,7 @@ fn check_json_output() {
 fn check_sarif_output() {
     let output = snapper_binary()
         .args([
+            "--native",
             "--check",
             "--output-format",
             "sarif",
@@ -458,7 +475,7 @@ fn config_ignore_skips_check_mode() {
     fs::write(dir.path().join("draft.md"), "Sentence one. Sentence two.\n").unwrap();
     let output = snapper_binary()
         .current_dir(dir.path())
-        .args(["--check", "draft.md"])
+        .args(["--native", "--check", "draft.md"])
         .output()
         .expect("failed to run snapper");
     assert!(output.status.success());
@@ -480,7 +497,7 @@ fn config_per_format_width_applies() {
     .unwrap();
     let output = snapper_binary()
         .current_dir(dir.path())
-        .arg("draft.txt")
+        .args(["--native", "draft.txt"])
         .output()
         .expect("failed to run snapper");
     assert!(output.status.success());

--- a/tests/pandoc_ast_backend.rs
+++ b/tests/pandoc_ast_backend.rs
@@ -11,7 +11,7 @@ use snapper_fmt::format::Format;
 use snapper_fmt::parser::Region;
 use snapper_fmt::parser::pandoc::{
     PandocBackend, PandocParser, WRITER_NEEDS_PATH, dropped_comment_kind, ffi_available,
-    ffi_write_available, regions_from_pandoc_json,
+    ffi_write_available, pandoc_default_available, regions_from_pandoc_json,
 };
 use snapper_fmt::{FormatConfig, format_text};
 
@@ -911,4 +911,207 @@ fn snapper_ffi_without_pandoc_on_path_is_inprocess_or_explicit() {
         err.contains("PATH") || err.contains(WRITER_NEEDS_PATH) || err.contains("writer"),
         "expected explicit writer PATH error, got: {err}"
     );
+}
+
+/// CLI default (no flag) uses pandoc when a writer runtime exists.
+#[test]
+fn snapper_cli_default_uses_pandoc_when_available() {
+    if !pandoc_default_available() {
+        eprintln!("skipping: no FFI writer and no pandoc on PATH");
+        return;
+    }
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let input = fixture("mixed.md");
+    let default_out = std::process::Command::new(bin)
+        .args(["--format", "markdown"])
+        .arg(&input)
+        .output()
+        .expect("spawn default");
+    let forced = std::process::Command::new(bin)
+        .args(["--use-pandoc", "--format", "markdown"])
+        .arg(&input)
+        .output()
+        .expect("spawn --use-pandoc");
+    assert!(
+        default_out.status.success(),
+        "default must use pandoc without error; stderr={} stdout={}",
+        String::from_utf8_lossy(&default_out.stderr),
+        String::from_utf8_lossy(&default_out.stdout)
+    );
+    assert!(
+        forced.status.success(),
+        "--use-pandoc must still work; stderr={}",
+        String::from_utf8_lossy(&forced.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&default_out.stdout),
+        String::from_utf8_lossy(&forced.stdout),
+        "default CLI output must match --use-pandoc when runtime exists"
+    );
+    let stdout = String::from_utf8_lossy(&default_out.stdout);
+    assert_has_sentence_break(&stdout, "Hello world.", "Second sentence");
+}
+
+/// `--native` keeps today's line parsers even when pandoc is available.
+#[test]
+fn snapper_cli_native_forces_line_parsers() {
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let input = fixture("numbered_heading.md");
+    let out = std::process::Command::new(bin)
+        .args(["--native", "--format", "markdown"])
+        .arg(&input)
+        .output()
+        .expect("spawn --native");
+    assert!(
+        out.status.success(),
+        "--native must exit 0; stderr={} stdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("### 1. `cargo binstall` (preferred binary install)"),
+        "native path must keep the full ATX source line:\n{stdout}"
+    );
+}
+
+/// Without FFI writer and without `pandoc` on PATH, the default stays native
+/// (no error, no silent all-prose of a structured file).
+#[test]
+fn snapper_cli_default_is_native_when_pandoc_missing() {
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let input = fixture("numbered_heading.md");
+    let out = std::process::Command::new(bin)
+        .args(["--format", "markdown"])
+        .arg(&input)
+        .env("PATH", "/nonexistent-snapper-32ps")
+        .env("SNAPPER_PANDOC_CACHE", "0")
+        .env_remove("SNAPPER_PANDOC_LIB")
+        .env_remove("SNAPPER_PANDOC_LIB_DIR")
+        .output()
+        .expect("spawn default without pandoc");
+    if ffi_write_available() {
+        assert!(
+            out.status.success(),
+            "FFI writer default must still succeed; stderr={}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        return;
+    }
+    assert!(
+        out.status.success(),
+        "default without pandoc must stay native, not error; stderr={} stdout={}",
+        String::from_utf8_lossy(&out.stderr),
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.contains("### 1. `cargo binstall` (preferred binary install)"),
+        "missing pandoc must keep native ATX line, not all-prose:\n{stdout}"
+    );
+}
+
+/// `--use-pandoc` still errors when the runtime is missing (default does not).
+#[test]
+fn snapper_cli_use_pandoc_still_errors_when_missing() {
+    if ffi_available() || ffi_write_available() {
+        eprintln!("skipping: FFI present, --use-pandoc would not miss a runtime");
+        return;
+    }
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let input = fixture("mixed.md");
+    let out = std::process::Command::new(bin)
+        .args(["--use-pandoc", "--format", "markdown"])
+        .arg(&input)
+        .env("PATH", "/nonexistent-snapper-32ps")
+        .env("SNAPPER_PANDOC_CACHE", "0")
+        .env_remove("SNAPPER_PANDOC_LIB")
+        .env_remove("SNAPPER_PANDOC_LIB_DIR")
+        .output()
+        .expect("spawn --use-pandoc without runtime");
+    assert!(
+        !out.status.success(),
+        "--use-pandoc without runtime must error; stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("PATH")
+            || err.contains("unavailable")
+            || err.contains("pandoc")
+            || err.contains("CLI"),
+        "expected explicit missing-runtime error, got: {err}"
+    );
+}
+
+/// `--help` names the new default and `--native`.
+#[test]
+fn snapper_help_names_native_and_default_pandoc() {
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let out = std::process::Command::new(bin)
+        .arg("--help")
+        .output()
+        .expect("snapper --help");
+    assert!(out.status.success(), "help must exit 0");
+    let text = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        text.contains("--native"),
+        "help must name --native:\n{text}"
+    );
+    assert!(
+        text.contains("native line parsers") || text.contains("today's native"),
+        "help must describe the native flag:\n{text}"
+    );
+    assert!(
+        text.contains("when") && (text.contains("available") || text.contains("PATH")),
+        "help must say the default uses pandoc when available:\n{text}"
+    );
+}
+
+/// `--native` and `--use-pandoc` conflict.
+#[test]
+fn snapper_cli_native_conflicts_with_use_pandoc() {
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let out = std::process::Command::new(bin)
+        .args(["--native", "--use-pandoc", "--format", "markdown"])
+        .output()
+        .expect("spawn snapper");
+    assert!(
+        !out.status.success(),
+        "--native --use-pandoc must fail; stdout={}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let err = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        err.contains("cannot be used with") || err.contains("conflict"),
+        "expected clap conflict, got: {err}"
+    );
+}
+
+/// `--native` matches library native `format_text` even when pandoc exists.
+#[test]
+fn snapper_cli_native_matches_library_native() {
+    let input = read_fixture("mixed.md");
+    let expected = format_text(
+        &input,
+        &FormatConfig {
+            format: Format::Markdown,
+            use_pandoc: false,
+            ..Default::default()
+        },
+    )
+    .expect("native format_text");
+    let bin = env!("CARGO_BIN_EXE_snapper");
+    let out = std::process::Command::new(bin)
+        .args(["--native", "--format", "markdown"])
+        .arg(fixture("mixed.md"))
+        .output()
+        .expect("spawn snapper");
+    assert!(
+        out.status.success(),
+        "--native must exit 0; stderr={}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert_eq!(stdout, expected);
 }


### PR DESCRIPTION
The CLI now uses pandoc (auto FFI then CLI) when an FFI writer or `pandoc` on PATH is available. Otherwise it keeps the native line parsers. `--native` forces those parsers. `--use-pandoc` still errors if the backend is missing.

The library default stays native. So do wasm and the LSP. Editors pin `--native` so a later PATH install cannot flip VS Code or nvim.

This is snapper-32ps.
