### PR TITLE
fix(rst): hang and reflow admonition and figure bodies

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -153,7 +153,8 @@ These tokens within prose are not split across lines:
 :PROPERTIES:
 :CUSTOM_ID: rst-structure
 :END:
-- Non-code directives (=.. math::=, =.. image::=, etc.) and their indented bodies
+- Non-code opaque directives (=.. math::=, =.. image::=, =.. raw::=, =.. include::=, =.. csv-table::=) and their indented bodies
+- Container directive openers (=.. note::=, =.. warning::=, =.. figure::=, =.. topic::=, =.. sidebar::=, =.. container::=) and their =:option:= fields; the indented body is prose
 - Literal blocks (text after =::= with indented or line-prefix-quoted content)
 - Section titles and underlines (=====, =-----=, etc.)
 - Field lists (=:Author:=, =:Date:=, etc.)
@@ -172,6 +173,7 @@ These tokens within prose are not split across lines:
 :CUSTOM_ID: rst-prose
 :END:
 - Paragraph text between structural elements
+- Indented bodies of container directives (admonitions, figure captions, topic, sidebar, container); hang spaces stay structure
 
 *** Auto-detection
 :PROPERTIES:

--- a/src/check.rs
+++ b/src/check.rs
@@ -537,7 +537,7 @@ mod tests {
     }
 
     #[test]
