### PR TITLE
fix(rst): keep two-space list hang inside open parentheses

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -421,9 +421,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // Structure so splice does not outdent them. Compact wrap
         // (no blank) is the same paragraph; join into the open Prose
         // so a reflow hang reparses as the source list item.
-        // A join_prose_gap newline after `No.` / `etc.` stays in that
-        // Prose; reflow repeats the hang on those continuation lines
-        // (GitHub #129).
+        // A join_prose_gap newline after `No.` / `etc.`, an open quote,
+        // or an open `(` stays in that Prose; reflow repeats the hang on
+        // those continuation lines (GitHub #129, #130, #131).
         if let Some(hang) = list_hang {
             let leading = line_text.len() - line_text.trim_start().len();
             if leading >= hang {
@@ -1548,6 +1548,76 @@ mod tests {
                 .iter()
                 .any(|r| matches!(r, Region::Structure(s) if s == "  ")),
             "compact abbrev hang must not be Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn compact_open_paren_list_hang_joins_into_one_prose_region() {
+        let input = concat!(
+            "- Ordering (smaller indices mean higher priority.\n",
+            "  Recurse to the left side of the array)\n",
+        );
+        let regions = RstParser.parse(input);
+        let prose: Vec<_> = regions
+            .iter()
+            .filter_map(|r| match r {
+                Region::Prose(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            prose,
+            [
+                "Ordering (smaller indices mean higher priority.\nRecurse to the left side of the array)"
+            ],
+            "compact open-paren hang must join into one Prose, got {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "  ")),
+            "compact open-paren hang must not be Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn reporter_open_paren_list_continuation_keeps_two_space_hang() {
+        use crate::format::Format;
+        use crate::oracle;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let input = concat!(
+            "- Ordering (smaller indices mean higher priority.\n",
+            "  Recurse to the left side of the array)\n",
+            "- Next item.\n",
+        );
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, input,
+            "open-paren list continuation must keep two-space hang, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n  Recurse to the left side of the array)"),
+            "continuation must stay hung, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\nRecurse to the left side of the array)"),
+            "must not outdent inside the open parenthesis, got:\n{out}"
+        );
+        let twice = format_text(&out, &cfg).unwrap();
+        assert_eq!(
+            out, twice,
+            "hung open-paren list must be identity, got:\n{twice}"
+        );
+        assert!(
+            oracle::matches(Format::Rst, input, &out),
+            "oracle mismatch\n in={input:?}\n out={out:?}"
         );
     }
 

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -920,8 +920,9 @@ fn wrap_atomic_words(
 /// Repeat list/quote hang after source newlines left inside one sentence.
 ///
 /// Compact RST list joins insert a newline after sentence punct (`No.`,
-/// `etc.`); abbreviation merge then keeps that as one sentence, so splice
-/// would otherwise emit the continuation flush-left (GitHub #129).
+/// `etc.`) or inside an open quote or `()`; abbreviation/delimiter merge
+/// then keeps that as one sentence, so splice would otherwise emit the
+/// continuation flush-left (GitHub #129, #130, #131).
 fn hang_internal_newlines(text: &str, hang: &str) -> String {
     if hang.is_empty() || !text.contains('\n') {
         return text.to_string();
@@ -1665,6 +1666,31 @@ They are endowed with reason and conscience and should act towards one another i
             concat!(
                 "- - Document typed fixture exports.\n",
                 "    The package already includes ``py.typed``.\n",
+            )
+        );
+    }
+
+    #[test]
+    fn rst_open_paren_list_keeps_hang_on_internal_newline() {
+        // GitHub #131: `(priority.` stays one sentence, so the
+        // compact-hang newline must still get the two-space prefix.
+        let result = reflow_regions(vec![
+            Region::Structure("- ".to_string()),
+            Region::Prose(
+                "Ordering (smaller indices mean higher priority.\nRecurse to the left side of the array)"
+                    .to_string(),
+            ),
+            Region::Structure("\n".to_string()),
+            Region::Structure("- ".to_string()),
+            Region::Prose("Next item.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            concat!(
+                "- Ordering (smaller indices mean higher priority.\n",
+                "  Recurse to the left side of the array)\n",
+                "- Next item.\n",
             )
         );
     }

--- a/tests/rst_paren_list_continuation.rs
+++ b/tests/rst_paren_list_continuation.rs
@@ -1,0 +1,58 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+/// GitHub #131 / snapper-cjrg: list hang stays while a parenthesis is open.
+/// The splitter keeps `(priority.\nRecurse)` as one sentence, so reflow
+/// must re-apply the two-space prefix to the source newline.
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+}
+
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "- Ordering (smaller indices mean higher priority.\n",
+        "  Recurse to the left side of the array)\n",
+        "- Next item.\n",
+    )
+}
+
+#[test]
+fn open_paren_list_continuation_keeps_two_space_hang() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "open-paren list continuation must keep two-space hang, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n  Recurse to the left side of the array)"),
+        "continuation must be two spaces, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\nRecurse to the left side of the array)"),
+        "must not outdent inside the open parenthesis, got:\n{out}"
+    );
+    let twice = format_text(&out, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, twice,
+        "hung open-paren list must be identity, got:\n{twice}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn fused_paren_list_item_stays_one_sentence() {
+    let input = "- Ordering (smaller indices mean higher priority. Recurse to the left side of the array)\n- Next item.\n";
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "must not split inside open parentheses, got:\n{out}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-cjrg (parent snapper-etv7). GitHub #131.

unanimous-green 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

While a parenthesis is open, the next sentence lost two-space hang.
Continuation indent is kept until the parenthesis closes.

## Test plan
- rustc tests in tests/rst_paren_list_continuation.rs
- terra: cargo test parser::rst reflow