### PR TITLE
fix(reflow): hang RST enumerated item continuations

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -909,6 +909,53 @@ mod tests {
     }
 
     #[test]
+    fn reporter_enumerated_item_second_sentence_hangs_at_marker_width() {
+        use crate::format::Format;
+        use crate::oracle;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = "#. First sentence. Second sentence.\n";
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, "#. First sentence.\n   Second sentence.\n",
+            "second sentence must hang at `#. ` width, got:\n{out}"
+        );
+        let twice = format_text(&out, &cfg).unwrap();
+        assert_eq!(
+            out, twice,
+            "hung enumerated item must be identity, got:\n{twice}"
+        );
+        assert!(
+            oracle::matches(Format::Rst, input, &out),
+            "oracle mismatch\n in={input:?}\n out={out:?}"
+        );
+
+        // Bullet hang from #51 stays.
+        let bullet = "* First sentence. Second sentence.\n";
+        let bullet_out = format_text(bullet, &cfg).unwrap();
+        assert_eq!(
+            bullet_out, "* First sentence.\n  Second sentence.\n",
+            "bullet hang must stay, got:\n{bullet_out}"
+        );
+        let bullet_twice = format_text(&bullet_out, &cfg).unwrap();
+        assert_eq!(
+            bullet_out, bullet_twice,
+            "hung bullet must be identity, got:\n{bullet_twice}"
+        );
+        let blank_hang = "- First sentence.\n\n  Second sentence.\n";
+        let blank_out = format_text(blank_hang, &cfg).unwrap();
+        assert_eq!(
+            blank_out, blank_hang,
+            "list continuation hang from #51 must stay, got:\n{blank_out}"
+        );
+    }
+
+    #[test]
     fn comment_opener_and_body_are_structure() {
         let input = "..\n   First sentence.\n   Second sentence.\n";
         let regions = RstParser.parse(input);

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -856,13 +856,15 @@ fn hanging_indent_width(s: &str) -> usize {
         return 0;
     }
     // Parser markers are `core` plus one trailing space; leading indent is
-    // part of the hang so nested `   - ` continues at column 5.
+    // part of the hang so nested `   - ` continues at column 5. RST `#.`
+    // is an auto-enumerator (GitHub #60); digits-only would miss it.
     let core = &trimmed[..trimmed.len() - 1];
     let is_bullet = matches!(core, "-" | "*" | "+");
+    let is_rst_autoenum = core == "#.";
     let is_ordered = (core.ends_with('.') || core.ends_with(')'))
         && core.len() > 1
         && core[..core.len() - 1].bytes().all(|b| b.is_ascii_digit());
-    if is_bullet || is_ordered {
+    if is_bullet || is_ordered || is_rst_autoenum {
         s.chars().count()
     } else {
         0
@@ -980,10 +982,12 @@ mod tests {
         assert_eq!(hanging_prefix("  > "), "  > ");
         assert_eq!(hanging_prefix("- "), "  ");
         assert_eq!(hanging_prefix("1. "), "   ");
+        assert_eq!(hanging_prefix("#. "), "   ");
         assert_eq!(hanging_prefix("  "), "  ");
         assert_eq!(hanging_indent_width("  "), 0);
         assert_eq!(hanging_indent_width("> "), 0);
         assert_eq!(hanging_indent_width("- "), 2);
+        assert_eq!(hanging_indent_width("#. "), 3);
     }
 
     #[test]
@@ -1411,6 +1415,7 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_indent_width("1. "), 3);
         assert_eq!(hanging_indent_width("10. "), 4);
         assert_eq!(hanging_indent_width("1) "), 3);
+        assert_eq!(hanging_indent_width("#. "), 3);
         assert_eq!(hanging_indent_width("   - "), 5);
         // Quotes are a prefix hang, not a space-hang bullet.
         assert_eq!(hanging_indent_width("> "), 0);
@@ -1420,6 +1425,7 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_prefix("  > "), "  > ");
         assert_eq!(hanging_prefix("- "), "  ");
         assert_eq!(hanging_prefix("1. "), "   ");
+        assert_eq!(hanging_prefix("#. "), "   ");
         assert_eq!(hanging_prefix("  "), "  ");
         assert_eq!(hanging_indent_width("  "), 0);
         assert_eq!(hanging_indent_width("\n"), 0);
@@ -1457,6 +1463,16 @@ They are endowed with reason and conscience and should act towards one another i
             Region::Structure("\n".to_string()),
         ]);
         assert_eq!(result, "1. One.\n   Two.\n");
+    }
+
+    #[test]
+    fn rst_autoenum_list_hanging_indent() {
+        let result = reflow_regions(vec![
+            Region::Structure("#. ".to_string()),
+            Region::Prose("First sentence. Second sentence.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(result, "#. First sentence.\n   Second sentence.\n");
     }
 
     #[test]


### PR DESCRIPTION
`#. First sentence. Second sentence.` emitted the second sentence at column 0. The hang for `#. ` was not repeated on the continuation.

The second sentence now hangs at the marker width. Bullet hang from #51 is unchanged.

Closes #60.