-    fn rst_title_and_note_body_are_not_prose() {
+    fn rst_title_is_not_prose_note_body_is_fused() {
         let input = concat!(
             "Title Here. With Period.\n",
             "========================\n",
@@ -554,8 +554,14 @@ mod tests {
         assert_no_kind_on(
             &found,
             DiagnosticKind::Fused,
-            &[1, 4, 6],
-            "rst title and note body must not be fused",
+            &[1, 4],
+            "rst title and note opener must not be fused",
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 6 && d.kind == DiagnosticKind::Fused),
+            "rst note body should be fused prose, got {found:?}"
         );
         assert!(
             found

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@
 //!   `Region::Code` (comment reflow via `[code.<lang>]`, optional formatters)
 //! - **LaTeX**: preamble and math preserved; `minted` / `lstlisting` are code regions
 //! - **Markdown**: front matter and headings preserved; fenced blocks are code regions
-//! - **RST**: directives and literals preserved; `.. code-block::` is a code region
+//! - **RST**: directives and literals preserved; admonition/figure/topic/sidebar/container bodies reflow; `.. code-block::` is a code region
 //! - **Plaintext**: everything treated as prose
 //!
 //! ## Library usage

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -56,7 +56,10 @@ impl FormatParser for RstParser {
 /// and quoted), doctest blocks, sections, field lists, option lists,
 /// footnotes, citations, comments, anonymous hyperlink targets, Jinja
 /// statements (`{% ... %}`), line blocks, tables, definition lists, and
-/// block-quote hang spaces as structure regions.
+/// block-quote hang spaces as structure regions. Docutils container
+/// directives (admonitions, figure, topic, sidebar, container)
+/// nested-parse their body: the opener and option fields stay Structure;
+/// the body hangs as Prose.
 fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut regions = Vec::new();
     let mut current_prose = String::new();
@@ -246,11 +249,19 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             continue;
         }
 
-        // RST directive (.. something::)
+        // RST directive (`.. name::`). Container directives (admonitions,
+        // figure, topic, sidebar, container) nested-parse their body:
+        // the opener and `:option:` fields stay Structure; the body
+        // hangs and reflows like a block quote. Opaque names keep the
+        // old freeze (GitHub #54).
         let trimmed = line_text.trim_start();
         if trimmed.starts_with(".. ") && trimmed.contains("::") {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
             regions.push(SpannedRegion::structure(input, line.span()));
+            if rst_directive_name(trimmed).is_some_and(|n| is_rst_container_directive(&n)) {
+                i += 1;
+                continue;
+            }
             let leading = line_text.len() - trimmed.len();
             // Docutils accepts a two-space body; +3 is convention only.
             directive_indent = leading + 2;
@@ -654,6 +665,49 @@ pub(crate) fn rst_footnote_citation_marker_len(line: &str) -> Option<usize> {
     FOOTNOTE_CITATION_MARKER_RE
         .find(&line[indent..])
         .map(|m| indent + m.end())
+}
+
+/// Docutils directive name on a `.. name::` line, ASCII-lowercased.
+/// `None` when the line is not an explicit-markup directive.
+fn rst_directive_name(trimmed: &str) -> Option<String> {
+    let rest = trimmed.strip_prefix("..")?;
+    if !rest.starts_with([' ', '\t']) {
+        return None;
+    }
+    let rest = rest.trim_start();
+    let name_end = rest.find("::")?;
+    let name = rest[..name_end].trim();
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+    {
+        return None;
+    }
+    Some(name.to_ascii_lowercase())
+}
+
+/// Docutils admonitions plus figure/topic/sidebar/container: bodies
+/// nested-parse, so hang + reflow. Option fields stay Structure via
+/// the field-list arm. Other directive names stay opaque.
+fn is_rst_container_directive(name: &str) -> bool {
+    matches!(
+        name,
+        "note"
+            | "warning"
+            | "caution"
+            | "danger"
+            | "tip"
+            | "important"
+            | "hint"
+            | "error"
+            | "attention"
+            | "admonition"
+            | "figure"
+            | "topic"
+            | "sidebar"
+            | "container"
+    )
 }
 
 /// True when `trimmed` is an RST comment opener, not a `.. name::`
@@ -2644,9 +2698,25 @@ mod tests {
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 
+    /// Ticket fixture (Format::Rst): container body hangs.
+    fn note_container_fixture() -> &'static str {
+        concat!(
+            ".. note::\n",
+            "\n",
+            "   This is a long note sentence that must reflow. Second sentence.\n",
+            "\n",
+            "After the note. Next.\n",
+        )
+    }
+
     #[test]
-    fn two_space_directive_option_and_body_are_structure() {
-        let input = ".. note::\n  :class: test\n\n  Body.\n";
+    fn container_directive_option_is_structure_body_is_prose() {
+        let input = concat!(
+            ".. note::\n",
+            "  :class: test\n",
+            "\n",
+            "  This is a long note sentence that must reflow. Second sentence.\n",
+        );
         let regions = RstParser.parse(input);
         assert!(
             regions
@@ -2661,21 +2731,52 @@ mod tests {
             "two-space option must be Structure, got {regions:?}"
         );
         assert!(
-            regions
-                .iter()
-                .any(|r| matches!(r, Region::Structure(s) if s.contains("Body."))),
-            "two-space body must be Structure, got {regions:?}"
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("This is a long note sentence that must reflow.")
+                        && s.contains("Second sentence.")
+            )),
+            "container body must be hung Prose, got {regions:?}"
         );
         assert!(
-            !regions
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("This is a long note sentence")
+            )),
+            "container body must not freeze as Structure, got {regions:?}"
+        );
+        assert!(
+            regions
                 .iter()
-                .any(|r| matches!(r, Region::Prose(s) if s.contains("Body."))),
-            "two-space body must not be Prose, got {regions:?}"
+                .any(|r| matches!(r, Region::Structure(s) if s == "  ")),
+            "container body hang must be Structure, got {regions:?}"
         );
     }
 
     #[test]
-    fn reporter_two_space_directive_body_is_identity_under_format() {
+    fn opaque_directive_body_stays_structure() {
+        for input in [
+            ".. raw:: html\n\n  <p>This is a long note sentence that must reflow. Second sentence.</p>\n",
+            ".. include:: foo.rst\n  :start-after: Body.\n",
+            ".. csv-table:: Title\n  :header: \"a\", \"b\"\n\n  \"1\", \"2\"\n",
+        ] {
+            let regions = RstParser.parse(input);
+            assert!(
+                !regions.iter().any(|r| matches!(
+                    r,
+                    Region::Prose(s)
+                        if s.contains("This is a long")
+                            || s.contains("start-after")
+                            || s.contains("\"1\", \"2\"")
+                )),
+                "opaque body must not be Prose, got {regions:?} for {input:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn reporter_two_space_container_option_is_identity_under_format() {
         use crate::format::Format;
         use crate::{FormatConfig, format_text};
 
@@ -2688,7 +2789,7 @@ mod tests {
         let out = format_text(input, &cfg).unwrap();
         assert_eq!(
             out, input,
-            "reporter two-space directive body must stay identity under format, got:\n{out}"
+            "single-sentence container body must stay identity under format, got:\n{out}"
         );
         assert!(
             out.contains("\n  :class: test"),
@@ -2698,6 +2799,132 @@ mod tests {
             out.contains("\n  Body."),
             "body must keep two-space indent, got:\n{out}"
         );
+    }
+
+    #[test]
+    fn note_container_fixture_body_hangs_and_splits() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let input = note_container_fixture();
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains(".. note::"))),
+            "note opener must stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("This is a long note sentence that must reflow.")
+                        && s.contains("Second sentence.")
+            )),
+            "note body must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("This is a long note sentence")
+            )),
+            "note body must not freeze as Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("After the note.") && s.contains("Next.")
+            )),
+            "prose after the note must remain Prose, got {regions:?}"
+        );
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out,
+            concat!(
+                ".. note::\n",
+                "\n",
+                "   This is a long note sentence that must reflow.\n",
+                "   Second sentence.\n",
+                "\n",
+                "After the note.\n",
+                "Next.\n",
+            ),
+            "note body must hang and split; following prose must reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    #[test]
+    fn leftover_container_names_reflow_like_note() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        for name in [
+            "warning",
+            "caution",
+            "danger",
+            "tip",
+            "important",
+            "hint",
+            "error",
+            "attention",
+            "admonition",
+            "figure",
+            "topic",
+            "sidebar",
+            "container",
+        ] {
+            let arg = if matches!(name, "figure" | "admonition" | "sidebar" | "topic") {
+                " Title"
+            } else {
+                ""
+            };
+            let input = format!(
+                ".. {name}::{arg}\n\n   This is a long note sentence that must reflow. Second sentence.\n\nAfter the note. Next.\n"
+            );
+            let regions = RstParser.parse(&input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Prose(s)
+                        if s.contains("This is a long note sentence that must reflow.")
+                            && s.contains("Second sentence.")
+                )),
+                "{name} body must be Prose, got {regions:?}"
+            );
+            assert!(
+                !regions.iter().any(|r| matches!(
+                    r,
+                    Region::Structure(s) if s.contains("This is a long note sentence")
+                )),
+                "{name} body must not freeze as Structure, got {regions:?}"
+            );
+            let out = format_text(&input, &cfg).unwrap();
+            assert!(
+                out.contains(
+                    "   This is a long note sentence that must reflow.\n   Second sentence.\n"
+                ),
+                "{name} body must hang and split, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the note.\nNext."),
+                "prose after {name} must still reflow, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &cfg).unwrap(), out);
+        }
     }
 
     #[test]

