### PR TITLE
fix(rst): treat footnotes and citations as hung prose

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -15,6 +15,21 @@ static CODE_DIRECTIVE_RE: LazyLock<Regex> = LazyLock::new(|| {
 static GRID_TABLE_TOP_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\+-[-+]+-\+ *$").unwrap());
 
+/// Docutils `explicit.constructs` footnote then citation (before comment).
+/// Footnote label: `[0-9]+` / `#` / `#simplename` / `*`. Citation: `simplename`.
+/// `Inliner.simplename` ASCII: alphanumerics with internal `-._+:`.
+static FOOTNOTE_CITATION_MARKER_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(concat!(
+        r"^\.\. +\[(?:",
+        r"[0-9]+",
+        r"|#(?:[A-Za-z0-9]+(?:[-._+:][A-Za-z0-9]+)*)?",
+        r"|\*",
+        r"|[A-Za-z0-9]+(?:[-._+:][A-Za-z0-9]+)*",
+        r")\](?: +|$)",
+    ))
+    .unwrap()
+});
+
 /// Docutils `Body.patterns['option_marker']`: short `-a`/`+v`, long
 /// `--long`/`/V`, optional arg (`--input=file`, `-b file`, `<file>`),
 /// comma groups, then two-or-more spaces or end of line.
@@ -39,8 +54,9 @@ impl FormatParser for RstParser {
 
 /// Line-based RST parser. Handles directives, literal blocks (indented
 /// and quoted), doctest blocks, sections, field lists, option lists,
-/// comments, anonymous hyperlink targets, line blocks, tables, definition
-/// lists, and block-quote hang spaces as structure regions.
+/// footnotes, citations, comments, anonymous hyperlink targets, line
+/// blocks, tables, definition lists, and block-quote hang spaces as
+/// structure regions.
 fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut regions = Vec::new();
     let mut current_prose = String::new();
@@ -239,6 +255,24 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             // Docutils accepts a two-space body; +3 is convention only.
             directive_indent = leading + 2;
             in_directive = true;
+            i += 1;
+            continue;
+        }
+
+        // Footnote / citation. Docutils explicit.constructs matches these
+        // before comment, so `.. [1]` is not a comment (GitHub #175).
+        // Marker is Structure; same-line body is hung Prose.
+        if let Some(marker_len) = rst_footnote_citation_marker_len(line_text) {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            list_hang = Some(marker_len);
+            regions.push(SpannedRegion::structure(
+                input,
+                ByteSpan::new(line.start, line.start + marker_len),
+            ));
+            if line_text.len() > marker_len {
+                current_prose.push_str(line_text[marker_len..].trim());
+                prose_span = Some(ByteSpan::new(line.start + marker_len, line.end));
+            }
             i += 1;
             continue;
         }
@@ -588,10 +622,24 @@ pub(crate) fn is_rst_anonymous_target(trimmed: &str) -> bool {
     trimmed == "__" || trimmed.starts_with("__ ")
 }
 
