### PR TITLE
fix(md): keep sentence break after punct inside link tails

### DIFF
--- a/src/parser/span.rs
+++ b/src/parser/span.rs
@@ -200,13 +200,122 @@ pub fn iter_lines(input: &str) -> Vec<Line<'_>> {
     lines
 }
 
+/// Closers peeled after `.!?` (quotes, brackets, markup). A Markdown
+/// `](url)` dest is not a closer: strip it first so the period inside
+/// `[the docs.](http://x.com)` is visible.
+const SENTENCE_CLOSERS: [char; 14] = [
+    '"', '\'', ')', ']', '}', '*', '_', '`', '~', '/', '=', '+', '\u{201d}', '\u{2019}',
+];
+
 /// True when `s` ends a sentence: `.!?` plus optional quotes, brackets,
-/// or markup closers.
+/// markup closers, or a trailing Markdown `](url)` destination.
 pub fn ends_sentence_punct(s: &str) -> bool {
-    let core = s.trim_end().trim_end_matches([
-        '"', '\'', ')', ']', '}', '*', '_', '`', '~', '/', '=', '+', '\u{201d}', '\u{2019}',
-    ]);
+    let mut core = s.trim_end();
+    loop {
+        let next = strip_trailing_md_link_dest(core).trim_end_matches(SENTENCE_CLOSERS);
+        if next.len() == core.len() {
+            break;
+        }
+        core = next;
+    }
     core.ends_with('.') || core.ends_with('!') || core.ends_with('?')
+}
+
+/// If `s` ends with CommonMark `](dest)` or `](dest "title")`, keep the `]`
+/// so [`SENTENCE_CLOSERS`] can peel it. Trailing closers after dest `)`
+/// (`"` / `*` / …) stay part of the dest tail so `trim_end_matches` cannot
+/// eat that `)` first.
+fn strip_trailing_md_link_dest(s: &str) -> &str {
+    let Some(open) = s.rfind("](") else {
+        return s;
+    };
+    if md_inline_dest_consumes(&s[open + 2..]) {
+        &s[..=open]
+    } else {
+        s
+    }
+}
+
+fn only_sentence_closers(s: &str) -> bool {
+    s.chars().all(|c| SENTENCE_CLOSERS.contains(&c))
+}
+
+/// `true` when `s` is dest (optional title), closing `)`, then only closers.
+fn md_inline_dest_consumes(s: &str) -> bool {
+    let Some(n) = md_inline_dest_len(s) else {
+        return false;
+    };
+    let rest = s[n..].trim_start_matches([' ', '\t']);
+    dest_close_then_closers(rest) || md_title_then_close(rest)
+}
+
+fn dest_close_then_closers(s: &str) -> bool {
+    s.strip_prefix(')').is_some_and(only_sentence_closers)
+}
+
+/// CommonMark dest length at the start of `s`. Empty dest is `]()` or `<>`.
+fn md_inline_dest_len(s: &str) -> Option<usize> {
+    let bytes = s.as_bytes();
+    if bytes.first() == Some(&b')') {
+        return Some(0);
+    }
+    if bytes.first() == Some(&b'<') {
+        let mut i = 1;
+        while i < bytes.len() {
+            match bytes[i] {
+                b'\n' | b'\r' | b'<' => return None,
+                b'>' => return Some(i + 1),
+                b'\\' if i + 1 < bytes.len() => i += 2,
+                _ => i += 1,
+            }
+        }
+        return None;
+    }
+    let mut i = 0;
+    let mut nest = 0i32;
+    while i < bytes.len() {
+        match bytes[i] {
+            0x00..=0x20 => break,
+            b'(' => nest += 1,
+            b')' => {
+                if nest == 0 {
+                    break;
+                }
+                nest -= 1;
+            }
+            b'\\' if i + 1 < bytes.len() => i += 1,
+            _ => {}
+        }
+        i += 1;
+    }
+    if nest != 0 || i == 0 {
+        None
+    } else {
+        Some(i)
+    }
+}
+
+fn md_title_then_close(s: &str) -> bool {
+    let bytes = s.as_bytes();
+    let close = match bytes.first() {
+        Some(b'"') => b'"',
+        Some(b'\'') => b'\'',
+        Some(b'(') => b')',
+        _ => return false,
+    };
+    let mut i = 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if i + 1 < bytes.len() => i += 2,
+            b if b == close => {
+                let after = s[i + 1..].trim_start_matches([' ', '\t']);
+                return dest_close_then_closers(after);
+            }
+            b'\n' | b'\r' => return false,
+            _ => i += 1,
+        }
+    }
+    false
 }
 
 /// Insert the join between accumulated prose lines.
