### PR TITLE
fix(rst): treat doctest blocks as structure

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -33,9 +33,9 @@ impl FormatParser for RstParser {
     }
 }
 
-/// Line-based RST parser. Handles directives, literal blocks, sections,
-/// field lists, option lists, comments, tables, definition lists, and
-/// block-quote hang spaces as structure regions.
+/// Line-based RST parser. Handles directives, literal blocks, doctest
+/// blocks, sections, field lists, option lists, comments, tables,
+/// definition lists, and block-quote hang spaces as structure regions.
 fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut regions = Vec::new();
     let mut current_prose = String::new();
@@ -277,6 +277,33 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             continue;
         }
 
+        // Doctest block: Docutils Body.doctest (`>>>( +|$)`). One
+        // doctest_block through the next blank or dedent; no inline parse.
+        if is_rst_doctest_opener(trimmed) {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            let block_indent = line_text.len() - trimmed.len();
+            let block_start = line.start;
+            let mut block_end = line.end;
+            i += 1;
+            while i < total {
+                let next = lines[i].text;
+                if next.trim().is_empty() {
+                    break;
+                }
+                let next_indent = next.len() - next.trim_start().len();
+                if next_indent < block_indent {
+                    break;
+                }
+                block_end = lines[i].end;
+                i += 1;
+            }
+            regions.push(SpannedRegion::structure(
+                input,
+                ByteSpan::new(block_start, block_end),
+            ));
+            continue;
+        }
+
         // List item: marker is Structure so `1. First` does not split
         // after `1.`, and each item is its own region so adjacent
         // bullets are not glued onto one line.
@@ -432,6 +459,12 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         ));
     }
     regions
+}
+
+/// Docutils `Body.patterns['doctest']`: `>>>( +|$)`.
+/// Prompt-only `>>>` and `>>> ` plus command both open a block; `>>>print` does not.
+pub(crate) fn is_rst_doctest_opener(trimmed: &str) -> bool {
+    trimmed == ">>>" || trimmed.starts_with(">>> ")
 }
 
 /// True when `trimmed` is an RST comment opener, not a `.. name::` directive.
@@ -1405,6 +1438,119 @@ mod tests {
         assert_eq!(
             out, "Before.\n\n   First sentence.\n   Second sentence.\n\nAfter.\n",
             "quoted sentences must reflow with hang, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn doctest_opener_matches_docutils_pattern() {
+        assert!(is_rst_doctest_opener(">>>"));
+        assert!(is_rst_doctest_opener(">>> "));
+        assert!(is_rst_doctest_opener(">>> print(1)"));
+        assert!(!is_rst_doctest_opener(">>>print(1)"));
+        assert!(!is_rst_doctest_opener(">> > print(1)"));
+        assert!(!is_rst_doctest_opener("print(1)"));
+        assert!(!is_rst_doctest_opener(".. >>>"));
+    }
+
+    #[test]
+    fn doctest_block_is_structure_not_prose() {
+        let input = concat!(
+            ">>> print('Python-specific usage examples; begun with \">>> \"')\n",
+            "Python-specific usage examples; begun with \">>> \"\n",
+            ">>> print('(cut and pasted from interactive Python sessions)')\n",
+            "(cut and pasted from interactive Python sessions)\n",
+        );
+        let regions = RstParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s)
+                    if s.contains(">>> print('Python-specific usage examples")
+                        && s.contains("Python-specific usage examples; begun with")
+                        && s.contains(">>> print('(cut and pasted")
+                        && s.contains("(cut and pasted from interactive Python sessions)")
+            )),
+            "doctest block must be one Structure region, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains(">>>") || s.contains("Python-specific")
+            )),
+            "doctest block must not be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(r, Region::Code { .. })),
+            "doctest block is Structure, not Code, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn reporter_doctest_block_is_identity_under_format() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = concat!(
+            ">>> print('Python-specific usage examples; begun with \">>> \"')\n",
+            "Python-specific usage examples; begun with \">>> \"\n",
+            ">>> print('(cut and pasted from interactive Python sessions)')\n",
+            "(cut and pasted from interactive Python sessions)\n",
+        );
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, input,
+            "doctest block must stay identity under format, got:\n{out}"
+        );
+        assert!(
+            !out.contains(
+                ">>> print('Python-specific usage examples; begun with \">>> \"') Python-specific"
+            ),
+            "SemBr must not join prompt and output, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\">>> \" >>> print"),
+            "SemBr must not join output and the next >>>, got:\n{out}"
+        );
+        assert_eq!(
+            format_text(&out, &cfg).unwrap(),
+            out,
+            "doctest identity must survive a second pass"
+        );
+    }
+
+    #[test]
+    fn surrounding_prose_still_reflows_around_doctest() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = concat!(
+            "Before. More before.\n\n",
+            ">>> print(1)\n",
+            "1\n\n",
+            "After. More after.\n",
+        );
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains("Before.\nMore before."),
+            "leading paragraph must still reflow, got:\n{out}"
+        );
+        assert!(
+            out.contains(">>> print(1)\n1\n"),
+            "doctest lines must stay unjoined, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nMore after."),
+            "trailing paragraph must still reflow, got:\n{out}"
         );
     }
 

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -228,6 +228,35 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             continue;
         }
 
