### PR TITLE
fix(latex): treat tree-sitter and latexindent math/table envs as structure

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -6,32 +6,67 @@ use crate::parser::{
 };
 use crate::sentence::unicode::latex_verb_span_end_with;
 
-// Environments whose content is NOT prose (math, code, figures, tables)
+// Environments whose content is NOT prose (math, code, figures, tables).
+// Extra names are tree-sitter-latex `math_environment` plus latexindent
+// `lookForAlignDelims` (amsmath / mathtools / tabularray), not a GPL copy.
 static NON_PROSE_ENVS: &[&str] = &[
     "equation",
     "equation*",
     "align",
     "align*",
+    "alignat",
+    "alignat*",
+    "aligned",
+    "aligned*",
+    "alignedat",
+    "alignedat*",
+    "flalign",
+    "flalign*",
     "gather",
     "gather*",
+    "gathered",
+    "gathered*",
     "multline",
     "multline*",
     "eqnarray",
     "eqnarray*",
+    "split",
+    "split*",
+    "displaymath",
+    "displaymath*",
+    "math",
     "figure",
     "figure*",
     "table",
     "table*",
     "tabular",
     "tabular*",
+    "tabularx",
+    "longtable",
+    "tabu",
+    "tblr",
+    "longtblr",
+    "talltblr",
     "lstlisting",
     "verbatim",
     "minted",
     "tikzpicture",
     "array",
+    "array*",
     "matrix",
     "pmatrix",
     "bmatrix",
+    "Bmatrix",
+    "vmatrix",
+    "Vmatrix",
+    "cases",
+    "cases*",
+    "dcases",
+    "dcases*",
+    "rcases",
+    "rcases*",
+    "drcases",
+    "drcases*",
 ];
 
 /// `\begin{minted}{LANG}` -- the language is the brace argument after the env.
@@ -1857,5 +1892,120 @@ Some text.
             footer.contains(r"\end{filecontents}"),
             "footer must be \\end{{filecontents}}, got footer={footer:?}"
         );
+    }
+    #[test]
+    fn tree_sitter_and_latexindent_math_table_envs_are_structure() {
+        // Names missing on origin/main; each body is Structure, not Prose.
+        let names = [
+            "displaymath",
+            "displaymath*",
+            "math",
+            "aligned",
+            "aligned*",
+            "alignat",
+            "alignat*",
+            "alignedat",
+            "alignedat*",
+            "flalign",
+            "flalign*",
+            "gathered",
+            "gathered*",
+            "split",
+            "split*",
+            "tabularx",
+            "longtable",
+            "tabu",
+            "cases",
+            "cases*",
+            "dcases",
+            "dcases*",
+            "rcases",
+            "rcases*",
+            "drcases",
+            "drcases*",
+            "tblr",
+            "longtblr",
+            "talltblr",
+            "Bmatrix",
+            "vmatrix",
+            "Vmatrix",
+            "array*",
+        ];
+        for name in names {
+            let input = format!(
+                "\\begin{{{name}}}\nThis is a long sentence that must not reflow as prose inside {name}.\n\\end{{{name}}}\n"
+            );
+            let needle = format!("must not reflow as prose inside {name}");
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Structure(s) if s.contains(&needle))),
+                "{name} body must be Structure, got: {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains(&needle))),
+                "{name} body must not be Prose, got: {regions:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn alignat_and_tabularx_bodies_are_structure_not_prose() {
+        let input = "\\begin{document}\n\\begin{alignat}{2}\nThis is a long sentence that must not reflow as prose inside alignat.\n\\end{alignat}\n\\begin{tabularx}{\\textwidth}{l}\nThis is a long sentence that must not reflow as prose inside tabularx.\n\\end{tabularx}\n\\end{document}\n";
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("must not reflow as prose inside alignat")
+            )),
+            "alignat body must be Structure, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("must not reflow as prose inside tabularx")
+            )),
+            "tabularx body must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains("inside alignat") || p.contains("inside tabularx")
+            )),
+            "alignat/tabularx bodies must not be Prose, got: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn alignat_and_tabularx_two_sentence_bodies_do_not_reflow() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\n\\begin{alignat}{2}\nFirst sentence inside alignat. Second sentence stays put.\n\\end{alignat}\n\\begin{tabularx}{\\textwidth}{l}\nFirst sentence inside tabularx. Second sentence stays put.\n\\end{tabularx}\nAfter the tables. Next.\n\\end{document}\n";
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("First sentence inside alignat. Second sentence stays put."),
+            "alignat body must not reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First sentence inside alignat.\nSecond sentence stays put."),
+            "alignat body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            out.contains("First sentence inside tabularx. Second sentence stays put."),
+            "tabularx body must not reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First sentence inside tabularx.\nSecond sentence stays put."),
+            "tabularx body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the tables.\nNext."),
+            "prose after the envs must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
 }

