### PR TITLE
fix(org): stop file: token swallowing sentence punct

### DIFF
--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -2451,4 +2451,32 @@ mod tests {
         );
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }
+
+    /// Ticket fixture (Format::Org / GitHub #169): `file:\S+` must not
+    /// swallow trailing `.!?` so `See file:/tmp/foo. Next` is two sentences.
+    #[test]
+    fn org_file_token_does_not_swallow_trailing_sentence_punct() {
+        use crate::format_text;
+
+        let two_line = "See file:/tmp/foo.\nNext sentence.\n";
+        let out = format_text(two_line, &org_cfg()).unwrap();
+        assert_eq!(
+            out, two_line,
+            "existing newline must stay two lines, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+        let same_line = "See file:/tmp/foo. Next sentence.\n";
+        let out = format_text(same_line, &org_cfg()).unwrap();
+        assert_eq!(
+            out, two_line,
+            "same-line file: period must split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+        let bang = "See file:/tmp/foo!\nNext sentence.\n";
+        let out = format_text("See file:/tmp/foo! Next sentence.\n", &org_cfg()).unwrap();
+        assert_eq!(out, bang, "same-line file: bang must split, got:\n{out}");
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
 }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -42,8 +42,8 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             r"<[A-Za-z][A-Za-z0-9+.\-]*:[^\s<>]*>", // Autolink: <http://...>
             r"<[^\s<>@]+@[^\s<>]+>",                // Autolink: <user@host>
             r#"https?://\S+[^.\s!?,;:)\]'""]"#,     // URLs (don't swallow trailing punctuation)
-            r"file:\S+",                            // Org file: links
-            r"@@[a-zA-Z]+:[^@]*@@",                 // Org inline export snippets: @@backend:value@@
+            r#"file:\S+[^.\s!?,;:)\]'""]"#, // Org file: links (don't swallow trailing punctuation)
+            r"@@[a-zA-Z]+:[^@]*@@",         // Org inline export snippets: @@backend:value@@
         ]
         .join("|"),
     )
@@ -1807,6 +1807,54 @@ mod tests {
         assert_eq!(
             split("See https://example.com/path?q=1&r=2. Next sentence."),
             vec!["See https://example.com/path?q=1&r=2.", "Next sentence."]
+        );
+    }
+
+    #[test]
+    fn org_file_token_trailing_punct_not_swallowed() {
+        // GitHub #169: `file:\S+` used to eat the period so
+        // `See file:/tmp/foo. Next` stayed one sentence.
+        let (_, placeholders) = protect_inline_tokens("See file:/tmp/foo. Next");
+        assert!(
+            placeholders.iter().any(|p| p == "file:/tmp/foo"),
+            "file: token must stop before sentence punct, got {placeholders:?}"
+        );
+        assert!(
+            !placeholders.iter().any(|p| p.contains("file:/tmp/foo.")),
+            "file: token must not swallow trailing period, got {placeholders:?}"
+        );
+        assert_eq!(
+            split("See file:/tmp/foo. Next"),
+            vec!["See file:/tmp/foo.".to_string(), "Next".to_string()]
+        );
+        assert_eq!(
+            split("See file:/tmp/foo. Next sentence."),
+            vec![
+                "See file:/tmp/foo.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+        assert_eq!(
+            split("See file:/tmp/foo! Next sentence."),
+            vec![
+                "See file:/tmp/foo!".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+        assert_eq!(
+            split("See file:/tmp/foo? Next sentence."),
+            vec![
+                "See file:/tmp/foo?".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+        // Mid-path dots stay inside the token (same as URL path segments).
+        assert_eq!(
+            split("See file:/tmp/foo.org. Next sentence."),
+            vec![
+                "See file:/tmp/foo.org.".to_string(),
+                "Next sentence.".to_string()
+            ]
         );
     }
 

--- a/tests/org_file_token_punct.rs
+++ b/tests/org_file_token_punct.rs
@@ -1,0 +1,41 @@
+//! GitHub #169 / snapper-u77y: Org `file:` tokens must not swallow
+//! trailing sentence punctuation.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+#[test]
+fn org_file_token_same_line_splits() {
+    let two_line = "See file:/tmp/foo.\nNext sentence.\n";
+    let out = format_text(two_line, &org_cfg()).unwrap();
+    assert_eq!(
+        out, two_line,
+        "existing newline must stay two lines, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let out = format_text("See file:/tmp/foo. Next sentence.\n", &org_cfg()).unwrap();
+    assert_eq!(
+        out, two_line,
+        "same-line file: period must split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn org_file_token_bang_and_question_split() {
+    let cfg = org_cfg();
+    let out = format_text("See file:/tmp/foo! Next sentence.\n", &cfg).unwrap();
+    assert_eq!(out, "See file:/tmp/foo!\nNext sentence.\n", "got:\n{out}");
+    let out = format_text("See file:/tmp/foo? Next sentence.\n", &cfg).unwrap();
+    assert_eq!(out, "See file:/tmp/foo?\nNext sentence.\n", "got:\n{out}");
+}


### PR DESCRIPTION
vissue: snapper-u77y (parent snapper-btho). GitHub #169.

unanimous-green-69 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

INLINE_TOKEN_RE file:\S+ ate trailing .!? so See file:/tmp/foo. Next
stayed one sentence. Match the URL token and leave sentence punct
for UAX.

## Test plan
- rustc tests in tests/org_file_token_punct.rs
- terra: cargo test parser::org sentence::unicode