@@ -311,5 +420,37 @@ mod tests {
             wrap,
             "The experiment ran for several weeks using the usual protocol."
         );
+    }
+
+    #[test]
+    fn ends_sentence_punct_sees_period_inside_md_link() {
+        assert!(ends_sentence_punct("See [the docs.](http://x.com)"));
+        assert!(ends_sentence_punct("See [the docs!](http://x.com)"));
+        assert!(ends_sentence_punct("See [the docs?](http://x.com)"));
+        assert!(ends_sentence_punct(
+            r#"See [the docs.](http://x.com "title")"#
+        ));
+        assert!(ends_sentence_punct("See [the docs.](<http://x.com>)"));
+        assert!(ends_sentence_punct("See [the docs.](<http://x.com/a)b>)"));
+        assert!(ends_sentence_punct("See [the docs.](http://x.com)\""));
+        assert!(ends_sentence_punct("See [the docs.](http://x.com)**"));
+        assert!(ends_sentence_punct(
+            "See [the docs.](http://x.com/foo(bar))"
+        ));
+        assert!(!ends_sentence_punct("See [the docs](http://x.com)"));
+        assert!(!ends_sentence_punct(
+            "See [the docs](http://x.com) for more"
+        ));
+        assert!(!ends_sentence_punct(
+            "Visit [Example Inc.](http://x.com) now"
+        ));
+    }
+
+    #[test]
+    fn join_prose_gap_keeps_break_after_md_link_sentence() {
+        let mut prose = String::from("See [the docs.](http://x.com)");
+        join_prose_gap(&mut prose);
+        prose.push_str("iCloud");
+        assert_eq!(prose, "See [the docs.](http://x.com)\niCloud");
     }
 }

--- a/src/parser/span.rs
+++ b/src/parser/span.rs
@@ -288,11 +288,7 @@ fn md_inline_dest_len(s: &str) -> Option<usize> {
         }
         i += 1;
     }
-    if nest != 0 || i == 0 {
-        None
-    } else {
-        Some(i)
-    }
+    if nest != 0 || i == 0 { None } else { Some(i) }
 }
 
 fn md_title_then_close(s: &str) -> bool {

--- a/tests/md_link_tail_sentence.rs
+++ b/tests/md_link_tail_sentence.rs
@@ -5,7 +5,7 @@
 //! `format_text` `Format::Markdown` `max_width=0`.
 
 use snapper_fmt::format::Format;
-use snapper_fmt::{format_text, FormatConfig};
+use snapper_fmt::{FormatConfig, format_text};
 
 fn md_cfg() -> FormatConfig {
     FormatConfig {

--- a/tests/md_link_tail_sentence.rs
+++ b/tests/md_link_tail_sentence.rs
@@ -1,0 +1,27 @@
+//! snapper-62xn / GitHub #170: join gap misses sentence punct inside
+//! markdown link tails.
+//!
+//! `See [the docs.](http://x.com)\niCloud` must stay two lines under
+//! `format_text` `Format::Markdown` `max_width=0`.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::{format_text, FormatConfig};
+
+fn md_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Markdown,
+        max_width: 0,
+        ..Default::default()
+    }
+}
+
+#[test]
+fn markdown_link_tail_icloud_stays_two_lines() {
+    let input = "See [the docs.](http://x.com)\niCloud\n";
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "must keep break after link-tail sentence, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
vissue: snapper-62xn (parent snapper-7ict). GitHub #170.

unanimous-green-82 4/4 GREEN after rustfmt child snapper-erx4 (impl-A,
impl-B, rev-1, rev-2).

ends_sentence_punct peeled trailing ) so a Markdown ](url) hid the
period in [the docs.](http://x.com). Strip the dest tail first so
See [the docs.](http://x.com)\niCloud stays two lines.

## Test plan
- rustc tests in tests/md_link_tail_sentence.rs
- terra: cargo test parser::span