### PR TITLE
fix(latex): treat Verbatim boxedverbatim and tcblisting as code

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,8 +14,9 @@ pub struct FormatOverrides {
     pub max_width: Option<usize>,
     /// Extra LaTeX environments treated as code (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
-    /// minted/lstlisting/verbatim/comment, filecontents, and tree-sitter
-    /// trivia list; entries are added to it.
+    /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
+    /// trivia, and Overleaf Verbatim/boxedverbatim/tcblisting/codeexample;
+    /// entries are added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,9 @@ pub struct FormatConfig {
     /// and assert the oracle themselves.
     pub render_backstop: bool,
     /// Extra LaTeX environments treated as code (no reflow), added to
-    /// minted/lstlisting/verbatim/comment, filecontents, and tree-sitter
-    /// trivia envs. Empty keeps the built-in list.
+    /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
+    /// trivia, and Overleaf Verbatim/boxedverbatim/tcblisting/codeexample.
+    /// Empty keeps the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -83,8 +83,11 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Beyond minted/lstlisting/verbatim: latexindent `fileContentsEnvironments`
 /// (`filecontents`, `filecontents*`) and tree-sitter-latex raw trivia envs
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
-/// `sageblock`) plus fancyvrb `verbatim*` and the `comment` package env
-/// (tree-sitter `comment_environment`: raw through matching `\end{comment}`).
+/// `sageblock`) plus fancyvrb `verbatim*` / `Verbatim`, moreverb
+/// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, and the
+/// `comment` package env (tree-sitter `comment_environment`: raw through
+/// matching `\end{comment}`). Overleaf `verbatimEnvNames` is Verbatim,
+/// boxedverbatim, tcblisting, codeexample.
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
@@ -92,6 +95,10 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "lstlisting"
             | "verbatim"
             | "verbatim*"
+            | "Verbatim"
+            | "boxedverbatim"
+            | "tcblisting"
+            | "codeexample"
             | "filecontents"
             | "filecontents*"
             | "asy"
@@ -1702,31 +1709,108 @@ Some text.
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 
+    /// Ticket fixture (GitHub #98 / snapper-3tj3): fancyvrb Verbatim is Code.
     #[test]
-    fn configured_verbatim_env_stops_fancyvrb_reflow() {
+    fn fancyvrb_verbatim_fixture_is_code_not_prose() {
         use crate::format_text;
 
-        let input = "\\begin{document}\nBefore.\n\\begin{Verbatim}\nFirst line. Second line.\n\\end{Verbatim}\nAfter the listing. Next.\n\\end{document}\n";
+        let input = concat!(
+            "\\begin{Verbatim}\n",
+            "First line. Second line.\n",
+            "\\end{Verbatim}\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "Verbatim body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "Verbatim body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("First line. Second line."),
+            "Verbatim body must not reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "Verbatim must stay verbatim, got:\n{out}"
+        );
+        assert_eq!(out, input, "Verbatim env must be identity, got:\n{out}");
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn boxedverbatim_tcblisting_codeexample_are_code_not_prose() {
+        use crate::format_text;
+
+        let names = ["boxedverbatim", "tcblisting", "codeexample"];
+        for name in names {
+            let input = format!(
+                "\\begin{{{name}}}\nFirst line. Second line.\n\\end{{{name}}}\nAfter the block. Next.\n"
+            );
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Code { body, .. } if body.contains("First line. Second line.")
+                )),
+                "{name} body must be Code, got: {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+                "{name} body must not leak into Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains("First line. Second line."),
+                "{name} body must not reflow, got:\n{out}"
+            );
+            assert!(
+                !out.contains("First line.\nSecond line."),
+                "{name} must stay verbatim, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the block.\nNext."),
+                "prose after {name} must still reflow, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+        }
+    }
+
+    #[test]
+    fn configured_verbatim_envs_still_add_unlisted_names() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nBefore.\n\\begin{MyListings}\nFirst line. Second line.\n\\end{MyListings}\nAfter the listing. Next.\n\\end{document}\n";
         let default_out = format_text(input, &latex_cfg()).unwrap();
         assert!(
             default_out.contains("First line.\nSecond line."),
-            "unlisted Verbatim body is prose and reflows, got:\n{default_out}"
+            "unlisted MyListings body is prose and reflows, got:\n{default_out}"
         );
 
         let cfg = crate::FormatConfig {
             format: crate::format::Format::Latex,
-            latex_verbatim_envs: vec!["Verbatim".into()],
+            latex_verbatim_envs: vec!["MyListings".into()],
             ..Default::default()
         }
         .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
             out.contains("First line. Second line."),
-            "configured Verbatim body must not reflow, got:\n{out}"
+            "configured MyListings body must not reflow, got:\n{out}"
         );
         assert!(
             !out.contains("First line.\nSecond line."),
-            "Verbatim must stay verbatim, got:\n{out}"
+            "MyListings must stay verbatim, got:\n{out}"
         );
         let regions = LatexParser::from_config(Some(&cfg)).parse(input);
         assert!(
@@ -1734,11 +1818,11 @@ Some text.
                 r,
                 Region::Code { body, .. } if body.contains("First line. Second line.")
             )),
