### PR TITLE
fix(org): treat dollar-dollar display math as Structure

### DIFF
--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -24,6 +24,13 @@ static LATEX_END_RE: LazyLock<Regex> =
 static EXPORT_SNIPPET_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"@@[a-zA-Z]+:[^@]*@@").unwrap());
 
+/// org-element / org-mode display math (`$$` or `\[`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DisplayMathDelim {
+    Bracket,
+    Dollars,
+}
+
 pub struct OrgParser;
 
 impl OrgParser {
@@ -125,13 +132,34 @@ impl OrgParser {
             .is_some_and(|caps| caps.get(1).unwrap().as_str() == env)
     }
 
-    /// Check if a line is a display math delimiter (\[ or \])
-    fn is_display_math_open(line: &str) -> bool {
-        line.trim() == r"\["
+    /// org-element latex-fragment display math: `\[` / `\]` or `$$` / `$$`.
+    fn display_math_open(line: &str) -> Option<DisplayMathDelim> {
+        let t = line.trim();
+        if t == r"\[" {
+            Some(DisplayMathDelim::Bracket)
+        } else if t.starts_with("$$") {
+            Some(DisplayMathDelim::Dollars)
+        } else {
+            None
+        }
     }
 
-    fn is_display_math_close(line: &str) -> bool {
-        line.trim() == r"\]"
+    /// A line that is only `$$` is an opener, not a one-line `$$...$$` block.
+    fn display_math_is_single_line(line: &str, delim: DisplayMathDelim) -> bool {
+        match delim {
+            DisplayMathDelim::Bracket => false,
+            DisplayMathDelim::Dollars => {
+                let t = line.trim();
+                t != "$$" && t.ends_with("$$")
+            }
+        }
+    }
+
+    fn is_display_math_close(line: &str, delim: DisplayMathDelim) -> bool {
+        match delim {
+            DisplayMathDelim::Bracket => line.trim() == r"\]",
+            DisplayMathDelim::Dollars => line.trim_end().ends_with("$$"),
+        }
     }
 
     /// Check if a line is entirely an inline export snippet (@@backend:...@@)
@@ -155,7 +183,7 @@ impl FormatParser for OrgParser {
         let mut src_body_start = 0usize;
         let mut in_drawer = false;
         let mut in_latex_env: Option<String> = None;
-        let mut in_display_math = false;
+        let mut in_display_math: Option<DisplayMathDelim> = None;
         let mut pragma_off = false;
         // Track list item context: indent level of the marker text.
         // Continuation lines indented at or beyond this level belong to the item.
@@ -233,11 +261,11 @@ impl FormatParser for OrgParser {
                 continue;
             }
 
-            // Inside display math \[...\] -- everything is structure
-            if in_display_math {
+            // Inside display math \[...\] / $$...$$ -- everything is structure
+            if let Some(delim) = in_display_math {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-                if Self::is_display_math_close(line_text) {
-                    in_display_math = false;
+                if Self::is_display_math_close(line_text, delim) {
+                    in_display_math = None;
                 }
                 regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
@@ -277,10 +305,12 @@ impl FormatParser for OrgParser {
                 continue;
             }
 
-            // Display math open (\[)
-            if Self::is_display_math_open(line_text) {
+            // Display math open (\[ or $$)
+            if let Some(delim) = Self::display_math_open(line_text) {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-                in_display_math = true;
+                if !Self::display_math_is_single_line(line_text, delim) {
+                    in_display_math = Some(delim);
+                }
                 regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
@@ -641,6 +671,14 @@ mod tests {
         assert!(matches!(&regions[4], Region::Prose(_)));
     }
 
+    fn org_cfg() -> crate::FormatConfig {
+        crate::FormatConfig {
+            format: crate::format::Format::Org,
+            ..Default::default()
+        }
+        .without_safety_backstops()
+    }
+
     #[test]
     fn display_math_preserved() {
         let input = "Some text.\n\\[\nx = 5\n\\]\nMore text.";
@@ -650,6 +688,163 @@ mod tests {
         assert!(matches!(&regions[2], Region::Structure(s) if s.contains("x = 5")));
         assert!(matches!(&regions[3], Region::Structure(s) if s.contains("\\]")));
         assert!(matches!(&regions[4], Region::Prose(_)));
+    }
+
+    #[test]
+    fn dollar_dollar_display_math_is_structure_not_prose() {
+        let input = "$$\nThis is a long sentence that must stay inside display math and must not reflow as prose.\n$$\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s)
+                    if s.contains("This is a long sentence that must stay inside display math")
+            )),
+            "$$ body must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains("This is a long sentence that must stay inside display math")
+            )),
+            "$$ body must not be Prose, got: {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.trim() == "$$")),
+            "$$ delimiters must be Structure, got: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn dollar_dollar_display_math_does_not_reflow_as_prose() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = "$$\nThis is a long sentence that must stay inside display math and must not reflow as prose.\n$$\n";
+        let cfg = FormatConfig {
+            format: Format::Org,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains(
+                "$$\nThis is a long sentence that must stay inside display math and must not reflow as prose.\n$$"
+            ),
+            "$$ display math must stay a structure block, got:\n{out}"
+        );
+        assert!(
+            !out.contains("$$ This is a long sentence"),
+            "must not join $$ into surrounding prose, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn dollar_dollar_two_sentences_do_not_split() {
+        use crate::format_text;
+
+        let input =
+            "$$\nFirst sentence. Second sentence that would split if this were prose.\n$$\n";
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains(
+                "$$\nFirst sentence. Second sentence that would split if this were prose.\n$$"
+            ),
+            "$$ display math must stay a structure block, got:\n{out}"
+        );
+        assert!(
+            !out.contains("$$ First sentence"),
+            "must not join $$ into surrounding prose, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First sentence.\nSecond sentence"),
+            "$$ body must not split at sentence end, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn dollar_dollar_single_line_display_is_structure() {
+        use crate::format_text;
+
+        let input = "Before the math. More before.\n$$E = mc^2$$\nAfter the math. More after.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains("$$E = mc^2$$"))),
+            "single-line $$...$$ must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("E = mc^2"))),
+            "single-line $$ body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("$$E = mc^2$$"),
+            "single-line $$ must stay intact, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before the math.\nMore before."),
+            "surrounding prose must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn bracket_display_math_still_structure() {
+        use crate::format_text;
+
+        let input = "\\[\nThis is a long sentence that must stay inside display math and must not reflow as prose.\n\\]\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("This is a long sentence that must stay inside display math")
+            )),
+            "\\[ body must stay Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("This is a long sentence that must stay inside display math")
+            )),
+            "\\[ body must not become Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains(
+                "\\[\nThis is a long sentence that must stay inside display math and must not reflow as prose.\n\\]"
+            ),
+            "\\[ display math must stay a structure block, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn inline_single_dollar_math_is_still_prose() {
+        use crate::format_text;
+
+        let input = "See $x = 1$ here. Next sentence.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("$x = 1$"))),
+            "inline $...$ must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("See $x = 1$ here.\nNext sentence."),
+            "inline $...$ must not open display math, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -578,6 +578,9 @@ fn org_opens_block(line: &str) -> bool {
     if t.starts_with("- ") || t.starts_with("+ ") {
         return true;
     }
+    if t.starts_with("$$") {
+        return true;
+    }
     ordered_list_start(t)
 }
 


### PR DESCRIPTION
vissue: snapper-2le9 (parent snapper-etv7). GitHub #83.

unanimous-green-30 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Native Org only treated \[ / \] as display math. A $$ ... $$ block is
now Structure through the matching closer, same as LaTeX #115.

## Test plan
- rustc tests in src/parser/org.rs
- terra: cargo test org::