+        // Doctest block: Docutils Body.doctest (`>>>( +|$)`) is checked
+        // before Body.line, so a prompt-only `>>>` / `>>> ` is not a
+        // `>` section underline. One doctest_block through the next
+        // blank or dedent; no inline parse.
+        if is_rst_doctest_opener(trimmed) {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            let block_indent = line_text.len() - trimmed.len();
+            let block_start = line.start;
+            let mut block_end = line.end;
+            i += 1;
+            while i < total {
+                let next = lines[i].text;
+                if next.trim().is_empty() {
+                    break;
+                }
+                let next_indent = next.len() - next.trim_start().len();
+                if next_indent < block_indent {
+                    break;
+                }
+                block_end = lines[i].end;
+                i += 1;
+            }
+            regions.push(SpannedRegion::structure(
+                input,
+                ByteSpan::new(block_start, block_end),
+            ));
+            continue;
+        }
+
         // Section underline
         if is_underline(line_text) {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
@@ -274,33 +303,6 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
                 }
             }
             i += 1;
-            continue;
-        }
-
-        // Doctest block: Docutils Body.doctest (`>>>( +|$)`). One
-        // doctest_block through the next blank or dedent; no inline parse.
-        if is_rst_doctest_opener(trimmed) {
-            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-            let block_indent = line_text.len() - trimmed.len();
-            let block_start = line.start;
-            let mut block_end = line.end;
-            i += 1;
-            while i < total {
-                let next = lines[i].text;
-                if next.trim().is_empty() {
-                    break;
-                }
-                let next_indent = next.len() - next.trim_start().len();
-                if next_indent < block_indent {
-                    break;
-                }
-                block_end = lines[i].end;
-                i += 1;
-            }
-            regions.push(SpannedRegion::structure(
-                input,
-                ByteSpan::new(block_start, block_end),
-            ));
             continue;
         }
 
