### PR TITLE
fix(latex): hang enumerate item continuation sentences

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -351,6 +351,17 @@ impl<'a> ParseState<'a> {
         }
     }
 
+    /// `\item` / `\item[label]` is Structure so reflow can hang the next
+    /// sentence at marker width (same class as Markdown/Org/RST `1.`).
+    fn append_item_or_prose(&mut self, abs_start: usize, piece: &str) {
+        if let Some(marker_len) = latex_item_marker_len(piece) {
+            self.push_structure(ByteSpan::new(abs_start, abs_start + marker_len));
+            self.append_prose_slice(abs_start + marker_len, &piece[marker_len..]);
+        } else {
+            self.append_prose_slice(abs_start, piece);
+        }
+    }
+
     fn append_prose_slice(&mut self, abs_start: usize, piece: &str) {
         let trimmed = piece.trim();
         if trimmed.is_empty() {
@@ -532,7 +543,7 @@ impl<'a> ParseState<'a> {
         let mut i = 0;
         while i < code.len() {
             if let Some(hit) = find_env_at(code, i, &self.parser.extra_verbatim_commands) {
-                self.append_prose_slice(line.start + i, &code[i..hit.start]);
+                self.append_item_or_prose(line.start + i, &code[i..hit.start]);
                 if hit.is_begin && self.parser.is_code_env(&hit.name) {
                     self.flush();
                     if let Some(end_at) = find_matching_raw_end(line.text, hit.end, &hit.name, 1) {
@@ -599,10 +610,39 @@ impl<'a> ParseState<'a> {
                 ));
                 return false;
             }
-            self.append_prose_slice(line.start + i, rest);
+            self.append_item_or_prose(line.start + i, rest);
             return false;
         }
         false
+    }
+}
+
+/// Byte length of a compact LaTeX `\item` opener: leading indent, `\item`,
+/// optional `[label]`, and one trailing space when present.
+/// `\itemize` / `\itemsep` are different control words.
+fn latex_item_marker_len(s: &str) -> Option<usize> {
+    let indent = s.len() - s.trim_start_matches([' ', '\t']).len();
+    let t = &s[indent..];
+    let rest = t.strip_prefix("\\item")?;
+    if rest.starts_with(|c: char| c.is_ascii_alphabetic()) {
+        return None;
+    }
+    let mut len = indent + "\\item".len();
+    if rest.starts_with('[') {
+        let close = rest.find(']')?;
+        if rest[1..close].contains('[') {
+            return None;
+        }
+        len += close + 1;
+        if rest[close + 1..].starts_with(' ') {
+            len += 1;
+        }
+        return Some(len);
+    }
+    if rest.starts_with(' ') {
+        Some(len + 1)
+    } else {
+        Some(len)
     }
 }
 
@@ -1546,5 +1586,81 @@ Some text.
             "\\Verbatim must remain in the source, got:\n{out}"
         );
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn latex_item_marker_len_skips_itemize() {
+        assert_eq!(latex_item_marker_len("\\item "), Some(6));
+        assert_eq!(latex_item_marker_len("  \\item "), Some(8));
+        assert_eq!(latex_item_marker_len("\\item[Term] "), Some(12));
+        assert_eq!(latex_item_marker_len("\\itemize"), None);
+        assert_eq!(latex_item_marker_len("\\itemsep"), None);
+        assert_eq!(latex_item_marker_len("not an item"), None);
+    }
+
+    #[test]
+    fn enumerate_item_marker_is_structure() {
+        let input =
+            "\\begin{enumerate}\n\\item First sentence. Second sentence.\n\\end{enumerate}\n";
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "\\item ")),
+            "\\item  must be Structure, got {regions:?}"
+        );
+        let prose: Vec<_> = regions
+            .iter()
+            .filter_map(|r| match r {
+                Region::Prose(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            prose,
+            ["First sentence. Second sentence."],
+            "item body must be one Prose region, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("\\begin{enumerate}")
+            )),
+            "enumerate opener must stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("\\end{enumerate}")
+            )),
+            "enumerate closer must stay Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn enumerate_item_hangs_next_sentence() {
+        use crate::format::Format;
+        use crate::oracle;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Latex,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input =
+            "\\begin{enumerate}\n\\item First sentence. Second sentence.\n\\end{enumerate}\n";
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out,
+            "\\begin{enumerate}\n\\item First sentence.\n      Second sentence.\n\\end{enumerate}\n",
+            "enumerate item must hang at \\\\item  width, got:\n{out}"
+        );
+        let twice = format_text(&out, &cfg).unwrap();
+        assert_eq!(out, twice, "hung enumerate must be identity, got:\n{twice}");
+        assert!(
+            oracle::matches(Format::Latex, input, &out),
+            "oracle mismatch\n in={input:?}\n out={out:?}"
+        );
     }
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -589,6 +589,11 @@ fn latex_opens_block(line: &str) -> bool {
     if t.starts_with("\\begin{") || t.starts_with("\\end{") || t.starts_with("\\[") {
         return true;
     }
+    if let Some(after) = t.strip_prefix("\\item") {
+        if !after.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return true;
+        }
+    }
     const CMDS: &[&str] = &[
         "\\part",
         "\\chapter",
@@ -864,11 +869,26 @@ fn hanging_indent_width(s: &str) -> usize {
     let is_ordered = (core.ends_with('.') || core.ends_with(')'))
         && core.len() > 1
         && core[..core.len() - 1].bytes().all(|b| b.is_ascii_digit());
-    if is_bullet || is_ordered || is_rst_autoenum {
+    // LaTeX `\item` / `\item[label]` (not `\itemize`).
+    if is_bullet || is_ordered || is_rst_autoenum || is_latex_item_core(core) {
         s.chars().count()
     } else {
         0
     }
+}
+
+fn is_latex_item_core(core: &str) -> bool {
+    let rest = match core.strip_prefix("\\item") {
+        Some(r) => r,
+        None => return false,
+    };
+    if rest.starts_with(|c: char| c.is_ascii_alphabetic()) {
+        return false;
+    }
+    if rest.is_empty() {
+        return true;
+    }
+    rest.starts_with('[') && rest.ends_with(']') && !rest[1..rest.len() - 1].contains(['[', ']'])
 }
 
 /// Markdown hard break payloads: two or more spaces plus newline, or `\\\n`.
@@ -983,11 +1003,13 @@ mod tests {
         assert_eq!(hanging_prefix("- "), "  ");
         assert_eq!(hanging_prefix("1. "), "   ");
         assert_eq!(hanging_prefix("#. "), "   ");
+        assert_eq!(hanging_prefix("\\item "), "      ");
         assert_eq!(hanging_prefix("  "), "  ");
         assert_eq!(hanging_indent_width("  "), 0);
         assert_eq!(hanging_indent_width("> "), 0);
         assert_eq!(hanging_indent_width("- "), 2);
         assert_eq!(hanging_indent_width("#. "), 3);
+        assert_eq!(hanging_indent_width("\\item "), 6);
     }
 
     #[test]
@@ -1426,6 +1448,7 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_prefix("- "), "  ");
         assert_eq!(hanging_prefix("1. "), "   ");
         assert_eq!(hanging_prefix("#. "), "   ");
+        assert_eq!(hanging_prefix("\\item "), "      ");
         assert_eq!(hanging_prefix("  "), "  ");
         assert_eq!(hanging_indent_width("  "), 0);
         assert_eq!(hanging_indent_width("\n"), 0);
@@ -1433,6 +1456,9 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_indent_width("$x$"), 0);
         assert_eq!(hanging_indent_width("`code`"), 0);
         assert_eq!(hanging_indent_width("## heading\n"), 0);
