### PR TITLE
fix(org): require space or EOL after hash comments

### DIFF
--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -153,10 +153,11 @@ impl OrgParser {
         trimmed.starts_with("#+") && !Self::is_block_begin(line) && !Self::is_block_end(line)
     }
 
-    /// Check if a line is a comment (starts with #, but not #+)
+    /// org.el `org-comment-regexp`: `^[ \t]*#(?: |$)`.
+    /// `#foo` is prose; `#` and `# comment` are comments. `#+` is a keyword.
     fn is_comment(line: &str) -> bool {
-        let trimmed = line.trim_start();
-        trimmed.starts_with('#') && !trimmed.starts_with("#+")
+        let trimmed = line.trim_start_matches([' ', '\t']);
+        trimmed == "#" || trimmed.starts_with("# ")
     }
 
     /// Check if a line is a table row
@@ -2291,5 +2292,114 @@ mod tests {
             "sentence after the citation must still reflow, got:\n{wrapped}"
         );
         assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+    }
+
+    /// Ticket fixture (Format::Org / GitHub #177): org-comment-regexp
+    /// requires space or EOL after `#`. `#foo` is prose.
+    fn hash_comment_space_or_eol_fixture() -> &'static str {
+        concat!(
+            "#not-a-comment This is a long sentence that must reflow as prose. Second sentence.\n",
+            "# This is a real comment and must stay frozen.\n",
+        )
+    }
+
+    #[test]
+    fn hash_without_space_is_not_a_comment() {
+        assert!(!OrgParser::is_comment(
+            "#not-a-comment This is a long sentence that must reflow as prose."
+        ));
+        assert!(!OrgParser::is_comment("#foo"));
+        assert!(!OrgParser::is_comment("#+TITLE: x"));
+        assert!(!OrgParser::is_comment("prose"));
+        assert!(OrgParser::is_comment("# This is a real comment"));
+        assert!(OrgParser::is_comment("#"));
+        assert!(OrgParser::is_comment("  # indented comment"));
+        assert!(OrgParser::is_comment("\t# tab-indented comment"));
+    }
+
+    #[test]
+    fn hash_without_space_is_prose_and_splits() {
+        use crate::format_text;
+
+        let input = hash_comment_space_or_eol_fixture();
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains("#not-a-comment")
+                        && p.contains("must reflow as prose.")
+                        && p.contains("Second sentence.")
+            )),
+            "#not-a-comment line must be Prose, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("#not-a-comment")
+            )),
+            "#not-a-comment must not freeze as Structure, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s)
+                    if s.contains("# This is a real comment and must stay frozen.")
+            )),
+            "#<space> comment must stay Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("# This is a real comment")
+            )),
+            "#<space> comment must not be Prose, got: {regions:?}"
+        );
+
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains(
+                "#not-a-comment This is a long sentence that must reflow as prose.\nSecond sentence."
+            ),
+            "#not-a-comment prose must split, got:\n{out}"
+        );
+        assert!(
+            !out.contains(
+                "#not-a-comment This is a long sentence that must reflow as prose. Second sentence."
+            ),
+            "#not-a-comment must not stay fused, got:\n{out}"
+        );
+        assert!(
+            out.lines()
+                .any(|l| l == "# This is a real comment and must stay frozen."),
+            "real comment must stay frozen, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn bare_hash_eol_is_a_comment() {
+        use crate::format_text;
+
+        let input = "#\nAfter. Next.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.trim() == "#")),
+            "bare # must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains('#'))),
+            "bare # must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("#\nAfter.\nNext."),
+            "bare # stays a comment; following prose reflows, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }
 }

--- a/tests/org_hash_comment.rs
+++ b/tests/org_hash_comment.rs
@@ -1,0 +1,45 @@
+//! GitHub #177 / snapper-stms: Org hash comments require a space or EOL.
+//! `#not-a-comment` is prose and must reflow; `# comment` stays Structure.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Org).
+fn hash_comment_space_or_eol_fixture() -> &'static str {
+    concat!(
+        "#not-a-comment This is a long sentence that must reflow as prose. Second sentence.\n",
+        "# This is a real comment and must stay frozen.\n",
+    )
+}
+
+#[test]
+fn hash_without_space_is_prose_and_splits() {
+    let input = hash_comment_space_or_eol_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "#not-a-comment This is a long sentence that must reflow as prose.\n",
+            "Second sentence.\n",
+            "# This is a real comment and must stay frozen.\n",
+        ),
+        "#not-a-comment must split; real comment stays frozen, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn bare_hash_eol_stays_comment() {
+    let out = format_text("#\nAfter. Next.\n", &org_cfg()).unwrap();
+    assert_eq!(out, "#\nAfter.\nNext.\n", "got:\n{out}");
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
vissue: snapper-stms (parent snapper-etv7). GitHub #177.

unanimous-green-76 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

org.el org-comment-regexp is ^[ \t]*#(?: |$). #foo is prose, not a
comment. # and # comment stay Structure.

## Test plan
- rustc tests in tests/org_hash_comment.rs
- terra: cargo test parser::org