### PR TITLE
fix(latex): treat IEEEeqnarray xltabular and math-star as structure

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -10,9 +10,10 @@ use crate::sentence::unicode::latex_verb_span_end_with;
 // Extra names are tree-sitter-latex `math_environment` plus latexindent
 // `lookForAlignDelims` (amsmath / mathtools / tabularray / nicematrix /
 // listabla / spreadtab), not a GPL copy.
-// Overleaf `equationEnvNames` includes `tikzcd`; pgfplots `axis` /
-// `pgfpicture` are the same class (and starred variants). Not every
-// pgfplots name.
+// Overleaf leftover names (tokens.mjs) are `IEEEeqnarray` /
+// `IEEEeqnarray*` / `subeqnarray` / `subeqnarray*` / `xltabular` /
+// `math*`. `tikzcd` / pgfplots `axis` / `pgfpicture` are the same
+// class (and starred variants). Not every pgfplots name.
 //
 // `figure` / `table` (and stars) are not here: Overleaf FigureEnvironment
 // is Content<Text>, tree-sitter caption curly_group is text. Float chrome
@@ -38,14 +39,20 @@ static NON_PROSE_ENVS: &[&str] = &[
     "multline*",
     "eqnarray",
     "eqnarray*",
+    "IEEEeqnarray",
+    "IEEEeqnarray*",
+    "subeqnarray",
+    "subeqnarray*",
     "split",
     "split*",
     "displaymath",
     "displaymath*",
     "math",
+    "math*",
     "tabular",
     "tabular*",
     "tabularx",
+    "xltabular",
     "longtable",
     "tabu",
     "tblr",
@@ -3075,6 +3082,76 @@ Some text.
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
 
+    #[test]
+    fn ieeeeqnarray_fixture_is_structure_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{IEEEeqnarray}{rCl}\n",
+            "This is a long sentence that must stay inside IEEEeqnarray and must not reflow as prose.\n",
+            "\\end{IEEEeqnarray}\n",
+            "After the array. Second sentence.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s)
+                    if s.contains("must stay inside IEEEeqnarray and must not reflow as prose")
+            )),
+            "IEEEeqnarray body must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains("must stay inside IEEEeqnarray and must not reflow as prose")
+            )),
+            "IEEEeqnarray body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(
+                "This is a long sentence that must stay inside IEEEeqnarray and must not reflow as prose."
+            ),
+            "IEEEeqnarray body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the array.\nSecond sentence."),
+            "prose after IEEEeqnarray must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+    #[test]
+    fn leftover_overleaf_ieee_xltabular_mathstar_are_structure() {
+        let names = [
+            "IEEEeqnarray",
+            "IEEEeqnarray*",
+            "subeqnarray",
+            "subeqnarray*",
+            "xltabular",
+            "math*",
+        ];
+        for name in names {
+            let input = format!(
+                "\\begin{{{name}}}\nThis is a long sentence that must not reflow as prose inside {name}.\n\\end{{{name}}}\n"
+            );
+            let needle = format!("must not reflow as prose inside {name}");
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Structure(s) if s.contains(&needle))),
+                "{name} body must be Structure, got: {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains(&needle))),
+                "{name} body must not be Prose, got: {regions:?}"
+            );
+        }
+    }
     #[test]
     fn leftover_latexindent_nicematrix_listabla_spreadtab_are_structure() {
         let names = [

--- a/tests/latex_ieeeeqnarray_xltabular.rs
+++ b/tests/latex_ieeeeqnarray_xltabular.rs
@@ -1,0 +1,113 @@
+//! snapper-twmw / GitHub #181: leftover Overleaf tokens.mjs names are
+//! Structure, not prose (`IEEEeqnarray` / `IEEEeqnarray*` / `subeqnarray`
+//! / `subeqnarray*` / `xltabular` / `math*`).
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::latex::LatexParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn latex_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Latex,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture: `\begin{IEEEeqnarray}{rCl}` / long sentence /
+/// `\end{IEEEeqnarray}` / surrounding two-sentence prose.
+fn ieeeeqnarray_fixture() -> &'static str {
+    concat!(
+        "\\begin{IEEEeqnarray}{rCl}\n",
+        "This is a long sentence that must stay inside IEEEeqnarray and must not reflow as prose.\n",
+        "\\end{IEEEeqnarray}\n",
+        "After the array. Second sentence.\n",
+    )
+}
+
+#[test]
+fn ieeeeqnarray_fixture_body_is_structure_surrounding_reflows() {
+    let input = ieeeeqnarray_fixture();
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s)
+                if s.contains("must stay inside IEEEeqnarray and must not reflow as prose")
+        )),
+        "IEEEeqnarray body must be Structure, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p)
+                if p.contains("must stay inside IEEEeqnarray and must not reflow as prose")
+        )),
+        "IEEEeqnarray body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains(
+            "This is a long sentence that must stay inside IEEEeqnarray and must not reflow as prose."
+        ),
+        "IEEEeqnarray body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the array.\nSecond sentence."),
+        "prose after IEEEeqnarray must still reflow, got:\n{out}"
+    );
+    assert!(
+        !out.contains("After the array. Second sentence."),
+        "fused surrounding prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+#[test]
+fn leftover_overleaf_envs_are_structure_and_do_not_reflow() {
+    for (name, opener) in [
+        ("IEEEeqnarray", "\\begin{IEEEeqnarray}{rCl}"),
+        ("IEEEeqnarray*", "\\begin{IEEEeqnarray*}{rCl}"),
+        ("subeqnarray", "\\begin{subeqnarray}"),
+        ("subeqnarray*", "\\begin{subeqnarray*}"),
+        ("xltabular", "\\begin{xltabular}{\\textwidth}{l}"),
+        ("math*", "\\begin{math*}"),
+    ] {
+        let input = format!(
+            "{opener}\nThis is a long sentence that must stay inside {name} and must not reflow as prose. Another sentence stays put.\n\\end{{{name}}}\nAfter the array. Second sentence.\n"
+        );
+        let fused = format!(
+            "This is a long sentence that must stay inside {name} and must not reflow as prose. Another sentence stays put."
+        );
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains(&fused))),
+            "{name} body must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("must not reflow"))),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&fused),
+            "{name} body must not split into prose sentences, got:\n{out}"
+        );
+        assert!(
+            !out.contains(&format!(
+                "inside {name} and must not reflow as prose.\nAnother"
+            )),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the array.\nSecond sentence."),
+            "prose after {name} must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+}


### PR DESCRIPTION
vissue: snapper-twmw (parent snapper-etv7). GitHub #181.

unanimous-green-70 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Add leftover Overleaf names to NON_PROSE_ENVS: IEEEeqnarray,
IEEEeqnarray*, subeqnarray, subeqnarray*, xltabular, math*. Names-only.

## Test plan
- rustc tests in tests/latex_ieeeeqnarray_xltabular.rs
- terra: cargo test parser::latex