### PR TITLE
fix(rst): keep two-space list hang inside open quotes

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -1721,6 +1721,30 @@ mod tests {
     }
 
     #[test]
+    fn compact_quoted_list_hang_joins_into_one_prose_region() {
+        let input = "* \"First sentence.\n  Second sentence.\"\n";
+        let regions = RstParser.parse(input);
+        let prose: Vec<_> = regions
+            .iter()
+            .filter_map(|r| match r {
+                Region::Prose(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            prose,
+            ["\"First sentence.\nSecond sentence.\""],
+            "compact open-quote hang must join into one Prose, got {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "  ")),
+            "compact open-quote hang must not be Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
     fn compact_open_paren_list_hang_joins_into_one_prose_region() {
         let input = concat!(
             "- Ordering (smaller indices mean higher priority.\n",
@@ -1746,6 +1770,43 @@ mod tests {
                 .iter()
                 .any(|r| matches!(r, Region::Structure(s) if s == "  ")),
             "compact open-paren hang must not be Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn reporter_open_quote_list_continuation_keeps_two_space_hang() {
+        use crate::format::Format;
+        use crate::oracle;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let input = "* \"First sentence.\n  Second sentence.\"\n* Next item.\n";
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, input,
+            "open-quote list continuation must keep two-space hang, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n  Second sentence.\""),
+            "continuation must stay hung, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\nSecond sentence."),
+            "must not outdent inside the open quote, got:\n{out}"
+        );
+        let twice = format_text(&out, &cfg).unwrap();
+        assert_eq!(
+            out, twice,
+            "hung open-quote list must be identity, got:\n{twice}"
+        );
+        assert!(
+            oracle::matches(Format::Rst, input, &out),
+            "oracle mismatch\n in={input:?}\n out={out:?}"
         );
     }
 

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1706,6 +1706,24 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn rst_open_quote_list_keeps_hang_on_internal_newline() {
+        // GitHub #130: `"First sentence.` stays one sentence, so the
+        // compact-hang newline must still get the two-space prefix.
+        let result = reflow_regions(vec![
+            Region::Structure("* ".to_string()),
+            Region::Prose("\"First sentence.\nSecond sentence.\"".to_string()),
+            Region::Structure("\n".to_string()),
+            Region::Structure("* ".to_string()),
+            Region::Prose("Next item.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            "* \"First sentence.\n  Second sentence.\"\n* Next item.\n"
+        );
+    }
+
+    #[test]
     fn space_hang_structure_continues_sentences() {
         let result = reflow_regions(vec![
             Region::Structure("  ".to_string()),

--- a/tests/rst_quoted_list_continuation.rs
+++ b/tests/rst_quoted_list_continuation.rs
@@ -1,0 +1,73 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+/// GitHub #130 / snapper-kb7g: list hang stays while a quotation is open.
+/// The splitter keeps `"First sentence.\nSecond sentence."` as one sentence,
+/// so reflow must re-apply the two-space prefix to the source newline.
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+}
+
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "* \"First sentence.\n",
+        "  Second sentence.\"\n",
+        "* Next item.\n",
+    )
+}
+
+#[test]
+fn open_quote_list_continuation_keeps_two_space_hang() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "open-quote list continuation must keep two-space hang, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n  Second sentence.\""),
+        "continuation must be two spaces, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\nSecond sentence."),
+        "must not outdent inside the open quote, got:\n{out}"
+    );
+    let twice = format_text(&out, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, twice,
+        "hung open-quote list must be identity, got:\n{twice}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn open_quote_three_line_list_keeps_hang() {
+    let input = concat!(
+        "* \"First sentence.\n",
+        "  Second sentence.\n",
+        "  Third sentence.\"\n",
+        "* Next item.\n",
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "multi-line open quote must keep hang on every continuation, got:\n{out}"
+    );
+}
+
+#[test]
+fn fused_quoted_list_item_stays_one_sentence() {
+    let input = "* \"First sentence. Second sentence.\"\n* Next item.\n";
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "must not split inside ASCII double quotes, got:\n{out}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-kb7g (parent snapper-etv7). GitHub #130.

unanimous-green-59 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

While a quotation is open, the next sentence lost two-space hang.
Continuation indent is kept until the quote closes.

## Test plan
- rustc tests in tests/rst_quoted_list_continuation.rs
- terra: cargo test parser::rst reflow