### PR TITLE
fix(rst): treat suffix role closer as sentence end

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -2576,6 +2576,22 @@ mod tests {
             "double-backtick literal must stay split, got:\n{out}"
         );
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
+
+        let suffix = "The task is in `README.md`:file:.\nUse this section for questions.\n";
+        let out = format_text(suffix, &cfg).unwrap();
+        assert_eq!(
+            out, suffix,
+            "suffix role closer must stay two lines, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+
+        let same_line = "The task is in `README.md`:file:. Use this section for questions.\n";
+        let out = format_text(same_line, &cfg).unwrap();
+        assert_eq!(
+            out, suffix,
+            "same-line suffix role closer must split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 
     #[test]

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -815,11 +815,12 @@ fn push_segment_preserving_space(dest: &mut String, piece: &str) {
 /// interpreted-text closer followed by `.!?`.
 ///
 /// `**Bold sentence.** Next` is one UAX sentence because the period lives
-/// inside the protected span. RST prefix roles put the period after the
-/// closer; `file:` token protection can also swallow that period, so UAX
-/// sees one sentence. Quotes are not paired spans, so they already split.
-/// Mid-span periods (`**the end. Still bold**`) have no closers after the
-/// period and stay one sentence.
+/// inside the protected span. RST prefix `:role:`text`. puts the period
+/// after the backtick; suffix `text`:role:. puts it after `:role:`.
+/// `file:\S+` can also swallow the period on suffix `:file:.`, so UAX
+/// sees one sentence. This post-pass runs after restore. Quotes are not
+/// paired spans, so they already split. Mid-span periods (`**the end. Still bold**`)
+/// have no closers after the period and stay one sentence.
 pub(crate) fn split_after_markup_sentence_end(segments: Vec<String>) -> Vec<String> {
     let mut out = Vec::new();
     for seg in segments {
@@ -839,13 +840,17 @@ fn push_markup_sentence_splits(out: &mut Vec<String>, seg: &str) {
 
 fn take_markup_terminal_sentence(seg: &str) -> Option<(String, String)> {
     // Terminal `.!?` immediately before `**` / `*` / `_` / backticks /
-    // `~~` / `](url)`, or an RST `:role:` / `:domain:role:` closer then
-    // `.!?`, then whitespace, then a new sentence (uppercase or opening
-    // quote). Opening ```` is not a closer. A lowercase continuation
-    // (`[Example Inc.](url) now.`) stays one sentence.
+    // `~~` / `](url)`, or an RST interpreted-text closer then `.!?`,
+    // then whitespace, then a new sentence (uppercase or opening quote).
+    // Prefix closer is `:role:`text`. / `:domain:role:`text`. Suffix
+    // closer is `text`:role:. / `text`:domain:role:. (the closer is
+    // `:role:`, not the backtick). Opening ```` is not a closer. Role
+    // charset has no `.` so `email:user.name:`host`. does not
+    // false-split. A lowercase continuation (`[Example Inc.](url) now.`)
+    // stays one sentence.
     static CAP: LazyLock<Regex> = LazyLock::new(|| {
         Regex::new(
-            r#"(?s)^(.*?(?:[.!?](?:\*{1,3}|_{1,3}|`+|~{1,2}|\]\([^)]*\))+|:[A-Za-z][A-Za-z0-9_-]*(?::[A-Za-z][A-Za-z0-9_-]*)*:`[^`\n]+`[.!?]))\s+([A-Z][\s\S]*|["'][A-Z][\s\S]*)$"#,
+            r#"(?s)^(.*?(?:[.!?](?:\*{1,3}|_{1,3}|`+|~{1,2}|\]\([^)]*\))+|:[A-Za-z][A-Za-z0-9_-]*(?::[A-Za-z][A-Za-z0-9_-]*)*:`[^`\n]+`[.!?]|`[^`\n]+`:[A-Za-z][A-Za-z0-9_-]*(?::[A-Za-z][A-Za-z0-9_-]*)*:[.!?]))\s+([A-Z][\s\S]*|["'][A-Z][\s\S]*)$"#,
         )
         .expect("valid markup-terminal sentence regex")
     });
@@ -1853,6 +1858,24 @@ mod tests {
                 "The task is in ``README.md``.".to_string(),
                 "Use this section for questions.".to_string()
             ]
+        );
+        assert_eq!(
+            split("The task is in `README.md`:file:. Use this section for questions."),
+            vec![
+                "The task is in `README.md`:file:.".to_string(),
+                "Use this section for questions.".to_string()
+            ]
+        );
+        assert_eq!(
+            split("See `RFC 2119`:rfc:keyword:. Next sentence."),
+            vec![
+                "See `RFC 2119`:rfc:keyword:.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+        assert_eq!(
+            split("See `README.md`:file:. now continue."),
+            vec!["See `README.md`:file:. now continue.".to_string()]
         );
     }
 


### PR DESCRIPTION
vissue: snapper-ui5y (parent snapper-btho). GitHub #168.

unanimous-green-68 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Prefix :role:`text`. already splits. Suffix `text`:role:. still fused
because the closer is :role: after the span. Recognize that form so
format_text Format::Rst max_width=0 keeps the README.md :file: fixture
as two lines.

## Test plan
- terra: cargo test parser::rst sentence::unicode