### PR TITLE
fix(sentence): keep break before lowercase proper noun

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -1,7 +1,9 @@
 use regex::Regex;
 use std::sync::LazyLock;
 
-use crate::parser::{ByteSpan, FormatParser, Line, SpannedRegion, flush_prose_spanned, iter_lines};
+use crate::parser::{
+    ByteSpan, FormatParser, Line, SpannedRegion, flush_prose_spanned, iter_lines, join_prose_gap,
+};
 use crate::sentence::unicode::latex_verb_span_end_with;
 
 // Environments whose content is NOT prose (math, code, figures, tables)
@@ -371,7 +373,7 @@ impl<'a> ParseState<'a> {
         let content_start = abs_start + lead;
         let content_end = content_start + trimmed.len();
         if !self.current_prose.is_empty() && !self.nospace_join {
-            self.current_prose.push(' ');
+            join_prose_gap(&mut self.current_prose);
         }
         self.current_prose.push_str(trimmed);
         match &mut self.prose_span {

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -2,7 +2,8 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::parser::{
-    ByteSpan, FormatParser, Line, SpannedRegion, flush_prose_spanned, iter_lines, push_prose_line,
+    ByteSpan, FormatParser, Line, SpannedRegion, flush_prose_spanned, iter_lines, join_prose_gap,
+    push_prose_line,
 };
 
 static HEADING_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(#{1,6}\s+)(.*)$").unwrap());
@@ -112,7 +113,7 @@ fn append_piece(
         let left = raw.len() - trimmed.len();
         if !trimmed.is_empty() {
             if !acc.text.is_empty() && join_space {
-                acc.text.push(' ');
+                join_prose_gap(acc.text);
             }
             acc.text.push_str(trimmed);
             let start = line.start + piece_from + left;
@@ -141,7 +142,7 @@ fn append_piece(
     }
     if !piece.is_empty() {
         if !acc.text.is_empty() && join_space {
-            acc.text.push(' ');
+            join_prose_gap(acc.text);
         }
         acc.text.push_str(piece);
         let start = line.start + piece_from;
@@ -596,7 +597,7 @@ mod tests {
         assert_eq!(
             regions,
             vec![Region::Prose(
-                "Hello world. This is a test. Another line here.".to_string()
+                "Hello world. This is a test.\nAnother line here.".to_string()
             )]
         );
     }
@@ -797,7 +798,7 @@ mod tests {
         assert_eq!(
             regions[1],
             Region::Prose(
-                "First line of item continuation text here. Another sentence.".to_string()
+                "First line of item continuation text here.\nAnother sentence.".to_string()
             )
         );
         // No trailing newline in the source, so no terminator Structure.
@@ -811,7 +812,7 @@ mod tests {
         assert_eq!(regions[0], Region::Structure("- ".to_string()));
         assert_eq!(
             regions[1],
-            Region::Prose("Item one text. continuation.".to_string())
+            Region::Prose("Item one text.\ncontinuation.".to_string())
         );
         assert_eq!(regions[2], Region::Structure("\n".to_string()));
         assert!(matches!(&regions[3], Region::BlankLines(_)));
@@ -1092,13 +1093,13 @@ mod tests {
         assert_eq!(regions[0], Region::Structure("1. ".to_string()));
         assert_eq!(
             regions[1],
-            Region::Prose("Parent one. Parent two.".to_string())
+            Region::Prose("Parent one.\nParent two.".to_string())
         );
         assert_eq!(regions[2], Region::Structure("\n".to_string()));
         assert_eq!(regions[3], Region::Structure("   - ".to_string()));
         assert_eq!(
             regions[4],
-            Region::Prose("Child one. Child two.".to_string())
+            Region::Prose("Child one.\nChild two.".to_string())
         );
         assert_eq!(regions[5], Region::Structure("\n".to_string()));
     }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -9,7 +9,7 @@ pub mod span;
 
 pub use span::{
     ByteSpan, CodeSpans, Line, RegionOrigin, SpannedRegion, flush_prose_spanned, iter_lines,
-    push_prose_line,
+    join_prose_gap, push_prose_line,
 };
 
 /// A region of text classified by a format parser.

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 
 use crate::parser::{
     ByteSpan, FormatParser, Region, RegionOrigin, SpannedRegion, flush_prose_spanned, iter_lines,
-    push_prose_line,
+    join_prose_gap, push_prose_line,
 };
 
 static HEADLINE_RE: LazyLock<Regex> =
@@ -359,7 +359,7 @@ impl FormatParser for OrgParser {
                         regions.pop();
                         if let Some(prev) = regions.last_mut() {
                             if let Region::Prose(prose) = &mut prev.region {
-                                prose.push(' ');
+                                join_prose_gap(prose);
                                 prose.push_str(line_text.trim());
                             }
                             if let Some(RegionOrigin::Whole(span)) = &mut prev.origin {
@@ -410,7 +410,7 @@ mod tests {
         assert_eq!(
             regions,
             vec![Region::Prose(
-                "Hello world. This is a test. Another line here.".to_string()
+                "Hello world. This is a test.\nAnother line here.".to_string()
             )]
         );
     }
@@ -586,11 +586,11 @@ mod tests {
     fn list_item_continuation() {
         let input = "- First sentence of item.\n  Continuation of the same item.\n- Second item";
         let regions = OrgParser.parse(input);
-        // First item: Structure("- ") + Prose("First sentence of item. Continuation of the same item.") + Structure("\n")
+        // First item: Structure("- ") + Prose + Structure("\n")
         assert_eq!(regions[0], Region::Structure("- ".to_string()));
         assert_eq!(
             regions[1],
-            Region::Prose("First sentence of item. Continuation of the same item.".to_string())
+            Region::Prose("First sentence of item.\nContinuation of the same item.".to_string())
         );
         assert_eq!(regions[2], Region::Structure("\n".to_string()));
         // Second item: Structure("- ") + Prose("Second item") + Structure("\n")
@@ -669,7 +669,7 @@ mod tests {
 
         let regions = OrgParser.parse(&out);
         assert_eq!(regions[0], Region::Structure("- ".to_string()));
-        assert_eq!(regions[1], Region::Prose("One. Two.".to_string()));
+        assert_eq!(regions[1], Region::Prose("One.\nTwo.".to_string()));
         assert_eq!(regions[2], Region::Structure("\n".to_string()));
         assert_eq!(regions.len(), 3);
     }
@@ -695,13 +695,13 @@ mod tests {
         assert_eq!(regions[0], Region::Structure("1. ".to_string()));
         assert_eq!(
             regions[1],
-            Region::Prose("Parent one. Parent two.".to_string())
+            Region::Prose("Parent one.\nParent two.".to_string())
         );
         assert_eq!(regions[2], Region::Structure("\n".to_string()));
         assert_eq!(regions[3], Region::Structure("   - ".to_string()));
         assert_eq!(
             regions[4],
-            Region::Prose("Child one. Child two.".to_string())
+            Region::Prose("Child one.\nChild two.".to_string())
         );
         assert_eq!(regions[5], Region::Structure("\n".to_string()));
         assert_eq!(regions.len(), 6);

--- a/src/parser/plaintext.rs
+++ b/src/parser/plaintext.rs
@@ -52,7 +52,7 @@ mod tests {
         assert_eq!(
             regions,
             vec![Region::Prose(
-                "Hello world. This is a test. Another line here.".to_string()
+                "Hello world. This is a test.\nAnother line here.".to_string()
             )]
         );
     }

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 
 use crate::parser::{
     ByteSpan, FormatParser, Line, Region, SpannedRegion, flush_prose_spanned, iter_lines,
-    push_prose_line,
+    join_prose_gap, push_prose_line,
 };
 
 /// Match `.. code-block:: LANG` or `.. sourcecode:: LANG` (or `.. code:: LANG`).
@@ -339,7 +339,7 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
                     }
                 } else if line_text.len() > leading {
                     if !current_prose.is_empty() {
-                        current_prose.push(' ');
+                        join_prose_gap(&mut current_prose);
                     }
                     current_prose.push_str(line_text[leading..].trim());
                     match prose_span.as_mut() {
@@ -846,7 +846,7 @@ mod tests {
             .collect();
         assert_eq!(
             prose,
-            ["One. Two."],
+            ["One.\nTwo."],
             "compact hang must join into one Prose, got {regions:?}"
         );
         assert!(

--- a/src/parser/span.rs
+++ b/src/parser/span.rs
@@ -200,6 +200,31 @@ pub fn iter_lines(input: &str) -> Vec<Line<'_>> {
     lines
 }
 
+/// True when `s` ends a sentence: `.!?` plus optional quotes, brackets,
+/// or markup closers.
+pub fn ends_sentence_punct(s: &str) -> bool {
+    let core = s.trim_end().trim_end_matches([
+        '"', '\'', ')', ']', '}', '*', '_', '`', '~', '/', '=', '+', '\u{201d}', '\u{2019}',
+    ]);
+    core.ends_with('.') || core.ends_with('!') || core.ends_with('?')
+}
+
+/// Insert the join between accumulated prose lines.
+///
+/// A source newline after sentence punctuation is a break. Replacing it
+/// with a space lets UAX SB8 fuse the next token when it starts lowercase
+/// (`iCloud`). Mid-sentence wraps still join with a space.
+pub fn join_prose_gap(prose: &mut String) {
+    if prose.is_empty() {
+        return;
+    }
+    if ends_sentence_punct(prose) {
+        prose.push('\n');
+    } else {
+        prose.push(' ');
+    }
+}
+
 /// Append a physical line to the running prose buffer and extend its span.
 ///
 /// `include_terminator` is true for ordinary paragraphs (the original
@@ -213,7 +238,7 @@ pub fn push_prose_line(
     include_terminator: bool,
 ) {
     if !prose.is_empty() && join_space {
-        prose.push(' ');
+        join_prose_gap(prose);
     }
     prose.push_str(line.text.trim());
     let end = if include_terminator {
@@ -270,5 +295,21 @@ mod tests {
         assert_eq!(lines[0].text, "a");
         assert_eq!(lines[0].span().slice(input), Some("a\r\n"));
         assert_eq!(lines[1].text, "b");
+    }
+
+    #[test]
+    fn join_prose_gap_keeps_break_after_sentence() {
+        let mut prose = String::from("First sentence.");
+        join_prose_gap(&mut prose);
+        prose.push_str("iCloud starts the second sentence.");
+        assert_eq!(prose, "First sentence.\niCloud starts the second sentence.");
+
+        let mut wrap = String::from("The experiment ran for several");
+        join_prose_gap(&mut wrap);
+        wrap.push_str("weeks using the usual protocol.");
+        assert_eq!(
+            wrap,
+            "The experiment ran for several weeks using the usual protocol."
+        );
     }
 }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -1926,7 +1926,13 @@ mod tests {
         use crate::{FormatConfig, format_text};
 
         let input = "First sentence.\niCloud starts the second sentence.\n";
-        for format in [Format::Markdown, Format::Plaintext] {
+        for format in [
+            Format::Markdown,
+            Format::Plaintext,
+            Format::Org,
+            Format::Latex,
+            Format::Rst,
+        ] {
             let cfg = FormatConfig {
                 format,
                 max_width: 0,

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -1919,4 +1919,25 @@ mod tests {
             "must not split before the closer, got:\n{out}"
         );
     }
+
+    #[test]
+    fn keeps_break_before_lowercase_proper_noun() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "First sentence.\niCloud starts the second sentence.\n";
+        for format in [Format::Markdown, Format::Plaintext] {
+            let cfg = FormatConfig {
+                format,
+                max_width: 0,
+                ..Default::default()
+            };
+            let out = format_text(input, &cfg).unwrap();
+            assert_eq!(
+                out, input,
+                "{format:?} must keep the break before iCloud, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &cfg).unwrap(), out);
+        }
+    }
 }


### PR DESCRIPTION
`First sentence.` plus `iCloud starts the second sentence.` was joined because the parser turned the source newline into a space and UAX SB8 will not break before a lowercase letter.

A newline after `.!?` is kept when joining prose. The fixture stays two lines on every native format.

Closes #65.
