### PR TITLE
fix(markdown): treat 0-3 space ATX headings as Structure

### DIFF
--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -6,7 +6,10 @@ use crate::parser::{
     push_prose_line,
 };
 
-static HEADING_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(#{1,6}\s+)(.*)$").unwrap());
+/// CommonMark 0.31.2 §4.2 ATX heading: 0–3 spaces, then 1–6 `#`, then
+/// whitespace. Four spaces is indented code (ex. 80), not a heading.
+static HEADING_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^( {0,3}#{1,6}\s+)(.*)$").unwrap());
 
 static FENCED_CODE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(`{3,}|~{3,})").unwrap());
 
@@ -1004,6 +1007,7 @@ impl FormatParser for MarkdownParser {
             //   ### 1.
             //   `cargo binstall` (preferred binary install)
             // CommonMark ATX headings are single-line; do not reflow them.
+            // 0–3 space indent is still a heading (CM 0.31.2 §4.2).
             if HEADING_RE.is_match(line_text) {
                 close_list_item(
                     &mut in_list_item,
@@ -1953,6 +1957,38 @@ mod tests {
         let regions = MarkdownParser.parse(input);
         assert_eq!(regions.len(), 1);
         assert_eq!(regions[0], Region::Structure("## My Heading".to_string()));
+    }
+
+    #[test]
+    fn three_space_atx_heading_is_structure() {
+        // snapper-zogf / GitHub #171 — CommonMark 0.31.2 §4.2 ex. 79.
+        let input = "   # Title. Still the title.\n\nBody sentence one. Body sentence two.\n";
+        let regions = MarkdownParser.parse(input);
+        assert!(
+            matches!(
+                &regions[0],
+                Region::Structure(s) if s == "   # Title. Still the title.\n"
+            ),
+            "indented ATX line including three spaces must be Structure, got: {:?}",
+            regions[0]
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("Still the title"))),
+            "heading title must not be Prose: {regions:?}"
+        );
+        let prose: Vec<_> = regions
+            .iter()
+            .filter_map(|r| match r {
+                Region::Prose(p) => Some(p.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            prose.iter().any(|p| p.contains("Body sentence one")),
+            "body must stay Prose: {regions:?}"
+        );
     }
 
     #[test]

--- a/tests/md_atx_heading_indent.rs
+++ b/tests/md_atx_heading_indent.rs
@@ -1,0 +1,97 @@
+//! GitHub #171 / snapper-zogf: CommonMark ATX headings allow 0–3
+//! spaces of indent. `HEADING_RE` was `^(#{1,6}\\s+)`, so a
+//! three-space `# Title` never matched and the title reflowed as Prose.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::markdown::MarkdownParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn md_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Markdown,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture: three-space ATX heading plus two-sentence body.
+fn three_space_atx_fixture() -> &'static str {
+    concat!(
+        "   # Title. Still the title.\n",
+        "\n",
+        "Body sentence one. Body sentence two.\n",
+    )
+}
+
+#[test]
+fn three_space_atx_heading_is_structure_body_still_splits() {
+    let input = three_space_atx_fixture();
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s == "   # Title. Still the title.\n"
+        )),
+        "ATX line including the three spaces must be Structure, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("Still the title"))),
+        "heading title must not be Prose: {regions:?}"
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("Body sentence one"))),
+        "body must stay Prose, got: {regions:?}"
+    );
+
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert!(
+        out.starts_with("   # Title. Still the title.\n"),
+        "heading must stay one Structure line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("Title.\nStill") && !out.contains("Title.\n   Still"),
+        "must not reflow the ATX title, got:\n{out}"
+    );
+    assert!(
+        out.contains("Body sentence one.\nBody sentence two."),
+        "body Prose must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("Body sentence one. Body sentence two."),
+        "fused body must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+}
+
+#[test]
+fn atx_heading_indent_zero_to_three_is_structure_four_is_code() {
+    for n in 0..=3 {
+        let pad = " ".repeat(n);
+        let line = format!("{pad}# Title. Still the title.");
+        let regions = MarkdownParser.parse(&line);
+        assert_eq!(
+            regions,
+            vec![Region::Structure(line.clone())],
+            "{n}-space ATX must be Structure"
+        );
+    }
+    let four = "    # Title. Still the title.\n";
+    let regions = MarkdownParser.parse(four);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Code { body, .. } if body.contains("# Title"))),
+        "four-space line is indented code, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains("# Title"))),
+        "four-space # must not be an ATX heading, got: {regions:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-zogf (parent snapper-etv7). GitHub #171.

unanimous-green-72 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

CommonMark 0.31.2 sec 4.2 allows 0-3 spaces of indent before an ATX
marker. HEADING_RE required column 0, so a three-space heading was
prose and the title reflowed.

## Test plan
- rustc tests in tests/md_atx_heading_indent.rs
- terra: cargo test parser::markdown