### PR TITLE
fix(rst): keep consecutive Jinja statements on their own lines

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -54,9 +54,9 @@ impl FormatParser for RstParser {
 
 /// Line-based RST parser. Handles directives, literal blocks (indented
 /// and quoted), doctest blocks, sections, field lists, option lists,
-/// footnotes, citations, comments, anonymous hyperlink targets, line
-/// blocks, tables, definition lists, and block-quote hang spaces as
-/// structure regions.
+/// footnotes, citations, comments, anonymous hyperlink targets, Jinja
+/// statements (`{% ... %}`), line blocks, tables, definition lists, and
+/// block-quote hang spaces as structure regions.
 fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut regions = Vec::new();
     let mut current_prose = String::new();
@@ -286,6 +286,17 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             // Any indent past the opener is body (docutils).
             comment_indent = leading + 1;
             in_comment = true;
+            i += 1;
+            continue;
+        }
+
+        // Jinja statement (`{% ... %}`). sphinx-jinja / Jinja2 block
+        // delimiters. Consecutive statements stay unjoined; they are
+        // not RST prose (GitHub #196).
+        if is_rst_jinja_statement(trimmed) {
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            list_hang = None;
+            regions.push(SpannedRegion::structure(input, line.span()));
             i += 1;
             continue;
         }
@@ -620,6 +631,17 @@ pub(crate) fn is_rst_doctest_opener(trimmed: &str) -> bool {
 /// Sibling of `..` explicit markup. `__https` (no space) is not a target.
 pub(crate) fn is_rst_anonymous_target(trimmed: &str) -> bool {
     trimmed == "__" || trimmed.starts_with("__ ")
+}
+
+/// Whole-line Jinja statement: `{%` … `%}` with optional whitespace-control
+/// `-`/`+` on either brace (`{%-`, `{%+`, `-%}`, `+%}`).
+///
+/// Kanged from Jinja2 / sphinx-jinja block delimiters (`block_start_string`
+/// / `block_end_string`), not a pandoc RST parse (GitHub #196).
+pub(crate) fn is_rst_jinja_statement(trimmed: &str) -> bool {
+    let s = trimmed.trim_end();
+    // `{%-` / `{%+` / `-%}` / `+%}` still start with `{%` and end with `%}`.
+    s.starts_with("{%") && s.ends_with("%}")
 }
 
 /// Byte length of a Docutils footnote or citation opener on `line`,
@@ -3311,6 +3333,84 @@ mod tests {
         assert!(
             wrap_out.contains("-a            "),
             "wrap must not eat option-column spaces, got:\n{wrap_out}"
+        );
+    }
+
+    #[test]
+    fn jinja_statement_matcher_follows_jinja2_block_delimiters() {
+        assert!(is_rst_jinja_statement(r#"{% set foo = "foo" %}"#));
+        assert!(is_rst_jinja_statement(r#"{% set bar = "bar" %}"#));
+        assert!(is_rst_jinja_statement("{%- set foo = \"foo\" %}"));
+        assert!(is_rst_jinja_statement("{% set foo = \"foo\" -%}"));
+        assert!(is_rst_jinja_statement("{%+ set foo = \"foo\" +%}"));
+        assert!(is_rst_jinja_statement("{% set foo = \"foo\" %}  "));
+        assert!(is_rst_jinja_statement("{% for k, v in topics.items() %}"));
+        assert!(is_rst_jinja_statement("{% endfor %}"));
+        assert!(!is_rst_jinja_statement("{{ foo }}"));
+        assert!(!is_rst_jinja_statement("{# comment #}"));
+        assert!(!is_rst_jinja_statement(r#"The tag {% set x = 1 %}"#));
+        assert!(!is_rst_jinja_statement("{% set foo = \"foo\""));
+        assert!(!is_rst_jinja_statement("set foo = \"foo\" %}"));
+        assert!(!is_rst_jinja_statement("Hello world."));
+        assert!(!is_rst_jinja_statement(".. code-block:: python"));
+    }
+
+    /// GitHub #196 / snapper-79b2: consecutive `{% ... %}` lines stay Structure.
+    #[test]
+    fn consecutive_jinja_statements_are_structure_not_prose() {
+        let input = concat!(
+            "         {% set foo = \"foo\" %}\n",
+            "         {% set bar = \"bar\" %}\n",
+            "\n",
+            "         .. code-block:: python\n",
+            "\n",
+            "            pass\n",
+        );
+        let regions = RstParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r#"{% set foo = "foo" %}"#)
+            )),
+            "first Jinja statement must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r#"{% set bar = "bar" %}"#)
+            )),
+            "second Jinja statement must be Structure, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("{% set foo") || s.contains("{% set bar")
+            )),
+            "Jinja statements must not be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("set foo") && s.contains("set bar")
+            )),
+            "Jinja statements must not join into one Prose region, got {regions:?}"
+        );
+        let code = regions.iter().find_map(|r| match r {
+            Region::Code {
+                lang, header, body, ..
+            } => Some((lang.clone(), header.clone(), body.clone())),
+            _ => None,
+        });
+        let (lang, header, body) = code.expect("expected .. code-block:: as Region::Code");
+        assert_eq!(lang.as_deref(), Some("python"));
+        assert!(
+            header.contains(".. code-block:: python"),
+            "code-block header must stay structure/code, got {header:?}"
+        );
+        assert!(
+            body.contains("pass"),
+            "code-block body must stay, got {body:?}"
         );
     }
 

