### PR TITLE
fix(rst): blank closes comments so later indent is a hung quote

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -48,6 +48,7 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut in_definition = false;
     let mut definition_indent: usize = 0;
     // Comment body: indented lines after `..` / `.. text` stay Structure.
+    // A blank closes the comment (GitHub #176).
     let mut in_comment = false;
     let mut comment_indent: usize = 0;
     // Hang column of the current list item (`- ` → 2) or block quote.
@@ -172,14 +173,21 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         }
 
         // Inside comment body (indented lines after `..` / `.. text`).
+        // Docutils explicit markup / comment() ends at a blank, so a
+        // later indent is a hung quote, not more comment Structure
+        // (GitHub #176).
         if in_comment {
-            let leading = line_text.len() - line_text.trim_start().len();
-            if line_text.trim().is_empty() || leading >= comment_indent {
-                regions.push(SpannedRegion::structure(input, line.span()));
-                i += 1;
-                continue;
+            if line_text.trim().is_empty() {
+                in_comment = false;
+            } else {
+                let leading = line_text.len() - line_text.trim_start().len();
+                if leading >= comment_indent {
+                    regions.push(SpannedRegion::structure(input, line.span()));
+                    i += 1;
+                    continue;
+                }
+                in_comment = false;
             }
-            in_comment = false;
         }
 
         // Blank line
@@ -2099,6 +2107,77 @@ mod tests {
             out.contains("\n   Second sentence."),
             "second comment body line must keep indent, got:\n{out}"
         );
+    }
+
+    /// GitHub #176 / snapper-k7bb ticket fixture.
+    fn comment_blank_then_quote_fixture() -> &'static str {
+        concat!(
+            ".. Comment sentence. Still comment.\n",
+            "\n",
+            "    This is a block quote. Another sentence.\n",
+        )
+    }
+
+    #[test]
+    fn comment_blank_closes_later_indent_is_hung_quote() {
+        let regions = RstParser.parse(comment_blank_then_quote_fixture());
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(".. Comment sentence. Still comment.")
+            )),
+            "comment opener must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(r, Region::BlankLines(_))),
+            "blank must close the comment, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("This is a block quote")
+            )),
+            "post-blank indent must not stay comment Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("This is a block quote.") && s.contains("Another sentence.")
+            )),
+            "post-blank indent must be hung Prose, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "    ")),
+            "quote hang spaces must be Structure, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn comment_blank_then_quote_splits_and_hangs() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(comment_blank_then_quote_fixture(), &cfg).unwrap();
+        assert_eq!(
+            out,
+            concat!(
+                ".. Comment sentence. Still comment.\n",
+                "\n",
+                "    This is a block quote.\n",
+                "    Another sentence.\n",
+            ),
+            "blank must close the comment; quote must hang and split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 
     #[test]

--- a/tests/rst_comment_blank.rs
+++ b/tests/rst_comment_blank.rs
@@ -1,0 +1,83 @@
+//! snapper-k7bb / GitHub #176: RST comments close on a blank line.
+//! A later indent is a hung quote that still splits, not comment Structure.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        ".. Comment sentence. Still comment.\n",
+        "\n",
+        "    This is a block quote. Another sentence.\n",
+    )
+}
+
+#[test]
+fn comment_opener_is_structure_blank_closes() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(".. Comment sentence. Still comment.")
+        )),
+        "comment opener must be Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(r, Region::BlankLines(_))),
+        "blank must close the comment, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("This is a block quote")
+        )),
+        "post-blank indent must not stay comment Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn later_indent_is_hung_quote_and_splits() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("This is a block quote.") && s.contains("Another sentence.")
+        )),
+        "post-blank indent must be hung Prose, got {regions:?}"
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "    ")),
+        "quote hang spaces must be Structure, got {regions:?}"
+    );
+    let out = format_text(ticket_fixture(), &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            ".. Comment sentence. Still comment.\n",
+            "\n",
+            "    This is a block quote.\n",
+            "    Another sentence.\n",
+        ),
+        "blank must close the comment; quote must hang and split, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &rst_cfg()).unwrap(),
+        out,
+        "hung quote must be identity, got:\n{out}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-k7bb (parent snapper-etv7). GitHub #176.

unanimous-green-78 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

in_comment treated empty lines as Structure, so a later indented
quote stayed comment body. A blank now closes the comment and the
following indent hangs as Prose that still splits.

## Test plan
- rustc tests in tests/rst_comment_blank.rs
- terra: cargo test parser::rst