### PR TITLE
fix(rst): keep block quote indent

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -20,7 +20,8 @@ impl FormatParser for RstParser {
 }
 
 /// Line-based RST parser. Handles directives, literal blocks, sections,
-/// field lists, comments, tables, and definition lists as structure regions.
+/// field lists, comments, tables, definition lists, and block-quote
+/// hang spaces as structure regions.
 fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut regions = Vec::new();
     let mut current_prose = String::new();
@@ -34,8 +35,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     // Comment body: indented lines after `..` / `.. text` stay Structure.
     let mut in_comment = false;
     let mut comment_indent: usize = 0;
-    // Hang column of the current list item (`- ` → 2). Continuation
-    // paragraphs after a blank stay in the item when indented this far.
+    // Hang column of the current list item (`- ` → 2) or block quote.
+    // Continuation paragraphs after a blank stay in the item when
+    // indented this far.
     let mut list_hang: Option<usize> = None;
     let mut pragma_off = false;
 
@@ -351,6 +353,26 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
                 continue;
             }
             list_hang = None;
+        }
+
+        // Block quote: indented prose that is not a list, directive,
+        // comment, definition, or literal. Hang spaces stay Structure
+        // so splice does not outdent them (GitHub #58). Compact wrap
+        // (no blank) joins via list_hang so SemBr still applies.
+        let leading = line_text.len() - line_text.trim_start().len();
+        if leading > 0 {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            list_hang = Some(leading);
+            regions.push(SpannedRegion::structure(
+                input,
+                ByteSpan::new(line.start, line.start + leading),
+            ));
+            if line_text.len() > leading {
+                current_prose.push_str(line_text[leading..].trim());
+                prose_span = Some(ByteSpan::new(line.start + leading, line.end));
+            }
+            i += 1;
+            continue;
         }
 
         // Regular prose
@@ -1094,6 +1116,113 @@ mod tests {
         assert!(
             out.contains("\n  print(\"hello\")"),
             "body must keep two-space indent, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn block_quote_hang_is_structure() {
+        let input = "Before.\n\n   First sentence.\n   Second sentence.\n\nAfter.\n";
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "   ")),
+            "quote hang must be Structure, got {regions:?}"
+        );
+        let prose: Vec<_> = regions
+            .iter()
+            .filter_map(|r| match r {
+                Region::Prose(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            prose.iter().any(|s| s.contains("Before.")),
+            "surrounding paragraph must stay Prose, got {regions:?}"
+        );
+        assert!(
+            prose.iter().any(|s| s.contains("After.")),
+            "trailing paragraph must stay Prose, got {regions:?}"
+        );
+        assert!(
+            prose
+                .iter()
+                .any(|s| s.contains("First sentence.") && s.contains("Second sentence.")),
+            "compact quote lines must join into one Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn reporter_block_quote_is_identity_under_format() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = "Before.\n\n   First sentence.\n   Second sentence.\n\nAfter.\n";
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, input,
+            "reporter block quote must stay identity under format, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n   First sentence."),
+            "first quote line must keep three-space indent, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n   Second sentence."),
+            "second quote line must keep three-space indent, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn surrounding_unquoted_paragraphs_still_reflow() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = concat!(
+            "Before. More before.\n\n",
+            "   First sentence.\n   Second sentence.\n\n",
+            "After. More after.\n"
+        );
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains("Before.\nMore before."),
+            "leading unquoted paragraph must still reflow, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n   First sentence.\n   Second sentence.\n"),
+            "quoted sentences must keep indent, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nMore after."),
+            "trailing unquoted paragraph must still reflow, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn compact_block_quote_reflows_with_hang() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = "Before.\n\n   First sentence. Second sentence.\n\nAfter.\n";
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, "Before.\n\n   First sentence.\n   Second sentence.\n\nAfter.\n",
+            "quoted sentences must reflow with hang, got:\n{out}"
         );
     }
 }


### PR DESCRIPTION
A three-space RST block quote was treated as ordinary prose and moved to column 0.

Hang spaces stay Structure so splice keeps the indent. Surrounding unquoted paragraphs still reflow. The reporter fixture is identity.

Closes #58.