--- a/tests/fixtures/rst_jinja_statements.rst
+++ b/tests/fixtures/rst_jinja_statements.rst
@@ -1,0 +1,6 @@
+         {% set foo = "foo" %}
+         {% set bar = "bar" %}
+
+         .. code-block:: python
+
+            pass

--- a/tests/rst_jinja_statements.rs
+++ b/tests/rst_jinja_statements.rs
@@ -1,0 +1,113 @@
+//! snapper-79b2 / GitHub #196: consecutive Jinja statements stay two lines.
+//! sphinx-jinja / Jinja2 `{% ... %}` block delimiters, not a pandoc parse.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// GitHub #196 fixture (Format::Rst).
+fn ticket_fixture() -> &'static str {
+    include_str!("fixtures/rst_jinja_statements.rst")
+}
+
+#[test]
+fn jinja_statements_are_structure_not_prose() {
+    let regions = RstParser.parse(ticket_fixture());
+    for needle in [r#"{% set foo = "foo" %}"#, r#"{% set bar = "bar" %}"#] {
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains(needle))),
+            "Jinja statement {needle:?} must be Structure, got {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(s) if s.contains(needle))),
+            "Jinja statement {needle:?} must not be Prose, got {regions:?}"
+        );
+    }
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains("set foo") && s.contains("set bar")
+        )),
+        "consecutive Jinja statements must not join into one Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn following_code_block_stays_structure() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| match r {
+            Region::Code { header, .. } => header.contains(".. code-block:: python"),
+            Region::Structure(s) => s.contains(".. code-block:: python"),
+            _ => false,
+        }),
+        "following .. code-block:: must stay Structure/Code, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(".. code-block::") || s.contains("pass")
+        )),
+        "following .. code-block:: must not be Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn consecutive_jinja_statements_stay_two_lines() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    let joined = r#"{% set foo = "foo" %} {% set bar = "bar" %}"#;
+    assert!(
+        !out.contains(joined),
+        "must not join consecutive Jinja statements, got:\n{out}"
+    );
+    let foo_lines = out
+        .lines()
+        .filter(|l| l.contains(r#"{% set foo = "foo" %}"#))
+        .count();
+    let bar_lines = out
+        .lines()
+        .filter(|l| l.contains(r#"{% set bar = "bar" %}"#))
+        .count();
+    assert_eq!(
+        foo_lines, 1,
+        "foo statement must stay one line, got:\n{out}"
+    );
+    assert_eq!(
+        bar_lines, 1,
+        "bar statement must stay one line, got:\n{out}"
+    );
+    assert_eq!(
+        out, input,
+        "Jinja statements and following code-block must stay identity, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &rst_cfg()).unwrap(),
+        out,
+        "hung Jinja fixture must be identity, got:\n{out}"
+    );
+}
+
+#[test]
+fn flush_left_jinja_statements_stay_two_lines() {
+    let input = concat!("{% set foo = \"foo\" %}\n", "{% set bar = \"bar\" %}\n",);
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "flush-left Jinja statements must stay two lines, got:\n{out}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-79b2 (parent snapper-etv7). GitHub #196.

unanimous-green-83 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Whole-line {% ... %} is Structure so sphinx-jinja setup blocks are
not SemBr-joined. Following .. code-block:: stays Code.

## Test plan
- rustc tests in tests/rst_jinja_statements.rs
- terra: cargo test parser::rst