### PR TITLE
fix(md): keep same-line 0. A. opener with its sentence

### DIFF
--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -362,6 +362,20 @@ mod tests {
     }
 
     #[test]
+    fn md_ol_opener_hang_is_oracle_veto() {
+        // pulldown: `* 0. A.` is a nested ordered list; `* 0.\n  A.` is
+        // a continuation paragraph. The hung form is not render-safe.
+        assert!(
+            !matches(Format::Markdown, "* 0. A.", "* 0.\n  A."),
+            "sembr hang after 0. must remain an oracle veto"
+        );
+        assert!(
+            !matches(Format::Markdown, "* 0. A.\n", "* 0.\n  A.\n"),
+            "sembr hang after 0. must remain an oracle veto"
+        );
+    }
+
+    #[test]
     fn configured_verb_percent_tree_matches_across_split() {
         let original = "\\begin{document}\nCode \\Verb!%! here. Next sentence.\n\\end{document}\n";
         let output = "\\begin{document}\nCode \\Verb!%! here.\nNext sentence.\n\\end{document}\n";

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -233,7 +233,10 @@ fn reflow_prose(
         _ => String::new(),
     };
     let hanging = hang.chars().count();
-    let sentences = splitter.split(text);
+    let mut sentences = splitter.split(text);
+    if config.format == Format::Markdown && hanging > 0 {
+        glue_md_same_line_ol_opener(&mut sentences, text);
+    }
     let nsent = sentences.len();
     for (i, sentence) in sentences.iter().enumerate() {
         if config.max_width > 0 || config.clause_breaks {
@@ -786,6 +789,65 @@ fn skip_block_opening_cut(
     break_at
 }
 
+/// pulldown treats `* 0. A.` as a nested ordered list. A wrap or sembr
+/// hang after the opener (`* 0.\n  A.`) is a continuation paragraph and
+/// the HTML oracle vetoes. Keep the opener with the next word instead of
+/// inventing a nested `0. ` Structure.
+fn skip_md_same_line_ol_opener_cut(
+    words: &[&str],
+    start: usize,
+    break_at: usize,
+    format: Format,
+    first: bool,
+    layout: &WrapLayout<'_>,
+) -> usize {
+    if format == Format::Markdown
+        && first
+        && layout.first_indent.is_empty()
+        && !layout.subsequent_indent.is_empty()
+        && break_at == start + 1
+        && break_at < words.len()
+        && is_ordered_list_marker(words[start])
+    {
+        return break_at + 1;
+    }
+    break_at
+}
+
+/// True when list-item prose starts with a same-line ordered list opener
+/// (`0. A.`). A source that is already hung (`0.\nA.`) stays hung.
+fn md_same_line_ol_opener(text: &str) -> bool {
+    let t = text.trim_start();
+    let bytes = t.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == 0 {
+        return false;
+    }
+    if !matches!(bytes.get(i), Some(b'.') | Some(b')')) {
+        return false;
+    }
+    i += 1;
+    matches!(bytes.get(i), Some(b' ') | Some(b'\t'))
+        && bytes.get(i + 1).is_some_and(|b| !b.is_ascii_whitespace())
+}
+
+/// Join a same-line Markdown `0.` / `1)` opener onto the next sentence so
+/// sembr does not hang after the opener.
+fn glue_md_same_line_ol_opener(sentences: &mut Vec<String>, source: &str) {
+    if sentences.len() < 2 || !md_same_line_ol_opener(source) {
+        return;
+    }
+    if !is_ordered_list_marker(sentences[0].trim()) {
+        return;
+    }
+    let rest = sentences[1].trim_start();
+    sentences[0] = format!("{} {rest}", sentences[0].trim());
+    sentences.remove(1);
+}
+
 fn emit_wrapped_line(
     words: &[&str],
     start: usize,
@@ -836,6 +898,7 @@ fn break_at_clause_punct(text: &str, format: Format, layout: WrapLayout<'_>) -> 
             .position(|w| ends_with_clause_punct(w))
             .map_or(words.len(), |i| start + i + 1);
         break_at = skip_block_opening_cut(&words, start, break_at, format);
+        break_at = skip_md_same_line_ol_opener_cut(&words, start, break_at, format, first, &layout);
         lines.push(emit_wrapped_line(
             &words, start, break_at, indent, may_escape, format,
         ));
@@ -909,6 +972,7 @@ fn wrap_atomic_words(
             }
         }
         break_at = skip_block_opening_cut(&words, start, break_at, format);
+        break_at = skip_md_same_line_ol_opener_cut(&words, start, break_at, format, first, &layout);
         lines.push(emit_wrapped_line(
             &words, start, break_at, indent, may_escape, format,
         ));
@@ -1161,6 +1225,15 @@ mod tests {
         assert_eq!(hanging_indent_width("- "), 2);
         assert_eq!(hanging_indent_width("#. "), 3);
         assert_eq!(hanging_indent_width("\\item "), 6);
+    }
+
+    #[test]
+    fn md_same_line_ol_opener_detects_compact_not_hung() {
+        assert!(md_same_line_ol_opener("0. A."));
+        assert!(md_same_line_ol_opener("1) Next."));
+        assert!(!md_same_line_ol_opener("0.\nA."));
+        assert!(!md_same_line_ol_opener("0."));
+        assert!(!md_same_line_ol_opener("Hello. 0. A."));
     }
 
     #[test]

--- a/tests/md_ol_opener_list_item.rs
+++ b/tests/md_ol_opener_list_item.rs
@@ -1,0 +1,93 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::markdown::MarkdownParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+/// snapper-9dc1: Markdown `* 0. A.` is one list item. pulldown treats
+/// `0. A.` as a nested ordered list. A sembr hang after `0.` is a
+/// continuation paragraph, so the HTML oracle vetoes. Keep the opener
+/// with the next sentence; do not invent a nested `0. ` Structure.
+
+fn md_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Markdown,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+#[test]
+fn compact_ol_opener_stays_on_one_line() {
+    let input = "* 0. A.";
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert_eq!(out, input, "must not sembr-hang after 0., got:\n{out}");
+    assert!(
+        !out.contains("0.\n"),
+        "must not emit * 0.\\n  A., got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Markdown, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+    assert!(
+        !snapper_fmt::oracle::matches(Format::Markdown, input, "* 0.\n  A."),
+        "hung form must stay an oracle veto"
+    );
+    let twice = format_text(&out, &md_cfg()).unwrap();
+    assert_eq!(
+        out, twice,
+        "compact ol opener must be identity, got:\n{twice}"
+    );
+}
+
+#[test]
+fn compact_ol_opener_is_not_a_nested_structure() {
+    let regions = MarkdownParser.parse("* 0. A.");
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "* ")),
+        "* marker must stay Structure, got: {regions:?}"
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("0. A."))),
+        "0. A. must stay one Prose region, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.trim() == "0.")),
+        "must not invent a nested 0. Structure, got: {regions:?}"
+    );
+}
+
+#[test]
+fn already_hung_ol_opener_stays_hung() {
+    let input = "* 0.\n  A.";
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "already-hung continuation must stay hung, got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Markdown, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn ordinary_list_item_still_hangs() {
+    let input = "* One. Two.";
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert_eq!(
+        out, "* One.\n  Two.",
+        "ordinary sembr hang must stay, got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Markdown, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-9dc1 (parent snapper-435i). GitHub #166.

unanimous-green-66 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

pulldown treats `* 0. A.` as a nested ordered list. A sembr hang after
`0.` is a continuation paragraph, so the HTML oracle vetoes. Glue the
opener to the next sentence instead of inventing a nested `0. `
Structure. Already-hung `* 0.\n  A.` stays hung.

## Test plan
- rustc tests in tests/md_ol_opener_list_item.rs
- terra: cargo test reflow oracle