### PR TITLE
fix(org): treat #+BEGIN: dynamic blocks as Structure

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -20,6 +20,7 @@ The classification depends on the format.
 :END:
 - Non-source =#+BEGIN_*= ...
 =#+END_*= fences, and the bodies of literal blocks (example, export, comment)
+- Dynamic blocks (=#+BEGIN: NAME= ... =#+END:=), including the generated body
 - Quote, verse, and center open/close lines; verse inner lines stay unjoined
 - =:PROPERTIES:= ...
 =:END:= drawers

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -147,10 +147,39 @@ impl OrgParser {
             || t.starts_with("CLOCK:")
     }
 
+    /// org-element-dynamic-block-open-re: `^[ \t]*#\+BEGIN:[ \t]+\S`
+    /// (`case-fold-search t`). A name is required; bare `#+BEGIN:` is a keyword.
+    fn is_dynamic_block_begin(line: &str) -> bool {
+        let t = line.trim_start_matches([' ', '\t']);
+        let upper = t.to_ascii_uppercase();
+        let Some(rest) = upper.strip_prefix("#+BEGIN:") else {
+            return false;
+        };
+        !rest.trim_start_matches([' ', '\t']).is_empty()
+    }
+
+    /// org-element-dynamic-block-parser closer: `^[ \t]*#\+END:?[ \t]*$`
+    /// (`case-fold-search t`). Does not match `#+END_NAME`.
+    fn is_dynamic_block_end(line: &str) -> bool {
+        let t = line.trim_start_matches([' ', '\t']);
+        let upper = t.to_ascii_uppercase();
+        let rest = if let Some(r) = upper.strip_prefix("#+END:") {
+            r
+        } else if let Some(r) = upper.strip_prefix("#+END") {
+            r
+        } else {
+            return false;
+        };
+        rest.trim_matches([' ', '\t']).is_empty()
+    }
+
     /// Check if a line is a keyword/directive (#+KEYWORD:)
     fn is_keyword(line: &str) -> bool {
         let trimmed = line.trim_start();
-        trimmed.starts_with("#+") && !Self::is_block_begin(line) && !Self::is_block_end(line)
+        trimmed.starts_with("#+")
+            && !Self::is_block_begin(line)
+            && !Self::is_block_end(line)
+            && !Self::is_dynamic_block_begin(line)
     }
 
     /// Check if a line is a comment (starts with #, but not #+)
@@ -361,6 +390,7 @@ impl FormatParser for OrgParser {
         // Quote/verse/center are containers (inner Prose); other names are opaque.
         let mut block_stack: Vec<OpenGreater> = Vec::new();
         let mut in_src_block = false;
+        let mut in_dynamic_block = false;
         let mut src_lang: Option<String> = None;
         let mut src_header = ByteSpan::default();
         let mut src_body_start = 0usize;
@@ -576,6 +606,25 @@ impl FormatParser for OrgParser {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 list_item_indent = None;
                 regions.push(SpannedRegion::blank(input, line.span()));
+                continue;
+            }
+
+            // Inside a dynamic block (`#+BEGIN: NAME` ... `#+END:`) -- Structure.
+            if in_dynamic_block {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                if Self::is_dynamic_block_end(line_text) {
+                    in_dynamic_block = false;
+                }
+                regions.push(SpannedRegion::structure(input, line.span()));
+                continue;
+            }
+
+            // #+BEGIN: NAME -- org-element dynamic block. Body stays Structure
+            // through #+END: / #+END (GitHub #178).
+            if Self::is_dynamic_block_begin(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                in_dynamic_block = true;
+                regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
 

--- a/tests/org_dynamic_block.rs
+++ b/tests/org_dynamic_block.rs
@@ -1,0 +1,65 @@
+//! GitHub #178 / snapper-57v0: Org dynamic-block bodies stay Structure.
+//! `#+BEGIN: NAME` … `#+END:` is not a one-line keyword plus Prose.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Org / GitHub #178).
+fn clocktable_fixture() -> &'static str {
+    concat!(
+        "#+BEGIN: clocktable :scope file\n",
+        "This is a long sentence inside a dynamic block that must stay frozen. Second sentence.\n",
+        "#+END:\n",
+        "Following paragraph. Another sentence.\n",
+    )
+}
+
+#[test]
+fn dynamic_block_body_stays_frozen_following_prose_splits() {
+    let input = clocktable_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "#+BEGIN: clocktable :scope file\n",
+            "This is a long sentence inside a dynamic block that must stay frozen. Second sentence.\n",
+            "#+END:\n",
+            "Following paragraph.\n",
+            "Another sentence.\n",
+        ),
+        "BEGIN through END stays frozen; following prose splits, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn lowercase_dynamic_block_is_also_structure() {
+    let input = concat!(
+        "#+begin: clocktable :scope file\n",
+        "Frozen one. Frozen two.\n",
+        "#+end:\n",
+        "After. Next.\n",
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "#+begin: clocktable :scope file\n",
+            "Frozen one. Frozen two.\n",
+            "#+end:\n",
+            "After.\n",
+            "Next.\n",
+        ),
+        "case-fold BEGIN:/END: must freeze the body, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
vissue: snapper-57v0 (parent snapper-etv7). GitHub #178.

unanimous-green-77 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

org-element-dynamic-block-open-re is #+BEGIN: NAME, not #+BEGIN_.
Freeze the body through #+END: so clocktable contents stay Structure
while the following paragraph still splits.

## Test plan
- rustc tests in tests/org_dynamic_block.rs
- terra: cargo test parser::org