+        assert_eq!(hanging_indent_width("\\item "), 6);
+        assert_eq!(hanging_indent_width("\\item[Term] "), 12);
+        assert_eq!(hanging_indent_width("\\itemize "), 0);
     }
 
     #[test]
@@ -1473,6 +1499,16 @@ They are endowed with reason and conscience and should act towards one another i
             Region::Structure("\n".to_string()),
         ]);
         assert_eq!(result, "#. First sentence.\n   Second sentence.\n");
+    }
+
+    #[test]
+    fn latex_item_list_hanging_indent() {
+        let result = reflow_regions(vec![
+            Region::Structure("\\item ".to_string()),
+            Region::Prose("One. Two.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(result, "\\item One.\n      Two.\n");
     }
 
     #[test]
@@ -1978,6 +2014,17 @@ They are endowed with reason and conscience and should act towards one another i
         assert!(
             section.contains("apples \\section"),
             "\\section is not an MD escape:\n{section}"
+        );
+
+        let item = wrap_fmt(
+            "The options are apples \\item extra words here.",
+            23,
+            crate::format::Format::Latex,
+        );
+        assert_no_col0_block(&item, &["\\item", "\\item "]);
+        assert!(
+            item.contains("apples \\item"),
+            "\\item is not an MD escape; skip-cut must keep it:\n{item}"
         );
     }
 

--- a/tests/latex_enumerate_hang.rs
+++ b/tests/latex_enumerate_hang.rs
@@ -1,0 +1,20 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+#[test]
+fn enumerate_item_hangs_next_sentence() {
+    let cfg = FormatConfig {
+        format: Format::Latex,
+        max_width: 0,
+        ..Default::default()
+    };
+    let input = "\\begin{enumerate}\n\\item First sentence. Second sentence.\n\\end{enumerate}\n";
+    let out = format_text(input, &cfg).unwrap();
+    assert_eq!(
+        out,
+        "\\begin{enumerate}\n\\item First sentence.\n      Second sentence.\n\\end{enumerate}\n",
+        "enumerate item must hang at \\\\item  width, got:\n{out}"
+    );
+    let twice = format_text(&out, &cfg).unwrap();
+    assert_eq!(out, twice, "hung enumerate must be identity, got:\n{twice}");
+}


### PR DESCRIPTION
`\item First sentence. Second sentence.` emitted the second sentence at column 0. Numbered `1.` lists already hang.

`\item` is Structure and the next sentence hangs at marker width. The enumerate env stays structure.

This is snapper-sawy.
