### PR TITLE
fix(md): cap ordered list markers at 9 digits

### DIFF
--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -18,16 +18,18 @@ static FENCED_CODE_RE: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^(`{3,}|~
 static FENCED_LANG_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(?:`{3,}|~{3,})\s*([A-Za-z0-9_+.\-]+)").unwrap());
 
-/// CommonMark list marker: 0–3 spaces, then `-`/`*`/`+` or `1.`/`1)`, then a space.
+/// CommonMark list marker: 0–3 spaces, then `-`/`*`/`+` or 1–9 digits plus
+/// `.`/`)`, then a space. Ten or more digits is prose (spec 0.31.2 sec 5.2).
 /// Four or more spaces is indented code, not a list (spec 0.31.2 ex. 289).
 static LIST_ITEM_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^( {0,3}(?:[-*+]|\d+[.)]) )(.*)$").unwrap());
+    LazyLock::new(|| Regex::new(r"^( {0,3}(?:[-*+]|\d{1,9}[.)]) )(.*)$").unwrap());
 
 /// List-looking line at any indent (including 4+ spaces). LIST_ITEM_RE is
 /// 0–3 only; a 4-space dash is indented code, but after a blank we still
 /// need the shape so hang-relative close can hand it to snapper-tupp.
+/// Digit cap matches LIST_ITEM_RE (CommonMark 1–9).
 static LIST_LOOKING_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[\t ]*(?:[-*+]|\d+[.)]) ").unwrap());
+    LazyLock::new(|| Regex::new(r"^[\t ]*(?:[-*+]|\d{1,9}[.)]) ").unwrap());
 
 /// Markdown blockquote prefix: optional indent plus one or more `>`
 /// each followed by an optional space (CommonMark 0.31.2 ex. 229).