--- a/tests/latex_non_prose_envs.rs
+++ b/tests/latex_non_prose_envs.rs
@@ -1,0 +1,82 @@
+//! snapper-wjmq: tree-sitter / latexindent math and align-delim envs are Structure.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::latex::LatexParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn latex_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Latex,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+#[test]
+fn alignat_body_is_structure_not_prose() {
+    let input = "\\begin{alignat}{2}\nThis is a long sentence that must not reflow as prose inside alignat.\n\\end{alignat}\n";
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("must not reflow as prose inside alignat")
+        )),
+        "alignat body must be Structure, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("must not reflow as prose inside alignat")
+        )),
+        "alignat body must not be Prose, got: {regions:?}"
+    );
+}
+
+#[test]
+fn tabularx_body_is_structure_not_prose() {
+    let input = "\\begin{tabularx}{\\textwidth}{l}\nThis is a long sentence that must not reflow as prose inside tabularx.\n\\end{tabularx}\n";
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("must not reflow as prose inside tabularx")
+        )),
+        "tabularx body must be Structure, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("must not reflow as prose inside tabularx")
+        )),
+        "tabularx body must not be Prose, got: {regions:?}"
+    );
+}
+
+#[test]
+fn alignat_and_tabularx_two_sentences_do_not_reflow() {
+    let alignat = "\\begin{alignat}{2}\nThis is a long sentence that must not reflow as prose inside alignat. Another sentence stays put.\n\\end{alignat}\n";
+    let tabularx = "\\begin{tabularx}{\\textwidth}{l}\nThis is a long sentence that must not reflow as prose inside tabularx. Another sentence stays put.\n\\end{tabularx}\n";
+    for (input, fused) in [
+        (
+            alignat,
+            "This is a long sentence that must not reflow as prose inside alignat. Another sentence stays put.",
+        ),
+        (
+            tabularx,
+            "This is a long sentence that must not reflow as prose inside tabularx. Another sentence stays put.",
+        ),
+    ] {
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(fused),
+            "env body must not split into prose sentences, got:\n{out}"
+        );
+        assert!(
+            !out.contains("alignat.\nAnother") && !out.contains("tabularx.\nAnother"),
+            "env body must not reflow as prose, got:\n{out}"
+        );
+        assert_eq!(out, input, "structure env must be identity, got:\n{out}");
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+}


### PR DESCRIPTION
vissue: snapper-wjmq (parent snapper-etv7). GitHub #80.

Drawer is 4/4 accept (impl-A, impl-B, rev-1, rev-2).

Missing NON_PROSE_ENVS from tree-sitter-latex math_environment and latexindent
lookForAlignDelims: displaymath, math, aligned, alignat, flalign, gathered,
split, cases, tabularx, longtable, tabu, tblr, and starred/mathtools variants.

Bodies are Structure, not prose. Names only. No GPL vendor. No pandoc at parse time.

Rebased onto #113. Dropped stacked $$ tests that belong to snapper-guev.

## Test plan
- rustc tests in src/parser/latex.rs and tests/latex_non_prose_envs.rs
- terra: cargo test --test latex_non_prose_envs