### PR TITLE
fix(org): reflow special-block interiors as prose

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -21,7 +21,8 @@ The classification depends on the format.
 - Non-source =#+BEGIN_*= ...
 =#+END_*= fences, and the bodies of literal blocks (example, export, comment)
 - Dynamic blocks (=#+BEGIN: NAME= ... =#+END:=), including the generated body
-- Quote, verse, and center open/close lines; verse inner lines stay unjoined
+- Quote, verse, center, and special-block (NOTE and other unknown NAME) open/close lines; verse inner lines stay unjoined
+- Special-block interiors (NOTE, ABSTRACT, WARNING, ...) reflow as prose
 - =:PROPERTIES:= ...
 =:END:= drawers
 - =#+KEYWORD:= directives (TITLE, AUTHOR, DATE, OPTIONS, etc.)
@@ -48,7 +49,7 @@ The classification depends on the format.
 :END:
 - Paragraph text
 - List item text (after the marker); continuation sentences hang at the marker width so Org rejoins the item
-- Quote, verse, and center inner text (verse stays line-preserving)
+- Quote, verse, center, and special-block inner text (verse stays line-preserving)
 
 *** Inline tokens (kept atomic)
 :PROPERTIES:

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -345,8 +345,10 @@ impl OrgParser {
     }
 
     /// org-element quote-block / verse-block / center-block contain paragraphs.
+    /// org-element special-block (NOTE, ABSTRACT, WARNING, ...) contains
+    /// paragraphs. Only lesser/literal names stay opaque (GitHub #179).
     fn is_container_block_name(name: &str) -> bool {
-        matches!(name, "QUOTE" | "VERSE" | "CENTER")
+        !matches!(name, "SRC" | "EXAMPLE" | "EXPORT" | "COMMENT")
     }
 
     fn greater_kind(name: &str) -> GreaterKind {

--- a/tests/org_special_block.rs
+++ b/tests/org_special_block.rs
@@ -1,0 +1,62 @@
+//! GitHub #179 / snapper-0rny: Org special-block interiors are prose.
+//! `#+BEGIN_NOTE` fences stay Structure; the body splits. After the note
+//! still reflows.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Org).
+fn special_block_note_fixture() -> &'static str {
+    concat!(
+        "#+BEGIN_NOTE\n",
+        "Quoted one. Quoted two.\n",
+        "#+END_NOTE\n",
+        "After the note. More.\n",
+    )
+}
+
+#[test]
+fn note_special_block_inner_prose_splits() {
+    let input = special_block_note_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "#+BEGIN_NOTE\n",
+            "Quoted one.\n",
+            "Quoted two.\n",
+            "#+END_NOTE\n",
+            "After the note.\n",
+            "More.\n",
+        ),
+        "NOTE fences stay; inner and following prose must split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn leftover_special_block_names_reflow_like_note() {
+    for name in ["TIP", "WARNING", "ABSTRACT", "PROOF"] {
+        let input = format!(
+            "#+BEGIN_{name}\nQuoted one. Quoted two.\n#+END_{name}\nAfter the note. More.\n"
+        );
+        let out = format_text(&input, &org_cfg()).unwrap();
+        assert_eq!(
+            out,
+            format!(
+                "#+BEGIN_{name}\nQuoted one.\nQuoted two.\n#+END_{name}\nAfter the note.\nMore.\n"
+            ),
+            "{name} is the same special-block class as NOTE, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+}


### PR DESCRIPTION
vissue: snapper-0rny (parent snapper-etv7). GitHub #179.

unanimous-green-79 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

org-element special-block is a greater element with paragraph
contents. Invert is_container_block_name so #+BEGIN_NOTE and other
unknown names reflow; example/export/comment stay literal.

## Test plan
- rustc tests in tests/org_special_block.rs
- terra: cargo test parser::org