### PR TITLE
fix(rst): keep two-space list hang inside open inline literals

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -490,8 +490,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // (no blank) is the same paragraph; join into the open Prose
         // so a reflow hang reparses as the source list item.
         // A join_prose_gap newline after `No.` / `etc.`, an open quote,
-        // or an open `(` stays in that Prose; reflow repeats the hang on
-        // those continuation lines (GitHub #129, #130, #131).
+        // an open `(`, or an open RST inline literal stays in that
+        // Prose; reflow repeats the hang on those continuation lines
+        // (GitHub #129, #130, #131, #143).
         // Empty current_prose after a nested Structure block (directive)
         // is a new hung paragraph, not a compact join (GitHub #135).
         if let Some(hang) = list_hang {
@@ -1911,6 +1912,36 @@ mod tests {
     }
 
     #[test]
+    fn compact_open_literal_list_hang_joins_into_one_prose_region() {
+        let input = concat!(
+            "- The error is ``not valid.\n",
+            "  Choose from: one, two`` and continue.\n",
+            "  A separate sentence.\n",
+        );
+        let regions = RstParser.parse(input);
+        let prose: Vec<_> = regions
+            .iter()
+            .filter_map(|r| match r {
+                Region::Prose(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            prose,
+            [
+                "The error is ``not valid.\nChoose from: one, two`` and continue.\nA separate sentence."
+            ],
+            "compact open-literal hang must join into one Prose, got {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "  ")),
+            "compact open-literal hang must not be Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
     fn compact_open_paren_list_hang_joins_into_one_prose_region() {
         let input = concat!(
             "- Ordering (smaller indices mean higher priority.\n",
@@ -1969,6 +2000,55 @@ mod tests {
         assert_eq!(
             out, twice,
             "hung open-quote list must be identity, got:\n{twice}"
+        );
+        assert!(
+            oracle::matches(Format::Rst, input, &out),
+            "oracle mismatch\n in={input:?}\n out={out:?}"
+        );
+    }
+
+    #[test]
+    fn reporter_open_literal_list_continuation_keeps_two_space_hang() {
+        use crate::format::Format;
+        use crate::oracle;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let input = concat!(
+            "- The error is ``not valid.\n",
+            "  Choose from: one, two`` and continue.\n",
+            "  A separate sentence.\n",
+        );
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out, input,
+            "open-literal list continuation must keep two-space hang, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n  Choose from: one, two`` and continue."),
+            "continuation inside the open literal must stay hung, got:\n{out}"
+        );
+        assert!(
+            out.contains("\n  A separate sentence."),
+            "following sentence in the same item must stay hung, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\nChoose from: one, two"),
+            "must not outdent inside the open inline literal, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\nA separate sentence."),
+            "must not outdent the following sentence, got:\n{out}"
+        );
+        let twice = format_text(&out, &cfg).unwrap();
+        assert_eq!(
+            out, twice,
+            "hung open-literal list must be identity, got:\n{twice}"
         );
         assert!(
             oracle::matches(Format::Rst, input, &out),

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1004,9 +1004,10 @@ fn wrap_atomic_words(
 /// Repeat list/quote hang after source newlines left inside one sentence.
 ///
 /// Compact RST list joins insert a newline after sentence punct (`No.`,
-/// `etc.`) or inside an open quote or `()`; abbreviation/delimiter merge
-/// then keeps that as one sentence, so splice would otherwise emit the
-/// continuation flush-left (GitHub #129, #130, #131).
+/// `etc.`) or inside an open quote, `()`, or an open RST inline literal;
+/// abbreviation/delimiter merge then keeps that as one sentence, so
+/// splice would otherwise emit the continuation flush-left
+/// (GitHub #129, #130, #131, #143).
 fn hang_internal_newlines(text: &str, hang: &str) -> String {
     if hang.is_empty() || !text.contains('\n') {
         return text.to_string();
@@ -1769,6 +1770,29 @@ They are endowed with reason and conscience and should act towards one another i
                 "  A second sentence.\n",
                 "* Uses queues, caches, etc.\n",
                 "  Another sentence.\n",
+            )
+        );
+    }
+
+    #[test]
+    fn rst_open_literal_list_keeps_hang_on_internal_newline() {
+        // GitHub #143: an open ``not valid.`` stays one sentence, so
+        // compact-hang newlines must still get the two-space prefix
+        // (including the following sentence in the same item).
+        let result = reflow_regions(vec![
+            Region::Structure("- ".to_string()),
+            Region::Prose(
+                "The error is ``not valid.\nChoose from: one, two`` and continue.\nA separate sentence."
+                    .to_string(),
+            ),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            concat!(
+                "- The error is ``not valid.\n",
+                "  Choose from: one, two`` and continue.\n",
+                "  A separate sentence.\n",
             )
         );
     }

--- a/tests/rst_literal_list_continuation.rs
+++ b/tests/rst_literal_list_continuation.rs
@@ -1,0 +1,77 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+/// GitHub #143 / snapper-nftt: list hang stays while an RST inline
+/// literal is open, and for the following sentence in the same item.
+/// `find_md_code_span` cannot pair ```` across a newline, so the
+/// splitter keeps the open literal as one sentence; reflow must
+/// re-apply the two-space prefix to those source newlines.
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+}
+
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "- The error is ``not valid.\n",
+        "  Choose from: one, two`` and continue.\n",
+        "  A separate sentence.\n",
+    )
+}
+
+#[test]
+fn open_literal_list_continuation_keeps_two_space_hang() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "open-literal list continuation must keep two-space hang, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n  Choose from: one, two`` and continue."),
+        "continuation inside the open literal must be two spaces, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n  A separate sentence."),
+        "following sentence in the same item must be two spaces, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\nChoose from: one, two"),
+        "must not outdent inside the open inline literal, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\nA separate sentence."),
+        "must not outdent the following sentence, got:\n{out}"
+    );
+    let twice = format_text(&out, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, twice,
+        "hung open-literal list must be identity, got:\n{twice}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn fused_literal_list_item_keeps_following_sentence_hang() {
+    let input =
+        "- The error is ``not valid. Choose from: one, two`` and continue. A separate sentence.\n";
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "- The error is ``not valid. Choose from: one, two`` and continue.\n",
+            "  A separate sentence.\n",
+        ),
+        "second sentence after a closed literal must hang, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\nA separate sentence."),
+        "must not outdent the following sentence, got:\n{out}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-nftt (parent snapper-etv7). GitHub #143.

unanimous-green 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

While an RST inline literal is open, the next sentence lost two-space
hang. Continuation indent is kept until the literal closes.

## Test plan
- rustc tests in tests/rst_literal_list_continuation.rs
- terra: cargo test parser::rst reflow