### PR TITLE
fix(rst): keep definition hang after nested directives

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -148,12 +148,27 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // Inside directive body
         if in_directive {
             let leading = line_text.len() - line_text.trim_start().len();
-            if line_text.trim().is_empty() || leading >= directive_indent {
+            if line_text.trim().is_empty() {
+                // Interior blanks stay in the body. A trailing blank
+                // (next non-blank is below the body indent, or EOF)
+                // ends the directive so the following hung paragraph
+                // is a real BlankLines + hang, not a splice that
+                // outdents the second sentence (GitHub #135).
+                match next_nonblank_indent(&lines, i) {
+                    Some(n) if n >= directive_indent => {
+                        regions.push(SpannedRegion::structure(input, line.span()));
+                        i += 1;
+                        continue;
+                    }
+                    _ => in_directive = false,
+                }
+            } else if leading >= directive_indent {
                 regions.push(SpannedRegion::structure(input, line.span()));
                 i += 1;
                 continue;
+            } else {
+                in_directive = false;
             }
-            in_directive = false;
         }
 
         // Inside comment body (indented lines after `..` / `.. text`).
@@ -424,13 +439,15 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // A join_prose_gap newline after `No.` / `etc.`, an open quote,
         // or an open `(` stays in that Prose; reflow repeats the hang on
         // those continuation lines (GitHub #129, #130, #131).
+        // Empty current_prose after a nested Structure block (directive)
+        // is a new hung paragraph, not a compact join (GitHub #135).
         if let Some(hang) = list_hang {
             let leading = line_text.len() - line_text.trim_start().len();
             if leading >= hang {
                 let after_blank = regions
                     .last()
                     .is_some_and(|r| matches!(r.region, Region::BlankLines(_)));
-                if after_blank {
+                if after_blank || current_prose.is_empty() {
                     flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                     regions.push(SpannedRegion::structure(
                         input,
@@ -803,6 +820,17 @@ fn list_item_definition_indent(lines: &[Line<'_>], i: usize, hang: usize) -> Opt
     }
     let next_indent = next.len() - next.trim_start().len();
     (next_indent > hang).then_some(next_indent)
+}
+
+/// Indent of the next non-blank line after `i`, if any.
+fn next_nonblank_indent(lines: &[Line<'_>], i: usize) -> Option<usize> {
+    for line in lines.iter().skip(i + 1) {
+        if line.text.trim().is_empty() {
+            continue;
+        }
+        return Some(line.text.len() - line.text.trim_start().len());
+    }
+    None
 }
 
 /// True when `lines[i]` is a definition-list term: the next physical line
@@ -1442,6 +1470,52 @@ mod tests {
                 )
             }),
             "definition inside a list item must not join as Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn hang_after_nested_pull_quote_is_structure() {
+        let input = concat!(
+            "Loading-state race:\n",
+            "\n",
+            "   Ask this question:\n",
+            "\n",
+            "   .. pull-quote::\n",
+            "\n",
+            "      What happens?\n",
+            "\n",
+            "   First sentence.\n",
+            "   Second sentence.\n",
+        );
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains(".. pull-quote::"))),
+            "nested directive must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "   ")),
+            "definition hang after the directive must be Structure, got {regions:?}"
+        );
+        let prose: Vec<_> = regions
+            .iter()
+            .filter_map(|r| match r {
+                Region::Prose(s) => Some(s.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            prose
+                .iter()
+                .any(|s| s.contains("First sentence.") && s.contains("Second sentence.")),
+            "definition sentences after the directive must be one Prose, got {regions:?}"
+        );
+        assert!(
+            !prose.iter().any(|s| s.contains("What happens?")),
+            "pull-quote body must not be Prose, got {regions:?}"
         );
     }
 

--- a/tests/rst_definition_after_directive.rs
+++ b/tests/rst_definition_after_directive.rs
@@ -1,0 +1,100 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+/// GitHub #135 / snapper-v1ze: after a nested `.. pull-quote::` the
+/// second definition/quote sentence must keep the three-space hang.
+/// Docutils keeps both sentences inside the same block; outdenting the
+/// last line moves it out of that container.
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "Loading-state race:\n",
+        "\n",
+        "   Ask this question:\n",
+        "\n",
+        "   .. pull-quote::\n",
+        "\n",
+        "      What happens?\n",
+        "\n",
+        "   First sentence.\n",
+        "   Second sentence.\n",
+    )
+}
+
+#[test]
+fn definition_paragraph_after_nested_directive_keeps_hang() {
+    let cfg = FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    };
+    let input = ticket_fixture();
+    let out = format_text(input, &cfg).unwrap();
+    assert_eq!(
+        out, input,
+        "second sentence must stay inside the definition, got:\n{out}"
+    );
+    assert!(
+        out.contains("\n   Second sentence."),
+        "second sentence must keep three-space indent, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\nSecond sentence."),
+        "second sentence must not outdent to column 0, got:\n{out}"
+    );
+    let twice = format_text(&out, &cfg).unwrap();
+    assert_eq!(
+        out, twice,
+        "hung definition paragraph must be identity, got:\n{twice}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn compact_sentences_after_nested_directive_hang() {
+    let cfg = FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    };
+    let input = concat!(
+        "Loading-state race:\n",
+        "\n",
+        "   Ask this question:\n",
+        "\n",
+        "   .. pull-quote::\n",
+        "\n",
+        "      What happens?\n",
+        "\n",
+        "   First sentence. Second sentence.\n",
+    );
+    let out = format_text(input, &cfg).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Loading-state race:\n",
+            "\n",
+            "   Ask this question:\n",
+            "\n",
+            "   .. pull-quote::\n",
+            "\n",
+            "      What happens?\n",
+            "\n",
+            "   First sentence.\n",
+            "   Second sentence.\n",
+        ),
+        "split second sentence must keep three-space hang, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\nSecond sentence."),
+        "split second sentence must not outdent, got:\n{out}"
+    );
+    let twice = format_text(&out, &cfg).unwrap();
+    assert_eq!(out, twice, "hung split must be identity, got:\n{twice}");
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-v1ze (parent snapper-etv7). GitHub #135.

unanimous-green 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Close a directive on trailing blanks and start a new hung paragraph
when current_prose is empty after nested Structure, so the second
sentence after a nested .. pull-quote:: keeps three-space indent.

## Test plan
- rustc tests in tests/rst_definition_after_directive.rs
- terra: cargo test parser::rst