--- a/tests/rst_container_directives.rs
+++ b/tests/rst_container_directives.rs
@@ -1,0 +1,180 @@
+//! RST container directive bodies hang and reflow.
+//! Docutils admonitions/figure/topic/sidebar nested-parse their body.
+//! Option fields stay Structure; code-block/raw/include/csv-table stay opaque.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst).
+fn note_container_fixture() -> &'static str {
+    concat!(
+        ".. note::\n",
+        "\n",
+        "   This is a long note sentence that must reflow. Second sentence.\n",
+        "\n",
+        "After the note. Next.\n",
+    )
+}
+
+#[test]
+fn note_container_body_hangs_and_splits() {
+    let input = note_container_fixture();
+    let regions = RstParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(".. note::"))),
+        "note opener must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("This is a long note sentence that must reflow.")
+                    && s.contains("Second sentence.")
+        )),
+        "note body must be hung Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("This is a long note sentence")
+        )),
+        "note body must not freeze as Structure, got {regions:?}"
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "   ")),
+        "note body hang spaces must be Structure, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            ".. note::\n",
+            "\n",
+            "   This is a long note sentence that must reflow.\n",
+            "   Second sentence.\n",
+            "\n",
+            "After the note.\n",
+            "Next.\n",
+        ),
+        "note body must hang and split; following prose must reflow, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn leftover_container_names_reflow_like_note() {
+    for name in [
+        "warning",
+        "caution",
+        "danger",
+        "tip",
+        "important",
+        "hint",
+        "error",
+        "attention",
+        "admonition",
+        "figure",
+        "topic",
+        "sidebar",
+        "container",
+    ] {
+        let input = format!(
+            ".. {name}::\n\n   This is a long note sentence that must reflow. Second sentence.\n\nAfter the note. Next.\n"
+        );
+        let out = format_text(&input, &rst_cfg()).unwrap();
+        assert_eq!(
+            out,
+            format!(
+                ".. {name}::\n\n   This is a long note sentence that must reflow.\n   Second sentence.\n\nAfter the note.\nNext.\n"
+            ),
+            "{name} is the same container class as note, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+    }
+}
+
+#[test]
+fn container_option_field_stays_structure() {
+    let input = concat!(
+        ".. note::\n",
+        "   :class: test\n",
+        "\n",
+        "   This is a long note sentence that must reflow. Second sentence.\n",
+    );
+    let regions = RstParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(":class: test"))),
+        "option field must stay Structure, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert!(
+        out.contains("   :class: test\n"),
+        "option field must stay identity, got:\n{out}"
+    );
+    assert!(
+        out.contains("   This is a long note sentence that must reflow.\n   Second sentence.\n"),
+        "body after option must hang and split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn opaque_directives_stay_frozen() {
+    for (label, input, needle) in [
+        (
+            "raw",
+            ".. raw:: html\n\n   <p>This is a long note sentence that must reflow. Second sentence.</p>\n",
+            "<p>This is a long note sentence that must reflow. Second sentence.</p>",
+        ),
+        (
+            "include",
+            ".. include:: foo.rst\n   :start-after: This is a long note sentence that must reflow. Second sentence.\n",
+            ":start-after: This is a long note sentence that must reflow. Second sentence.",
+        ),
+        (
+            "csv-table",
+            ".. csv-table:: Title\n   :header: \"a\", \"b\"\n\n   \"This is a long note sentence that must reflow. Second sentence.\", \"x\"\n",
+            "\"This is a long note sentence that must reflow. Second sentence.\", \"x\"",
+        ),
+        (
+            "code-block",
+            ".. code-block:: python\n\n   print(\"This is a long note sentence that must reflow. Second sentence.\")\n",
+            "print(\"This is a long note sentence that must reflow. Second sentence.\")",
+        ),
+    ] {
+        let regions = RstParser.parse(input);
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(s) if s.contains("This is a long note"))),
+            "{label} body must not be Prose, got {regions:?}"
+        );
+        let out = format_text(input, &rst_cfg()).unwrap();
+        assert!(
+            out.contains(needle),
+            "{label} body must stay opaque, got:\n{out}"
+        );
+        assert_eq!(
+            format_text(&out, &rst_cfg()).unwrap(),
+            out,
+            "{label} must be identity, got:\n{out}"
+        );
+    }
+}


### PR DESCRIPTION
vissue: snapper-q88q (parent snapper-etv7). GitHub #203.

unanimous-green-86 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

Docutils nested-parses note/warning/figure/topic/sidebar/container.
Opener and :option: fields stay Structure; the body hangs and splits.
code-block/raw/include/csv-table stay opaque.

## Test plan
- rustc tests in tests/rst_container_directives.rs
- terra: cargo test parser::rst