### PR TITLE
fix(rst): treat option lists as structure plus hung prose

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -11,6 +11,20 @@ static CODE_DIRECTIVE_RE: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"^\s*\.\.\s+(?:code-block|sourcecode|code)::\s*([A-Za-z0-9_+.\-]+)?\s*$").unwrap()
 });
 
+/// Docutils `Body.patterns['option_marker']`: short `-a`/`+v`, long
+/// `--long`/`/V`, optional arg (`--input=file`, `-b file`, `<file>`),
+/// comma groups, then two-or-more spaces or end of line.
+static OPTION_MARKER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(concat!(
+        r"^((-|\+)[a-zA-Z0-9]( ?([a-zA-Z][a-zA-Z0-9_-]*|<[^<>]+>))?",
+        r"|(--|/)[a-zA-Z0-9][a-zA-Z0-9_-]*([ =]([a-zA-Z][a-zA-Z0-9_-]*|<[^<>]+>))?)",
+        r"(, ((-|\+)[a-zA-Z0-9]( ?([a-zA-Z][a-zA-Z0-9_-]*|<[^<>]+>))?",
+        r"|(--|/)[a-zA-Z0-9][a-zA-Z0-9_-]*([ =]([a-zA-Z][a-zA-Z0-9_-]*|<[^<>]+>))?))*",
+        r"(  +| ?$)",
+    ))
+    .unwrap()
+});
+
 pub struct RstParser;
 
 impl FormatParser for RstParser {
@@ -20,8 +34,8 @@ impl FormatParser for RstParser {
 }
 
 /// Line-based RST parser. Handles directives, literal blocks, sections,
-/// field lists, comments, tables, definition lists, and block-quote
-/// hang spaces as structure regions.
+/// field lists, option lists, comments, tables, definition lists, and
+/// block-quote hang spaces as structure regions.
 fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut regions = Vec::new();
     let mut current_prose = String::new();
@@ -281,6 +295,24 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             continue;
         }
 
+        // Option list: option column (marker + 2+ spaces) is Structure
+        // so wrap cannot eat the alignment. Description is Prose and
+        // hangs at the column width like a list item (GitHub #89).
+        if let Some(col_len) = rst_option_column_len(line_text) {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            list_hang = Some(col_len);
+            regions.push(SpannedRegion::structure(
+                input,
+                ByteSpan::new(line.start, line.start + col_len),
+            ));
+            if line_text.len() > col_len {
+                current_prose.push_str(line_text[col_len..].trim());
+                prose_span = Some(ByteSpan::new(line.start + col_len, line.end));
+            }
+            i += 1;
+            continue;
+        }
+
         // Grid table rows (`| cell |` / `+---+---+`)
         if trimmed.starts_with('|') || trimmed.starts_with('+') {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
@@ -430,6 +462,15 @@ pub(crate) fn source_has_dropped_rst_comments(input: &str) -> bool {
     input
         .lines()
         .any(|line| is_rst_dropped_comment_opener(line.trim_start()))
+}
+
+/// Byte length of the RST option column on `line`, including leading
+/// indent and the two-or-more spaces (or EOL) after the last option.
+/// Docutils `Body.option_marker`: `-a`, `--long`, `--input=file`, `/V`.
+pub(crate) fn rst_option_column_len(line: &str) -> Option<usize> {
+    let indent = line.len() - line.trim_start().len();
+    let t = &line[indent..];
+    OPTION_MARKER_RE.find(t).map(|m| indent + m.end())
 }
 
 /// Byte length of a compact RST list opener on `line`, including the
@@ -1295,5 +1336,138 @@ mod tests {
             "double-backtick literal must stay split, got:\n{out}"
         );
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn option_column_len_matches_docutils_forms() {
+        assert_eq!(
+            rst_option_column_len("-a            Output all. Keep this aligned."),
+            Some(14)
+        );
+        assert_eq!(
+            rst_option_column_len("--long        Long option. Another sentence."),
+            Some(14)
+        );
+        assert_eq!(rst_option_column_len("--input=file  Input file."), Some(14));
+        assert_eq!(rst_option_column_len("/V            VMS option."), Some(14));
+        assert_eq!(rst_option_column_len("-a, --all     Output all."), Some(14));
+        assert_eq!(rst_option_column_len("- First item"), None);
+        assert_eq!(rst_option_column_len("Hello world."), None);
+    }
+
+    #[test]
+    fn option_list_column_is_structure_description_is_prose() {
+        let input = concat!(
+            "-a            Output all. Keep this aligned.\n",
+            "--long        Long option. Another sentence.\n",
+        );
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "-a            ")),
+            "short option column must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "--long        ")),
+            "long option column must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| {
+                matches!(r, Region::Prose(s) if s.contains("Output all.") && s.contains("Keep this aligned."))
+            }),
+            "short-option description must be Prose, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| {
+                matches!(r, Region::Prose(s) if s.contains("Long option.") && s.contains("Another sentence."))
+            }),
+            "long-option description must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| {
+                matches!(
+                    r,
+                    Region::Prose(s) if s.contains("-a") || s.contains("--long")
+                )
+            }),
+            "option column must not be Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn reporter_option_list_keeps_alignment_and_hangs_description() {
+        use crate::format::Format;
+        use crate::oracle;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = concat!(
+            "-a            Output all. Keep this aligned.\n",
+            "--long        Long option. Another sentence.\n",
+        );
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out,
+            concat!(
+                "-a            Output all.\n",
+                "              Keep this aligned.\n",
+                "--long        Long option.\n",
+                "              Another sentence.\n",
+            ),
+            "option descriptions must hang at the option column, got:\n{out}"
+        );
+        assert!(
+            out.contains("-a            Output all."),
+            "short option must keep two-or-more spaces, got:\n{out}"
+        );
+        assert!(
+            out.contains("--long        Long option."),
+            "long option must keep two-or-more spaces, got:\n{out}"
+        );
+        let twice = format_text(&out, &cfg).unwrap();
+        assert_eq!(
+            out, twice,
+            "hung option list must be identity, got:\n{twice}"
+        );
+        assert!(
+            oracle::matches(Format::Rst, input, &out),
+            "oracle mismatch\n in={input:?}\n out={out:?}"
+        );
+
+        let extra = concat!(
+            "--input=file  Input file. Another sentence.\n",
+            "/V            VMS option. Another sentence.\n"
+        );
+        let extra_out = format_text(extra, &cfg).unwrap();
+        assert_eq!(
+            extra_out,
+            concat!(
+                "--input=file  Input file.\n",
+                "              Another sentence.\n",
+                "/V            VMS option.\n",
+                "              Another sentence.\n",
+            ),
+            "--input=file and /V must hang at the option column, got:\n{extra_out}"
+        );
+
+        // max_width wrap used to collapse the 2+ spaces into one.
+        let wrap_cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 22,
+            ..Default::default()
+        };
+        let wrap_in = "-a            Output all extra words here.\n";
+        let wrap_out = format_text(wrap_in, &wrap_cfg).unwrap();
+        assert!(
+            wrap_out.contains("-a            "),
+            "wrap must not eat option-column spaces, got:\n{wrap_out}"
+        );
     }
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -638,6 +638,9 @@ fn rst_opens_block(line: &str) -> bool {
     if t.starts_with(':') && t[1..].contains(':') {
         return true;
     }
+    if crate::parser::rst::rst_option_column_len(t).is_some() {
+        return true;
+    }
     ordered_list_start(t)
 }
 
