### PR TITLE
fix(rst): keep two-space list hang after abbreviations

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -421,6 +421,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // Structure so splice does not outdent them. Compact wrap
         // (no blank) is the same paragraph; join into the open Prose
         // so a reflow hang reparses as the source list item.
+        // A join_prose_gap newline after `No.` / `etc.` stays in that
+        // Prose; reflow repeats the hang on those continuation lines
+        // (GitHub #129).
         if let Some(hang) = list_hang {
             let leading = line_text.len() - line_text.trim_start().len();
             if leading >= hang {
@@ -1504,6 +1507,71 @@ mod tests {
                 .iter()
                 .any(|r| matches!(r, Region::Structure(s) if s == "  ")),
             "compact hang must not be Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn compact_abbrev_list_hang_joins_into_one_prose_region() {
+        let input = "* **Answer**: No.\n  A second sentence.\n";
+        let regions = RstParser.parse(input);
+        let prose: Vec<_> = regions
+            .iter()
+            .filter_map(|r| match r {
+                Region::Prose(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            prose,
+            ["**Answer**: No.\nA second sentence."],
+            "compact abbrev hang must join into one Prose, got {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "  ")),
+            "compact abbrev hang must not be Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn reporter_abbrev_list_continuation_keeps_two_space_hang() {
+        use crate::format::Format;
+        use crate::oracle;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        };
+        let input = concat!(
+            "* **Answer**: No.\n",
+            "  A second sentence.\n",
+            "* Uses queues, caches, etc.\n",
+            "  Another sentence.\n",
+        );
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, input,
+            "list continuation after No./etc. must keep two-space hang, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n  A second sentence."),
+            "No. continuation must hang, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n  Another sentence."),
+            "etc. continuation must hang, got:\n{out}"
+        );
+        let twice = format_text(&out, &cfg).unwrap();
+        assert_eq!(
+            out, twice,
+            "hung abbrev list must be identity, got:\n{twice}"
+        );
+        assert!(
+            oracle::matches(Format::Rst, input, &out),
+            "oracle mismatch\n in={input:?}\n out={out:?}"
         );
     }
 

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -254,7 +254,11 @@ fn reflow_prose(
             if hanging > 0 && i > 0 {
                 output.push_str(&hang);
             }
-            output.push_str(sentence);
+            if hanging > 0 {
+                output.push_str(&hang_internal_newlines(sentence, &hang));
+            } else {
+                output.push_str(sentence);
+            }
         }
         if i + 1 < nsent {
             output.push('\n');
@@ -911,6 +915,26 @@ fn wrap_atomic_words(
         start = break_at;
     }
     lines
+}
+
+/// Repeat list/quote hang after source newlines left inside one sentence.
+///
+/// Compact RST list joins insert a newline after sentence punct (`No.`,
+/// `etc.`); abbreviation merge then keeps that as one sentence, so splice
+/// would otherwise emit the continuation flush-left (GitHub #129).
+fn hang_internal_newlines(text: &str, hang: &str) -> String {
+    if hang.is_empty() || !text.contains('\n') {
+        return text.to_string();
+    }
+    let mut out = String::with_capacity(text.len() + hang.len());
+    let bytes = text.as_bytes();
+    for (i, c) in text.char_indices() {
+        out.push(c);
+        if c == '\n' && i + 1 < bytes.len() {
+            out.push_str(hang);
+        }
+    }
+    out
 }
 
 /// True when `s` is a list or quote marker that continuation lines hang from.
@@ -1597,6 +1621,27 @@ They are endowed with reason and conscience and should act towards one another i
             Region::Structure("\n".to_string()),
         ]);
         assert_eq!(result, "- One.\n  Two.\n");
+    }
+
+    #[test]
+    fn rst_abbrev_list_internal_newline_keeps_hang() {
+        let result = reflow_regions(vec![
+            Region::Structure("* ".to_string()),
+            Region::Prose("**Answer**: No.\nA second sentence.".to_string()),
+            Region::Structure("\n".to_string()),
+            Region::Structure("* ".to_string()),
+            Region::Prose("Uses queues, caches, etc.\nAnother sentence.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            concat!(
+                "* **Answer**: No.\n",
+                "  A second sentence.\n",
+                "* Uses queues, caches, etc.\n",
+                "  Another sentence.\n",
+            )
+        );
     }
 
     #[test]

--- a/tests/rst_abbrev_list_continuation.rs
+++ b/tests/rst_abbrev_list_continuation.rs
@@ -1,0 +1,50 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+/// GitHub #129 / snapper-u4lh: RST list continuations after `No.` / `etc.`
+/// keep the two-space hang. Abbreviation merge leaves the join_prose_gap
+/// newline inside one sentence; reflow must still hang that line.
+#[test]
+fn abbrev_list_continuation_keeps_two_space_hang() {
+    let cfg = FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    };
+    let input = concat!(
+        "* **Answer**: No.\n",
+        "  A second sentence.\n",
+        "* Uses queues, caches, etc.\n",
+        "  Another sentence.\n",
+    );
+    let out = format_text(input, &cfg).unwrap();
+    assert_eq!(
+        out, input,
+        "continuation after No./etc. must keep two-space hang, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n  A second sentence."),
+        "No. continuation must be two spaces, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n  Another sentence."),
+        "etc. continuation must be two spaces, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\nA second sentence."),
+        "No. continuation must not outdent, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\nAnother sentence."),
+        "etc. continuation must not outdent, got:\n{out}"
+    );
+    let twice = format_text(&out, &cfg).unwrap();
+    assert_eq!(
+        out, twice,
+        "hung abbrev list must be identity, got:\n{twice}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-u4lh (parent snapper-etv7). GitHub #129.

unanimous-green-58 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

A sentence split after No. or etc. dropped the next sentence to
column 0. Two-space list hang is kept after those abbreviations.

## Test plan
- rustc tests in tests/rst_abbrev_list_continuation.rs
- terra: cargo test parser::rst reflow