### PR TITLE
fix(latex): treat tikzcd axis and pgfpicture as structure

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -9,6 +9,9 @@ use crate::sentence::unicode::latex_verb_span_end_with;
 // Environments whose content is NOT prose (math, code, figures, tables).
 // Extra names are tree-sitter-latex `math_environment` plus latexindent
 // `lookForAlignDelims` (amsmath / mathtools / tabularray), not a GPL copy.
+// Overleaf `equationEnvNames` includes `tikzcd`; pgfplots `axis` /
+// `pgfpicture` are the same class (and starred variants). Not every
+// pgfplots name.
 static NON_PROSE_ENVS: &[&str] = &[
     "equation",
     "equation*",
@@ -51,6 +54,12 @@ static NON_PROSE_ENVS: &[&str] = &[
     "verbatim",
     "minted",
     "tikzpicture",
+    "tikzcd",
+    "tikzcd*",
+    "pgfpicture",
+    "pgfpicture*",
+    "axis",
+    "axis*",
     "array",
     "array*",
     "matrix",
@@ -2459,6 +2468,121 @@ Some text.
             "prose after the envs must still reflow, got:\n{out}"
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #97 / snapper-e916): tikzcd is Structure.
+    #[test]
+    fn tikzcd_fixture_is_structure_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{tikzcd}\n",
+            "This is a long sentence that must not reflow as prose inside tikzcd.\n",
+            "\\end{tikzcd}\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("must not reflow as prose inside tikzcd")
+            )),
+            "tikzcd body must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("must not reflow as prose inside tikzcd")
+            )),
+            "tikzcd body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("This is a long sentence that must not reflow as prose inside tikzcd."),
+            "tikzcd body must stay one source line, got:\n{out}"
+        );
+        assert_eq!(out, input, "tikzcd env must be identity, got:\n{out}");
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn tikzcd_axis_pgfpicture_and_stars_are_structure() {
+        let names = [
+            "tikzcd",
+            "tikzcd*",
+            "axis",
+            "axis*",
+            "pgfpicture",
+            "pgfpicture*",
+        ];
+        for name in names {
+            let input = format!(
+                "\\begin{{{name}}}\nThis is a long sentence that must not reflow as prose inside {name}.\n\\end{{{name}}}\n"
+            );
+            let needle = format!("must not reflow as prose inside {name}");
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Structure(s) if s.contains(&needle))),
+                "{name} body must be Structure, got: {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains(&needle))),
+                "{name} body must not be Prose, got: {regions:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn tikzcd_axis_pgfpicture_two_sentence_bodies_do_not_reflow() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nBefore the figures. More before.\n\\begin{tikzcd}\nFirst sentence inside tikzcd. Second sentence stays put.\n\\end{tikzcd}\n\\begin{axis}\nFirst sentence inside axis. Second sentence stays put.\n\\end{axis}\n\\begin{pgfpicture}\nFirst sentence inside pgfpicture. Second sentence stays put.\n\\end{pgfpicture}\nAfter the figures. Next.\n\\end{document}\n";
+        let out = format_text(input, &latex_cfg()).unwrap();
+        for fused in [
+            "First sentence inside tikzcd. Second sentence stays put.",
+            "First sentence inside axis. Second sentence stays put.",
+            "First sentence inside pgfpicture. Second sentence stays put.",
+        ] {
+            assert!(
+                out.contains(fused),
+                "tikz/pgf body must not reflow, missing {fused:?}, got:\n{out}"
+            );
+        }
+        assert!(
+            !out.contains("inside tikzcd.\nSecond")
+                && !out.contains("inside axis.\nSecond")
+                && !out.contains("inside pgfpicture.\nSecond"),
+            "tikz/pgf bodies must stay one source line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before the figures.\nMore before.")
+                && out.contains("After the figures.\nNext."),
+            "prose around tikz/pgf envs must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn tikzcd_fixture_file_is_structure_not_prose() {
+        let input = include_str!("../../tests/fixtures/tikzcd.tex");
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("must not reflow as prose inside tikzcd")
+            )),
+            "tests/fixtures/tikzcd.tex body must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("inside tikzcd")
+            )),
+            "tikzcd fixture must not be Prose, got: {regions:?}"
+        );
     }
 
     #[test]

--- a/tests/fixtures/tikzcd.tex
+++ b/tests/fixtures/tikzcd.tex
@@ -1,0 +1,3 @@
+\begin{tikzcd}
+This is a long sentence that must not reflow as prose inside tikzcd.
+\end{tikzcd}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -110,6 +110,13 @@ fn latex_verbatim_fixture_stays_verbatim() {
 }
 
 #[test]
+fn latex_tikzcd_fixture_stays_structure() {
+    let actual = run_format("latex", &fixture_path("tikzcd.tex"));
+    let expected = fs::read_to_string(fixture_path("tikzcd.tex")).unwrap();
+    pretty_assertions::assert_eq!(actual, expected);
+}
+
+#[test]
 fn latex_comment_fixture_stays_verbatim() {
     let actual = run_format("latex", &fixture_path("comment.tex"));
     let expected = fs::read_to_string(fixture_path("comment.tex")).unwrap();

--- a/tests/latex_tikz_pgf_envs.rs
+++ b/tests/latex_tikz_pgf_envs.rs
@@ -1,0 +1,78 @@
+//! snapper-e916 / GitHub #97: Overleaf tikzcd / pgfplots axis / pgfpicture
+//! are Structure, not prose.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::latex::LatexParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn latex_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Latex,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture: `\begin{tikzcd}` / long sentence / `\end{tikzcd}`.
+#[test]
+fn tikzcd_fixture_is_structure_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{tikzcd}\n",
+        "This is a long sentence that must not reflow as prose inside tikzcd.\n",
+        "\\end{tikzcd}\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("must not reflow as prose inside tikzcd")
+        )),
+        "tikzcd body must be Structure, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("must not reflow as prose inside tikzcd")
+        )),
+        "tikzcd body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("This is a long sentence that must not reflow as prose inside tikzcd."),
+        "tikzcd body must stay one source line, got:\n{out}"
+    );
+    assert_eq!(out, input, "tikzcd env must be identity, got:\n{out}");
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+#[test]
+fn axis_pgfpicture_and_stars_do_not_reflow() {
+    for name in ["tikzcd*", "axis", "axis*", "pgfpicture", "pgfpicture*"] {
+        let input = format!(
+            "\\begin{{{name}}}\nThis is a long sentence that must not reflow as prose inside {name}. Another sentence stays put.\n\\end{{{name}}}\n"
+        );
+        let fused = format!(
+            "This is a long sentence that must not reflow as prose inside {name}. Another sentence stays put."
+        );
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains(&fused))),
+            "{name} body must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("must not reflow"))),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert_eq!(out, input, "{name} env must be identity, got:\n{out}");
+        assert!(
+            !out.contains(&format!("inside {name}.\nAnother")),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+    }
+}


### PR DESCRIPTION
vissue: snapper-e916 (parent snapper-etv7). GitHub #97.

unanimous-green-51 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Overleaf equationEnvNames includes tikzcd; pgfplots axis and
pgfpicture are the same class. Native had tikzpicture only. Those
environments (and starred forms) are now Structure so the body does
not reflow as prose.

May need a rebase after #150 (n8wz also touches latex.rs).

## Test plan
- rustc tests in src/parser/latex.rs and tests/latex_tikz_pgf_envs.rs
- terra: cargo test parser::latex