### PR TITLE
fix(org): treat [cite...] as an atomic inline token

### DIFF
--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -2241,4 +2241,55 @@ mod tests {
         );
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }
+
+    /// Ticket fixture (Format::Org / GitHub #112): org-element 5.5
+    /// citations are atomic so `p.` inside is not a sentence boundary.
+    fn cite_page_locator_fixture() -> &'static str {
+        "See [cite/t:see;@foo p. 7;@bar pp. 4;by foo]. Next sentence.\n"
+    }
+
+    #[test]
+    fn org_cite_page_locator_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let cite = "[cite/t:see;@foo p. 7;@bar pp. 4;by foo]";
+        let input = cite_page_locator_fixture();
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains(cite) && p.contains("Next sentence.")
+            )),
+            "citation stays inline Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("See [cite/t:see;@foo p. 7;@bar pp. 4;by foo].\nNext sentence."),
+            "sentence after the citation must reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+        // max_width 30 wraps through the locator unless [cite...] is atomic.
+        let wrap_cfg = crate::FormatConfig {
+            format: crate::format::Format::Org,
+            max_width: 30,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let wrapped = format_text(input, &wrap_cfg).unwrap();
+        assert!(
+            wrapped.lines().any(|l| l.contains(cite)),
+            "wrap must not cut inside the citation, got:\n{wrapped}"
+        );
+        assert!(
+            !wrapped.contains("p.\n7"),
+            "must not split on p. inside the citation, got:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("Next sentence."),
+            "sentence after the citation must still reflow, got:\n{wrapped}"
+        );
+        assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+    }
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1865,6 +1865,20 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_org_cite_atomic() {
+        let token = "[cite/t:see;@foo p. 7;@bar pp. 4;by foo]";
+        let sentence = "See [cite/t:see;@foo p. 7;@bar pp. 4;by foo]. Next sentence.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 30, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("p.\n7"),
+                "must not wrap on p. inside the citation, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn max_width_keeps_math_atomic() {
         let token = "$E = m c^{2}$";
         let sentence = "The identity $E = m c^{2}$ holds in this frame.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -16,12 +16,16 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
         &[
             r"\[\[[^\]]*\]\]",           // Org links: [[url]] or [[url][desc]]
             r"\[\[[^\]]*\]\[[^\]]*\]\]", // Org links with desc
-            r"\[[^\]]+\]\([^)]+\)",      // Markdown links: [text](url)
-            r"!\[[^\]]*\]\([^)]+\)",     // Markdown images: ![alt](url)
-            r"\$\$[^$\n]+\$\$",          // Display math: $$...$$
-            r"\$[^$\n]+\$",              // Inline math: $...$
-            r"\\\([^\\\n]+\\\)",         // LaTeX inline math: \(...\)
-            r"\\([a-zA-Z]+)\{[^}]*\}",   // LaTeX commands: \cmd{arg}
+            // org-element 5.5 citation: [cite/style:prefix;@key p. 7;suffix]
+            // Must be atomic so a page locator is not a sentence boundary.
+            r"\[cite(?:/[-a-zA-Z0-9_/]*)?:[^\]]*\]",
+            r"\[[^\]]+\]\([^)]+\)",    // Markdown links: [text](url)
+            r"!\[[^\]]*\]\([^)]+\)",   // Markdown images: ![alt](url)
+            r"\$\$[^$\n]+\$\$",        // Display math: $$...$$
+            r"\$[^$\n]+\$",            // Inline math: $...$
+            r"\\\([^\\\n]+\\\)",       // LaTeX inline math: \(...\)
+            r"\\\[[^\n]+?\\\]",        // Org / LaTeX display math fragment: \[...\]
+            r"\\([a-zA-Z]+)\{[^}]*\}", // LaTeX commands: \cmd{arg}
             // Org emphasis must be protected before sentence splits so a line
             // cannot begin with `*rest` (false headline) or leave markers open.
             // Org requires a non-space immediately after the opener and before
@@ -583,7 +587,7 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 }
 
 /// Byte ranges of inline tokens that wrapping must not split (links, images,
-/// inline code, autolinks, math, Org `[[...]]`, paired spans).
+/// inline code, autolinks, math, Org `[[...]]`, Org `[cite...]`, paired spans).
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.
@@ -1349,6 +1353,33 @@ mod tests {
             vec![
                 "See [[https://example.com][Ex. Site]] for details.",
                 "Then continue."
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_cite_page_locator_is_not_a_sentence_boundary() {
+        // EN_ABBREVIATIONS has `pp` but not `p`. Bracket-depth merge can
+        // glue a UAX split, but wrap still cuts on `p. 7` unless the
+        // org-element citation is one inline token.
+        let cite = "[cite/t:see;@foo p. 7;@bar pp. 4;by foo]";
+        let text = "See [cite/t:see;@foo p. 7;@bar pp. 4;by foo]. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == cite),
+            "org citation must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == cite),
+            "citation must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See [cite/t:see;@foo p. 7;@bar pp. 4;by foo].".to_string(),
+                "Next sentence.".to_string()
             ]
         );
     }


### PR DESCRIPTION
vissue: snapper-95i9 (parent snapper-etv7). GitHub #112.

unanimous-green-50 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

org-element 5.5 citations must stay one object. Native INLINE_TOKEN_RE
had [[...]] but not [cite...], so See [cite/t:see;@foo p. 7;@bar pp. 4;by
foo]. Next split on p. 7. The citation is now an atomic token.

## Test plan
- rustc tests in src/parser/org.rs, src/reflow.rs, src/sentence/unicode.rs
- terra: cargo test parser::org sentence::unicode