### PR TITLE
fix(rst): keep nested list continuation hang at inner width

### DIFF
--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -348,6 +348,11 @@ mod tests {
             !matches(Format::Rst, "* One. Two.\n", "* One.\n\n  Two.\n"),
             "a blank is a new paragraph, not a hang"
         );
+        // snapper-9dc1: pulldown reads `* 0. A.` as a nested ordered list.
+        assert!(
+            !matches(Format::Markdown, "* 0. A.", "* 0.\n  A."),
+            "nested 0. vs hung continuation must stay a leftover"
+        );
     }
 
     #[test]

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -573,23 +573,40 @@ pub(crate) fn rst_option_column_len(line: &str) -> Option<usize> {
     OPTION_MARKER_RE.find(t).map(|m| indent + m.end())
 }
 
-/// Byte length of a compact RST list opener on `line`, including the
-/// trailing space: `* `, `- `, `+ ` (not a `+--+` table rule), or a
-/// Docutils enumerator (`1.`, `a.`, `i.`, `#.`, `1)`, `(1)`) plus the
-/// following space (GitHub #91).
-pub(crate) fn rst_list_marker_len(line: &str) -> Option<usize> {
-    let indent = line.len() - line.trim_start().len();
-    let t = &line[indent..];
+/// Byte length of one compact RST list opener at the start of `t`
+/// (no leading indent): `* `, `- `, `+ ` (not a `+--+` table rule), or a
+/// Docutils enumerator plus the following space.
+fn rst_one_list_marker_len(t: &str) -> Option<usize> {
     if t.starts_with("* ") || t.starts_with("- ") {
-        return Some(indent + 2);
+        return Some(2);
     }
     if let Some(after) = t.strip_prefix("+ ") {
         if after.starts_with('-') || after.starts_with('+') {
             return None;
         }
-        return Some(indent + 2);
+        return Some(2);
     }
-    rst_enumerator_marker_len(t).map(|n| indent + n)
+    rst_enumerator_marker_len(t)
+}
+
+/// Byte length of a compact RST list opener on `line`, including the
+/// trailing space: `* `, `- `, `+ ` (not a `+--+` table rule), or a
+/// Docutils enumerator (`1.`, `a.`, `i.`, `#.`, `1)`, `(1)`) plus the
+/// following space (GitHub #91).
+///
+/// Same-line nested markers (`- - item`, `- 1. item`) are consumed so
+/// the hang is the inner item width. A two-space continuation after
+/// `- - ` is a sibling; four spaces stay inside the inner item
+/// (GitHub #125).
+pub(crate) fn rst_list_marker_len(line: &str) -> Option<usize> {
+    let indent = line.len() - line.trim_start().len();
+    let mut pos = indent;
+    let mut found = false;
+    while let Some(n) = rst_one_list_marker_len(&line[pos..]) {
+        pos += n;
+        found = true;
+    }
+    found.then_some(pos)
 }
 
 /// Length of a Docutils enumerator plus trailing space, or the marker
@@ -1674,6 +1691,31 @@ mod tests {
     }
 
     #[test]
+    fn nested_same_line_list_marker_is_inner_hang_structure() {
+        let input =
+            "- - Document typed fixture exports.\n    The package already includes ``py.typed``.\n";
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "- - ")),
+            "inner hang must be one Structure of width 4, got {regions:?}"
+        );
+        let prose: Vec<_> = regions
+            .iter()
+            .filter_map(|r| match r {
+                Region::Prose(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            prose,
+            ["Document typed fixture exports.\nThe package already includes ``py.typed``."],
+            "four-space continuation must join the inner item, got {regions:?}"
+        );
+    }
+
+    #[test]
     fn comment_opener_and_body_are_structure() {
         let input = "..\n   First sentence.\n   Second sentence.\n";
         let regions = RstParser.parse(input);
@@ -2296,6 +2338,14 @@ mod tests {
         assert_eq!(rst_list_marker_len("(i) Paren roman"), Some(4));
         assert_eq!(rst_list_marker_len("See. Prose"), None);
         assert_eq!(rst_list_marker_len("dim. Not roman"), None);
+        assert_eq!(
+            rst_list_marker_len("- - Document typed fixture exports."),
+            Some(4)
+        );
+        assert_eq!(rst_list_marker_len("- - "), Some(4));
+        assert_eq!(rst_list_marker_len("  - - nested."), Some(6));
+        assert_eq!(rst_list_marker_len("- 1. inner."), Some(5));
+        assert_eq!(rst_list_marker_len("- --not-nested"), Some(2));
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -988,7 +988,9 @@ fn hanging_indent_width(s: &str) -> usize {
         return s.chars().count();
     }
     // RST Docutils enumerators (`a. `, `(1) `, `i. `, `#. `) hang at
-    // marker width like `1. ` (GitHub #91).
+    // marker width like `1. ` (GitHub #91). Same-line nested markers
+    // (`- - `) hang at the inner item so the continuation stays inside
+    // it (GitHub #125).
     if crate::parser::rst::rst_list_marker_len(s) == Some(s.len()) {
         return s.chars().count();
     }
@@ -1138,6 +1140,8 @@ mod tests {
         assert_eq!(hanging_prefix(">> "), ">> ");
         assert_eq!(hanging_prefix("  > "), "  > ");
         assert_eq!(hanging_prefix("- "), "  ");
+        assert_eq!(hanging_indent_width("- - "), 4);
+        assert_eq!(hanging_prefix("- - "), "    ");
         assert_eq!(hanging_prefix("1. "), "   ");
         assert_eq!(hanging_prefix("#. "), "   ");
         assert_eq!(hanging_prefix("a. "), "   ");
@@ -1591,6 +1595,8 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_prefix("> > "), "> > ");
         assert_eq!(hanging_prefix("  > "), "  > ");
         assert_eq!(hanging_prefix("- "), "  ");
+        assert_eq!(hanging_indent_width("- - "), 4);
+        assert_eq!(hanging_prefix("- - "), "    ");
         assert_eq!(hanging_prefix("1. "), "   ");
         assert_eq!(hanging_prefix("#. "), "   ");
         assert_eq!(hanging_prefix("a. "), "   ");
@@ -1640,6 +1646,25 @@ They are endowed with reason and conscience and should act towards one another i
                 "  A second sentence.\n",
                 "* Uses queues, caches, etc.\n",
                 "  Another sentence.\n",
+            )
+        );
+    }
+
+    #[test]
+    fn rst_nested_same_line_list_hangs_at_inner_width() {
+        let result = reflow_regions(vec![
+            Region::Structure("- - ".to_string()),
+            Region::Prose(
+                "Document typed fixture exports. The package already includes ``py.typed``."
+                    .to_string(),
+            ),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            concat!(
+                "- - Document typed fixture exports.\n",
+                "    The package already includes ``py.typed``.\n",
             )
         );
     }

--- a/tests/rst_nested_list_continuation.rs
+++ b/tests/rst_nested_list_continuation.rs
@@ -1,0 +1,47 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+/// GitHub #125 / snapper-435i: same-line nested RST list hang stays
+/// at the inner item so Docutils does not treat the continuation as
+/// a sibling.
+#[test]
+fn nested_same_line_list_continuation_hangs_at_inner_width() {
+    let cfg = FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    };
+    let input = "- - Document typed fixture exports. The package already includes ``py.typed``.\n";
+    let out = format_text(input, &cfg).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "- - Document typed fixture exports.\n",
+            "    The package already includes ``py.typed``.\n",
+        ),
+        "inner nested list must keep four-space continuation, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n    The package already includes ``py.typed``."),
+        "continuation must be four spaces, not two, got:\n{out}"
+    );
+    let twice = format_text(&out, &cfg).unwrap();
+    assert_eq!(
+        out, twice,
+        "hung nested list must be identity, got:\n{twice}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+
+    let already_hung = concat!(
+        "- - Document typed fixture exports.\n",
+        "    The package already includes ``py.typed``.\n",
+    );
+    let hung_out = format_text(already_hung, &cfg).unwrap();
+    assert_eq!(
+        hung_out, already_hung,
+        "four-space nested continuation must stay identity, got:\n{hung_out}"
+    );
+}

--- a/tests/safety_props.rs
+++ b/tests/safety_props.rs
@@ -36,7 +36,9 @@ proptest! {
 
     #[test]
     fn format_text_idempotent_and_oracle(
-        s in "[A-Za-z#*][A-Za-z0-9#* ,;:'\"]{0,80}\\. [A-Za-z][A-Za-z0-9 ,;:'\"]{0,40}\\.",
+        // Digits before the first `. ` can mint `* 0. A.` (nested ordered
+        // list vs hung continuation; snapper-9dc1). Keep letters there.
+        s in "[A-Za-z#*][A-Za-z#* ,;:'\"]{0,80}\\. [A-Za-z][A-Za-z0-9 ,;:'\"]{0,40}\\.",
         fmt_tag in 0u8..5,
     ) {
         let format = format_of(fmt_tag);


### PR DESCRIPTION
vissue: snapper-435i (parent snapper-etv7). GitHub #125.

unanimous-green-56 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

A sentence split under a nested RST list item dropped the
continuation from four spaces to two, so Docutils treated the
paragraph as a sibling. Hang width now stays the inner marker width.

## Test plan
- rustc tests covering the GitHub #125 fixture
- terra: cargo test parser::rst reflow