-/// True when `trimmed` is an RST comment opener, not a `.. name::` directive.
+/// Byte length of a Docutils footnote or citation opener on `line`,
+/// including leading indent and the space after `]`.
+/// `None` when the line is a comment or other explicit markup.
+pub(crate) fn rst_footnote_citation_marker_len(line: &str) -> Option<usize> {
+    let indent = line.len() - line.trim_start().len();
+    FOOTNOTE_CITATION_MARKER_RE
+        .find(&line[indent..])
+        .map(|m| indent + m.end())
+}
+
+/// True when `trimmed` is an RST comment opener, not a `.. name::`
+/// directive and not a footnote/citation (`.. [1]`, `.. [CIT2002]`).
 /// Bare `..` (no trailing space) is a valid opener; so is `.. text`.
 pub(crate) fn is_rst_comment_opener(trimmed: &str) -> bool {
     if trimmed.contains("::") {
+        return false;
+    }
+    if rst_footnote_citation_marker_len(trimmed).is_some() {
         return false;
     }
     trimmed == ".." || trimmed.starts_with(".. ") || trimmed.starts_with("..\t")
@@ -2365,6 +2413,35 @@ mod tests {
         assert!(!is_rst_comment_opener(".. note::"));
         assert!(!is_rst_comment_opener("..."));
         assert!(!is_rst_comment_opener("Hello"));
+        assert!(!is_rst_comment_opener(".. [1]"));
+        assert!(!is_rst_comment_opener(".. [#]"));
+        assert!(!is_rst_comment_opener(".. [*]"));
+        assert!(!is_rst_comment_opener(".. [CIT2002]"));
+        assert!(is_rst_comment_opener(".. [not closed"));
+        assert!(is_rst_comment_opener(".. [1]no-space"));
+        assert!(is_rst_comment_opener(".. [not a footnote]"));
+    }
+
+    #[test]
+    fn footnote_citation_marker_follows_docutils() {
+        assert_eq!(rst_footnote_citation_marker_len(".. [1] "), Some(7));
+        assert_eq!(rst_footnote_citation_marker_len(".. [#] "), Some(7));
+        assert_eq!(rst_footnote_citation_marker_len(".. [*] "), Some(7));
+        assert_eq!(rst_footnote_citation_marker_len(".. [CIT2002] "), Some(13));
+        assert_eq!(rst_footnote_citation_marker_len(".. [1]"), Some(6));
+        assert_eq!(rst_footnote_citation_marker_len("  .. [1] text"), Some(9));
+        assert_eq!(rst_footnote_citation_marker_len(".. [#note] x"), Some(11));
+        assert_eq!(rst_footnote_citation_marker_len("..[1] text"), None);
+        assert_eq!(rst_footnote_citation_marker_len(".. [1]no-space"), None);
+        assert_eq!(rst_footnote_citation_marker_len(".. [not closed"), None);
+        assert_eq!(
+            rst_footnote_citation_marker_len(".. This is a comment."),
+            None
+        );
+        assert_eq!(
+            rst_footnote_citation_marker_len(".. [not a footnote]"),
+            None
+        );
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1085,6 +1085,11 @@ fn hanging_indent_width(s: &str) -> usize {
     if crate::parser::rst::rst_line_block_marker_len(s) == Some(s.len()) {
         return s.chars().count();
     }
+    // RST footnote/citation (`.. [1] `, `.. [CIT2002] `): hang at
+    // marker width so the body stays a hung paragraph (GitHub #175).
+    if crate::parser::rst::rst_footnote_citation_marker_len(s) == Some(s.len()) {
+        return s.chars().count();
+    }
     // Parser markers are `core` plus one or more trailing spaces; leading
     // indent is part of the hang so nested `   - ` continues at column 5.
     // Extra spaces after `*` (`*  Candidate:`) stay in the hang so a
@@ -1741,6 +1746,12 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_prefix("|   "), "    ");
         assert_eq!(hanging_indent_width("  | "), 4);
         assert_eq!(hanging_indent_width("|"), 0);
+        assert_eq!(hanging_indent_width(".. [1] "), 7);
+        assert_eq!(hanging_indent_width(".. [#] "), 7);
+        assert_eq!(hanging_indent_width(".. [*] "), 7);
+        assert_eq!(hanging_indent_width(".. [CIT2002] "), 13);
+        assert_eq!(hanging_prefix(".. [1] "), "       ");
+        assert_eq!(hanging_prefix(".. [CIT2002] "), "             ");
     }
 
     #[test]

--- a/tests/rst_footnotes_citations.rs
+++ b/tests/rst_footnotes_citations.rs
@@ -1,0 +1,118 @@
+//! snapper-17lc / GitHub #175: RST footnotes and citations are not comments.
+//! `.. [1]` is Structure; the body is hung Prose that still splits.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture: footnote reference paragraph plus `.. [1]` definition.
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "See [1]_. Next sentence.\n",
+        "\n",
+        ".. [1] Footnote text. Second sentence.\n",
+    )
+}
+
+#[test]
+fn footnote_opener_is_structure_body_is_hung_prose() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == ".. [1] ")),
+        ".. [1] must be Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains("Footnote text.") && s.contains("Second sentence.")
+        )),
+        "footnote body must be Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("Footnote text")
+        )),
+        "footnote body must not stay Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn footnote_fixture_body_splits_and_hangs() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "See [1]_.\n",
+            "Next sentence.\n",
+            "\n",
+            ".. [1] Footnote text.\n",
+            "       Second sentence.\n",
+        ),
+        "footnote opener stays; body hangs and splits, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &rst_cfg()).unwrap(),
+        out,
+        "hung footnote must be identity, got:\n{out}"
+    );
+}
+
+#[test]
+fn auto_symbol_and_citation_are_structure_plus_hung_prose() {
+    for (marker, hang) in [
+        (".. [#] ", "       "),
+        (".. [*] ", "       "),
+        (".. [CIT2002] ", "             "),
+    ] {
+        let input =
+            format!("See the note. Next sentence.\n\n{marker}Footnote text. Second sentence.\n");
+        let regions = RstParser.parse(&input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == marker)),
+            "{marker:?} must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("Footnote text.") && s.contains("Second sentence.")
+            )),
+            "{marker:?} body must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("Footnote text")
+            )),
+            "{marker:?} body must not stay Structure, got {regions:?}"
+        );
+        let out = format_text(&input, &rst_cfg()).unwrap();
+        let expected = format!(
+            "See the note.\nNext sentence.\n\n{marker}Footnote text.\n{hang}Second sentence.\n"
+        );
+        assert_eq!(
+            out, expected,
+            "{marker:?} body must hang and split, got:\n{out}"
+        );
+        assert_eq!(
+            format_text(&out, &rst_cfg()).unwrap(),
+            out,
+            "{marker:?} hung fixture must be identity, got:\n{out}"
+        );
+    }
+}


### PR DESCRIPTION
vissue: snapper-17lc (parent snapper-etv7). GitHub #175.

unanimous-green-75 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Docutils explicit.constructs matches footnote/citation before comment.
Classify `.. [1]` as Structure and reflow the body as hung Prose.

## Test plan
- rustc tests in tests/rst_footnotes_citations.rs
- terra: cargo test parser::rst reflow