-            "configured Verbatim must be Code, got: {regions:?}"
+            "configured MyListings must be Code, got: {regions:?}"
         );
         assert!(
             out.contains("After the listing.\nNext."),
-            "prose after Verbatim must still reflow, got:\n{out}"
+            "prose after MyListings must still reflow, got:\n{out}"
         );
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
@@ -1956,6 +2040,25 @@ Some text.
         assert!(
             oracle::matches(Format::Latex, input, &out),
             "oracle mismatch\n in={input:?}\n out={out:?}"
+        );
+    }
+
+    #[test]
+    fn verbatim_fixture_file_is_code_not_prose() {
+        let input = include_str!("../../tests/fixtures/verbatim.tex");
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "tests/fixtures/verbatim.tex body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "verbatim fixture must not be Prose, got: {regions:?}"
         );
     }
 

--- a/tests/fixtures/verbatim.tex
+++ b/tests/fixtures/verbatim.tex
@@ -1,0 +1,3 @@
+\begin{Verbatim}
+First line. Second line.
+\end{Verbatim}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -103,6 +103,13 @@ fn latex_pycode_fixture_stays_verbatim() {
 }
 
 #[test]
+fn latex_verbatim_fixture_stays_verbatim() {
+    let actual = run_format("latex", &fixture_path("verbatim.tex"));
+    let expected = fs::read_to_string(fixture_path("verbatim.tex")).unwrap();
+    pretty_assertions::assert_eq!(actual, expected);
+}
+
+#[test]
 fn latex_comment_fixture_stays_verbatim() {
     let actual = run_format("latex", &fixture_path("comment.tex"));
     let expected = fs::read_to_string(fixture_path("comment.tex")).unwrap();

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -1,0 +1,76 @@
+//! snapper-3tj3 / GitHub #98: Overleaf verbatimEnvNames are Code, not prose.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::latex::LatexParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn latex_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Latex,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture: `\begin{Verbatim}` / First line. Second line. / `\end{Verbatim}`.
+#[test]
+fn verbatim_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{Verbatim}\n",
+        "First line. Second line.\n",
+        "\\end{Verbatim}\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Code { body, .. } if body.contains("First line. Second line.")
+        )),
+        "Verbatim body must be Code, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "Verbatim body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("First line. Second line."),
+        "Verbatim body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "Verbatim must not reflow as prose, got:\n{out}"
+    );
+    assert_eq!(out, input, "Verbatim env must be identity, got:\n{out}");
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+#[test]
+fn boxedverbatim_tcblisting_codeexample_do_not_reflow() {
+    for name in ["boxedverbatim", "tcblisting", "codeexample"] {
+        let input = format!("\\begin{{{name}}}\nFirst line. Second line.\n\\end{{{name}}}\n");
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "{name} body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert_eq!(out, input, "{name} env must be identity, got:\n{out}");
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+    }
+}


### PR DESCRIPTION
vissue: snapper-3tj3 (parent snapper-etv7). GitHub #98.

unanimous-green-48 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Overleaf verbatimEnvNames includes Verbatim, boxedverbatim,
tcblisting, and codeexample. Those bodies reflowed as prose unless
listed in verbatim_envs. They are now builtin Code through the
matching end.

## Test plan
- rustc tests in src/parser/latex.rs and tests/latex_verbatim_envs.rs
- terra: parser::latex 61/61 plus latex_verbatim_envs 2/2