@@ -637,9 +639,14 @@ fn take_roman_place(b: &[u8], i: usize, one: u8, five: u8, ten: u8) -> usize {
 
 /// Check if a line is a section underline (2+ repeated punctuation chars).
 /// Includes `' . _ < >` in addition to the common `= - ~ ^ " # * +` set.
+/// Docutils Body.doctest wins over Body.line: prompt-only `>>>` / `>>> `
+/// are not `>` adornments. `>>>>>` (and `>>` / `>>>>`) stay underlines.
 fn is_underline(line: &str) -> bool {
     let trimmed = line.trim();
     if trimmed.len() < 2 {
+        return false;
+    }
+    if is_rst_doctest_opener(trimmed) {
         return false;
     }
     let first = trimmed.as_bytes()[0];
@@ -1450,6 +1457,19 @@ mod tests {
         assert!(!is_rst_doctest_opener(">> > print(1)"));
         assert!(!is_rst_doctest_opener("print(1)"));
         assert!(!is_rst_doctest_opener(".. >>>"));
+        assert!(!is_rst_doctest_opener(">>>>"));
+        assert!(!is_rst_doctest_opener(">>>>>"));
+    }
+
+    #[test]
+    fn doctest_opener_is_not_a_section_underline() {
+        assert!(!is_underline(">>>"));
+        assert!(!is_underline(">>> "));
+        assert!(!is_underline("  >>>"));
+        assert!(is_underline(">>"));
+        assert!(is_underline(">>>>"));
+        assert!(is_underline(">>>>>"));
+        assert!(is_underline("===== "));
     }
 
     #[test]
@@ -1551,6 +1571,125 @@ mod tests {
         assert!(
             out.contains("After.\nMore after."),
             "trailing paragraph must still reflow, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn prompt_only_doctest_is_structure_not_underline() {
+        let input = concat!(
+            ">>>\n",
+            "Python-specific usage examples; begun with \">>> \"\n",
+            ">>> print('(cut and pasted from interactive Python sessions)')\n",
+            "(cut and pasted from interactive Python sessions)\n",
+        );
+        let regions = RstParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s)
+                    if s.contains(">>>")
+                        && s.contains("Python-specific usage examples; begun with")
+                        && s.contains(">>> print('(cut and pasted")
+                        && s.contains("(cut and pasted from interactive Python sessions)")
+            )),
+            "prompt-only >>> must open one Structure doctest, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains(">>>") || s.contains("Python-specific")
+            )),
+            "prompt-only >>> must not leave output as Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn prompt_only_doctest_is_identity_under_format() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = concat!(
+            ">>>\n",
+            "Python-specific usage examples; begun with \">>> \"\n",
+            ">>> print('(cut and pasted from interactive Python sessions)')\n",
+            "(cut and pasted from interactive Python sessions)\n",
+        );
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, input,
+            "prompt-only >>> must stay identity under format, got:\n{out}"
+        );
+        assert!(
+            !out.contains(">>> Python-specific"),
+            "must not join prompt-only >>> onto the output line, got:\n{out}"
+        );
+        assert_eq!(
+            format_text(&out, &cfg).unwrap(),
+            out,
+            "prompt-only doctest identity must survive a second pass"
+        );
+    }
+
+    #[test]
+    fn prompt_only_doctest_does_not_steal_preceding_prose_as_title() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = concat!("Before. More before.\n", ">>>\n", "1\n",);
+        let out = format_text(input, &cfg).unwrap();
+        assert!(
+            out.contains("Before.\nMore before."),
+            "preceding prose must still reflow, not become a section title, got:\n{out}"
+        );
+        assert!(
+            out.contains(">>>\n1\n"),
+            "prompt-only >>> plus output must stay unjoined, got:\n{out}"
+        );
+        assert!(
+            !out.contains("Before. More before.\n>>>"),
+            "title-lookahead must not freeze preceding prose as a section, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn five_gt_adornment_stays_a_section_underline() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = "Input\n>>>>>\n";
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(out, input, ">>>>> must stay a > adornment, got:\n{out}");
+        assert!(
+            !out.contains("Input >>>>>"),
+            "must not glue >>>>> onto the title, got:\n{out}"
+        );
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains("Input"))),
+            "title above >>>>> must stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.trim() == ">>>>>")),
+            ">>>>> must stay Structure adornment, got {regions:?}"
         );
     }
 

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -657,6 +657,9 @@ fn latex_opens_block(line: &str) -> bool {
 
 fn rst_opens_block(line: &str) -> bool {
     let t = line.trim_start();
+    if crate::parser::rst::is_rst_doctest_opener(t) {
+        return true;
+    }
     if t == ".." || t.starts_with(".. ") || t.starts_with("..\t") {
         return true;
     }

--- a/tests/rst_doctest_blocks.rs
+++ b/tests/rst_doctest_blocks.rs
@@ -58,3 +58,57 @@ fn doctest_block_is_identity_under_format() {
         "hung doctest must be identity, got:\n{out}"
     );
 }
+
+/// GitHub #90 leftover / snapper-ijxt: prompt-only `>>>` is Body.doctest,
+/// not a `>` section underline. Fails on origin/main (opener stolen,
+/// output reflows as Prose) then passes.
+fn prompt_only_fixture() -> &'static str {
+    concat!(
+        ">>>\n",
+        "Python-specific usage examples; begun with \">>> \"\n",
+        ">>> print('(cut and pasted from interactive Python sessions)')\n",
+        "(cut and pasted from interactive Python sessions)\n",
+    )
+}
+
+#[test]
+fn prompt_only_doctest_is_structure_not_underline() {
+    let regions = RstParser.parse(prompt_only_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s)
+                if s.contains(">>>")
+                    && s.contains("Python-specific usage examples; begun with")
+                    && s.contains(">>> print('(cut and pasted")
+                    && s.contains("(cut and pasted from interactive Python sessions)")
+        )),
+        "prompt-only >>> must open one Structure doctest, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(">>>") || s.contains("Python-specific")
+        )),
+        "prompt-only >>> must not leave output as Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn prompt_only_doctest_is_identity_under_format() {
+    let input = prompt_only_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "prompt-only >>> must stay identity under format, got:\n{out}"
+    );
+    assert!(
+        !out.contains(">>> Python-specific"),
+        "must not join prompt-only >>> onto the output line, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &rst_cfg()).unwrap(),
+        out,
+        "prompt-only doctest identity must survive a second pass"
+    );
+}

--- a/tests/rst_doctest_blocks.rs
+++ b/tests/rst_doctest_blocks.rs
@@ -1,0 +1,60 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+/// GitHub #90 / snapper-g2od: RST doctest blocks must not reflow as prose.
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+}
+
+fn ticket_fixture() -> &'static str {
+    concat!(
+        ">>> print('Python-specific usage examples; begun with \">>> \"')\n",
+        "Python-specific usage examples; begun with \">>> \"\n",
+        ">>> print('(cut and pasted from interactive Python sessions)')\n",
+        "(cut and pasted from interactive Python sessions)\n",
+    )
+}
+
+#[test]
+fn doctest_block_is_structure_not_prose() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s)
+                if s.contains(">>> print('Python-specific usage examples")
+                    && s.contains("Python-specific usage examples; begun with")
+                    && s.contains(">>> print('(cut and pasted")
+                    && s.contains("(cut and pasted from interactive Python sessions)")
+        )),
+        "doctest block must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(">>>") || s.contains("Python-specific")
+        )),
+        "doctest block must not be Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn doctest_block_is_identity_under_format() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "doctest prompt, output, and next >>> must stay unjoined, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &rst_cfg()).unwrap(),
+        out,
+        "hung doctest must be identity, got:\n{out}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-g2od (parent snapper-etv7). GitHub #90.

unanimous-green-38 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Docutils Body.doctest. Native RST treated >>> lines as Prose, so SemBr
joined prompt, output, and the next >>>.

## Test plan
- rustc tests in src/parser/rst.rs
- terra: cargo test rst::