@@ -1876,6 +1878,25 @@ mod tests {
                 .iter()
                 .any(|r| matches!(r, Region::Structure(s) if s.contains("with a pipe"))),
             "prose pipe must not become Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn ten_digit_ordered_marker_is_prose() {
+        let input = "1234567890. This is a long sentence. Another sentence.";
+        let regions = MarkdownParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("1234567890."))),
+            "10-digit opener must stay Prose, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("1234567890.")
+            )),
+            "10-digit opener must not be a list Structure, got: {regions:?}"
         );
     }
 

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -435,7 +435,9 @@ fn is_ordered_list_marker(word: &str) -> bool {
     if delim != b'.' && delim != b')' {
         return false;
     }
-    bytes[..bytes.len() - 1].iter().all(|b| b.is_ascii_digit())
+    let digits = &bytes[..bytes.len() - 1];
+    // Markdown-only caller. CommonMark 0.31.2 sec 5.2: 1–9 arabic digits.
+    (1..=9).contains(&digits.len()) && digits.iter().all(|b| b.is_ascii_digit())
 }
 
 fn ordered_list_start(text: &str) -> bool {
@@ -444,7 +446,7 @@ fn ordered_list_start(text: &str) -> bool {
     while i < bytes.len() && bytes[i].is_ascii_digit() {
         i += 1;
     }
-    if i == 0 {
+    if i == 0 || i > 9 {
         return false;
     }
     matches!(bytes.get(i), Some(b'.') | Some(b')')) && matches!(bytes.get(i + 1), Some(b' ') | None)
@@ -510,7 +512,21 @@ fn md_list_start(text: &str) -> bool {
     text.starts_with("- ")
         || text.starts_with("* ")
         || text.starts_with("+ ")
-        || ordered_list_start(text)
+        || md_ordered_list_start(text)
+}
+
+/// CommonMark 0.31.2 sec 5.2: 1–9 arabic digits, then `.`/`)`.
+/// Ten or more digits is prose, so wrap must not escape it as a marker.
+fn md_ordered_list_start(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == 0 || i > 9 {
+        return false;
+    }
+    matches!(bytes.get(i), Some(b'.') | Some(b')')) && matches!(bytes.get(i + 1), Some(b' ') | None)
 }
 
 fn md_link_ref_def(text: &str) -> bool {
@@ -1243,6 +1259,14 @@ mod tests {
         assert!(!md_same_line_ol_opener("0.\nA."));
         assert!(!md_same_line_ol_opener("0."));
         assert!(!md_same_line_ol_opener("Hello. 0. A."));
+    }
+
+    #[test]
+    fn md_ordered_list_start_caps_at_nine_digits() {
+        assert!(md_ordered_list_start("123456789. "));
+        assert!(!md_ordered_list_start("1234567890. "));
+        assert!(is_ordered_list_marker("123456789."));
+        assert!(!is_ordered_list_marker("1234567890."));
     }
 
     #[test]
@@ -2233,6 +2257,31 @@ They are endowed with reason and conscience and should act towards one another i
                 "wrap must not invent a block:\n{result}"
             );
         }
+    }
+
+    #[test]
+    fn wrap_created_ten_digit_opener_is_not_escaped() {
+        let config = crate::FormatConfig {
+            format: crate::format::Format::Markdown,
+            max_width: 23,
+            ..Default::default()
+        };
+        let nine = crate::format_text("The options are apples 123456789. oranges extra.", &config)
+            .unwrap();
+        assert!(
+            nine.lines().any(|l| l.starts_with("123456789\\. ")),
+            "9-digit wrap-created opener must escape:\n{nine}"
+        );
+        let ten = crate::format_text("The options are apples 1234567890. oranges extra.", &config)
+            .unwrap();
+        assert!(
+            !ten.contains('\\'),
+            "10-digit wrap-created opener is prose, not a list:\n{ten}"
+        );
+        assert!(
+            ten.lines().any(|l| l.starts_with("1234567890. ")),
+            "10-digit number may start a wrap line:\n{ten}"
+        );
     }
 
     #[test]

--- a/tests/md_ol_ten_digit.rs
+++ b/tests/md_ol_ten_digit.rs
@@ -1,0 +1,118 @@
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::markdown::MarkdownParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+/// snapper-sp7k / GitHub #172: CommonMark 0.31.2 sec 5.2 and pulldown
+/// `scan_list_marker_with_indent` cap ordered markers at 9 digits.
+/// `1234567890.` is prose, not a list. Oracle stays one `<p>`.
+
+fn md_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Markdown,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "1234567890. This is a long sentence. Another sentence."
+}
+
+#[test]
+fn ten_digit_marker_is_prose_not_a_list() {
+    let input = ticket_fixture();
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("1234567890."))),
+        "10-digit opener must stay Prose, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("1234567890.")
+        )),
+        "10-digit opener must not be a list Structure, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| match r {
+            Region::Structure(s) => {
+                let t = s.trim();
+                !t.is_empty()
+                    && t.chars()
+                        .all(|c| c.is_ascii_digit() || c == '.' || c == ')')
+            }
+            _ => false,
+        }),
+        "must not invent an ordered-list Structure, got: {regions:?}"
+    );
+}
+
+#[test]
+fn ten_digit_fixture_stays_one_paragraph() {
+    let input = ticket_fixture();
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert!(
+        !out.contains("            Another sentence."),
+        "must not hang-indent as a 10-digit list, got:\n{out}"
+    );
+    assert!(
+        out.contains("Another sentence."),
+        "second sentence must remain, got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Markdown, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+    let twice = format_text(&out, &md_cfg()).unwrap();
+    assert_eq!(out, twice, "10-digit prose must be identity, got:\n{twice}");
+}
+
+#[test]
+fn nine_digit_marker_is_still_a_list() {
+    let input = "123456789. This is a long sentence. Another sentence.";
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "123456789. ")),
+        "9-digit opener must stay a list, got: {regions:?}"
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("This is a long sentence."))),
+        "9-digit item body must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert!(
+        out.contains("           Another sentence."),
+        "9-digit list must hang the next sentence, got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Markdown, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn ten_digit_paren_marker_is_prose() {
+    let input = "1234567890) This is a long sentence. Another sentence.";
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("1234567890)"))),
+        "10-digit paren opener must stay Prose, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("1234567890)")
+        )),
+        "10-digit paren opener must not be a list Structure, got: {regions:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-sp7k (parent snapper-etv7). GitHub #172.

unanimous-green-73 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

CommonMark 0.31.2 sec 5.2 and pulldown reject 10+ digit openers.
Treat 1234567890. as prose so the paragraph stays one p.

## Test plan
- rustc tests in tests/md_ol_ten_digit.rs
- terra: cargo test parser::markdown reflow