@@ -869,6 +872,11 @@ fn hanging_indent_width(s: &str) -> usize {
     let trimmed = s.trim_start();
     if trimmed.len() < 2 {
         return 0;
+    }
+    // RST option column (`-a            `, `--long        `): hang at
+    // the full column so the description stays aligned (GitHub #89).
+    if crate::parser::rst::rst_option_column_len(s) == Some(s.len()) {
+        return s.chars().count();
     }
     // Parser markers are `core` plus one trailing space; leading indent is
     // part of the hang so nested `   - ` continues at column 5. RST `#.`
@@ -1474,6 +1482,10 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_indent_width("\\item "), 6);
         assert_eq!(hanging_indent_width("\\item[Term] "), 12);
         assert_eq!(hanging_indent_width("\\itemize "), 0);
+        assert_eq!(hanging_indent_width("-a            "), 14);
+        assert_eq!(hanging_indent_width("--long        "), 14);
+        assert_eq!(hanging_prefix("-a            "), "              ");
+        assert_eq!(hanging_prefix("--long        "), "              ");
     }
 
     #[test]
@@ -1524,6 +1536,19 @@ They are endowed with reason and conscience and should act towards one another i
             Region::Structure("\n".to_string()),
         ]);
         assert_eq!(result, "\\item One.\n      Two.\n");
+    }
+
+    #[test]
+    fn rst_option_list_hanging_indent() {
+        let result = reflow_regions(vec![
+            Region::Structure("-a            ".to_string()),
+            Region::Prose("Output all. Keep this aligned.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            "-a            Output all.\n              Keep this aligned.\n"
+        );
     }
 
     #[test]

--- a/tests/rst_option_lists.rs
+++ b/tests/rst_option_lists.rs
@@ -1,0 +1,52 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+/// GitHub #89 / snapper-zqew: RST option-list gutter must survive SemBr.
+#[test]
+fn option_list_description_hangs_at_option_column() {
+    let cfg = FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    };
+    let input = concat!(
+        "-a            Output all. Keep this aligned.\n",
+        "--long        Long option. Another sentence.\n",
+    );
+    let out = format_text(input, &cfg).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "-a            Output all.\n",
+            "              Keep this aligned.\n",
+            "--long        Long option.\n",
+            "              Another sentence.\n",
+        ),
+        "option descriptions must hang at the option column, got:\n{out}"
+    );
+    let twice = format_text(&out, &cfg).unwrap();
+    assert_eq!(
+        out, twice,
+        "hung option list must be identity, got:\n{twice}"
+    );
+}
+
+/// Wrap must not collapse the two-or-more spaces between option and description.
+#[test]
+fn wrap_does_not_eat_option_list_gutter() {
+    let cfg = FormatConfig {
+        format: Format::Rst,
+        max_width: 36,
+        ..Default::default()
+    };
+    let input = "-a            Output all extra words that force a wrap here.\n";
+    let out = format_text(input, &cfg).unwrap();
+    assert!(
+        out.contains("-a            "),
+        "wrap must keep the two-or-more option gutter, got:\n{out}"
+    );
+    assert!(
+        !out.contains("-a Output"),
+        "wrap must not collapse option pad to one space, got:\n{out}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-zqew (parent snapper-etv7). GitHub #89.

unanimous-green-35 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Docutils Body.option_marker / OptionList. Native RST had no option
marker, so -a / --long / --input=file / /V were Prose and wrap ate
the two-or-more spaces between option and description.

## Test plan
- rustc tests in src/parser/rst.rs
- terra: cargo test rst::