### PR TITLE
fix(rst): keep two-space bullet marker hang width

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -615,6 +615,11 @@ fn rst_one_list_marker_len(t: &str) -> Option<usize> {
 /// the hang is the inner item width. A two-space continuation after
 /// `- - ` is a sibling; four spaces stay inside the inner item
 /// (GitHub #125).
+///
+/// Extra spaces after that compact opener (`*  Candidate:`) stay in the
+/// hang. Shrinking only the marker to `* Candidate:` leaves a
+/// three-space body and child, which Docutils treats as a block quote
+/// (GitHub #133).
 pub(crate) fn rst_list_marker_len(line: &str) -> Option<usize> {
     let indent = line.len() - line.trim_start().len();
     let mut pos = indent;
@@ -622,6 +627,11 @@ pub(crate) fn rst_list_marker_len(line: &str) -> Option<usize> {
     while let Some(n) = rst_one_list_marker_len(&line[pos..]) {
         pos += n;
         found = true;
+    }
+    if found {
+        while pos < line.len() && line.as_bytes()[pos] == b' ' {
+            pos += 1;
+        }
     }
     found.then_some(pos)
 }
@@ -1860,6 +1870,42 @@ mod tests {
     }
 
     #[test]
+    fn two_space_bullet_marker_is_width_three_structure() {
+        let input = concat!(
+            "*  Candidate:\n",
+            "\n",
+            "   Search API.\n",
+            "\n",
+            "   * Child item.\n",
+        );
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "*  ")),
+            "two-space bullet must be Structure of width 3, got {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "* ")),
+            "must not shrink the marker to one space, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(s) if s.contains("Candidate:"))),
+            "item text must be Prose, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "   * ")),
+            "child bullet must keep three-space indent, got {regions:?}"
+        );
+    }
+
+    #[test]
     fn comment_opener_and_body_are_structure() {
         let input = "..\n   First sentence.\n   Second sentence.\n";
         let regions = RstParser.parse(input);
@@ -2490,6 +2536,10 @@ mod tests {
         assert_eq!(rst_list_marker_len("  - - nested."), Some(6));
         assert_eq!(rst_list_marker_len("- 1. inner."), Some(5));
         assert_eq!(rst_list_marker_len("- --not-nested"), Some(2));
+        assert_eq!(rst_list_marker_len("*  Candidate:"), Some(3));
+        assert_eq!(rst_list_marker_len("*  "), Some(3));
+        assert_eq!(rst_list_marker_len("-  Term"), Some(3));
+        assert_eq!(rst_list_marker_len("  *  Nested"), Some(5));
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -995,9 +995,11 @@ fn hanging_indent_width(s: &str) -> usize {
     if crate::parser::rst::rst_list_marker_len(s) == Some(s.len()) {
         return s.chars().count();
     }
-    // Parser markers are `core` plus one trailing space; leading indent is
-    // part of the hang so nested `   - ` continues at column 5. RST `#.`
-    // is an auto-enumerator (GitHub #60); digits-only would miss it.
+    // Parser markers are `core` plus one or more trailing spaces; leading
+    // indent is part of the hang so nested `   - ` continues at column 5.
+    // Extra spaces after `*` (`*  Candidate:`) stay in the hang so a
+    // three-space body is not a Docutils block quote (GitHub #133).
+    // RST `#.` is an auto-enumerator (GitHub #60); digits-only would miss it.
     let core = &trimmed[..trimmed.len() - 1];
     let is_bullet = matches!(core, "-" | "*" | "+");
     let is_rst_autoenum = core == "#.";
@@ -1143,6 +1145,8 @@ mod tests {
         assert_eq!(hanging_prefix("- "), "  ");
         assert_eq!(hanging_indent_width("- - "), 4);
         assert_eq!(hanging_prefix("- - "), "    ");
+        assert_eq!(hanging_indent_width("*  "), 3);
+        assert_eq!(hanging_prefix("*  "), "   ");
         assert_eq!(hanging_prefix("1. "), "   ");
         assert_eq!(hanging_prefix("#. "), "   ");
         assert_eq!(hanging_prefix("a. "), "   ");
@@ -1589,6 +1593,8 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_indent_width("   - "), 5);
         assert_eq!(hanging_indent_width("  * "), 4);
         assert_eq!(hanging_prefix("  * "), "    ");
+        assert_eq!(hanging_indent_width("*  "), 3);
+        assert_eq!(hanging_prefix("*  "), "   ");
         // Quotes are a prefix hang, not a space-hang bullet.
         assert_eq!(hanging_indent_width("> "), 0);
         assert_eq!(hanging_indent_width("> > "), 0);

--- a/tests/rst_two_space_bullet_marker.rs
+++ b/tests/rst_two_space_bullet_marker.rs
@@ -1,0 +1,51 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+/// GitHub #133 / snapper-7yj2: two spaces after an RST bullet stay in
+/// the hang. Shrinking `*  Candidate:` to `* Candidate:` leaves the
+/// three-space body and child, which Docutils treats as a block quote.
+#[test]
+fn two_space_bullet_keeps_marker_and_nested_indent() {
+    let cfg = FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    };
+    let input = concat!(
+        "*  Candidate:\n",
+        "\n",
+        "   Search API.\n",
+        "\n",
+        "   * Child item.\n",
+    );
+    let out = format_text(input, &cfg).unwrap();
+    assert_eq!(
+        out, input,
+        "two-space bullet must stay identity, got:\n{out}"
+    );
+    assert!(
+        out.contains("*  Candidate:"),
+        "marker must keep two spaces after *, got:\n{out}"
+    );
+    assert!(
+        !out.contains("* Candidate:"),
+        "must not shrink the marker to one space, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n   Search API."),
+        "body must keep three-space indent, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n   * Child item."),
+        "child must keep three-space indent, got:\n{out}"
+    );
+    let twice = format_text(&out, &cfg).unwrap();
+    assert_eq!(
+        out, twice,
+        "two-space bullet must be identity, got:\n{twice}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-7yj2 (parent snapper-etv7). GitHub #133.

unanimous-green 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Extra spaces after `*  Candidate:` stay in the marker so a three-space
body and child are not a Docutils block quote.

## Test plan
- rustc tests in tests/rst_two_space_bullet_marker.rs
- terra: cargo test parser::rst reflow