### PR TITLE
ci(docs): do not serialize PR builds on the pages lock

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -6,10 +6,13 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
+# One Cloudflare site: serialize only main/tag deploys. PR builds must
+# not share that lock or the job never finishes on the current SHA.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build-deploy:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -71,8 +71,10 @@ gh workflow run crates.yml --ref main -f dry_run=true
 4. Open the release PR. `main` is branch-protected with `enforce_admins`:
    `gh pr merge` is refused until the required checks are green (not pending).
    Required on every PR: `check (ubuntu-latest)`, `check (macos-latest)`,
-   `Public availability contract`, `Link check`, `build-deploy`.
+   `Public availability contract`, `Link check`.
    Those include the dogfood `--check` on docs and examples.
+   `build-deploy` still runs (docs site on `main` / tags) but is not a
+   merge gate: a single `pages` lock cannot finish on every open PR head.
    Path-filtered jobs (WASM, wheels, crates) are not required because they
    do not run on every PR; still wait for them when they do run.
    Use `gh pr merge --auto` to queue; do not merge while anything required


### PR DESCRIPTION
The merge gate required `build-deploy`. Every PR shared concurrency
group `pages`, so the check never completed on the current SHA and
auto-merge stayed BLOCKED.

`build-deploy` is no longer a required check. This PR also splits
concurrency: each PR builds on its own group; main/tag deploys stay
serialized. Deploy to Cloudflare is still main/tags only.

## Test plan
- confirm main required checks no longer include build-deploy
- confirm this PR can merge on ubuntu/macos/link/avail