### PR TITLE
fix(latex): treat fancyvrb BVerbatim and LVerbatim as code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ All notable changes to this project will be documented in this file. See [conven
 
 - - -
 ## Unreleased (main)
+#### Bug Fixes
+- (**latex**) treat fancyvrb `BVerbatim` and `LVerbatim` as code so listing bodies do not reflow as prose (#209)
 
 - - -
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,8 +15,8 @@ pub struct FormatOverrides {
     /// Extra LaTeX environments treated as code (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
     /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
-    /// trivia, and Overleaf Verbatim/boxedverbatim/tcblisting/codeexample;
-    /// entries are added to it.
+    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
+    /// and fancyvrb BVerbatim/LVerbatim; entries are added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,8 +115,8 @@ pub struct FormatConfig {
     pub render_backstop: bool,
     /// Extra LaTeX environments treated as code (no reflow), added to
     /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
-    /// trivia, and Overleaf Verbatim/boxedverbatim/tcblisting/codeexample.
-    /// Empty keeps the built-in list.
+    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
+    /// and fancyvrb BVerbatim/LVerbatim. Empty keeps the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -127,11 +127,13 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Beyond minted/lstlisting/verbatim: latexindent `fileContentsEnvironments`
 /// (`filecontents`, `filecontents*`) and tree-sitter-latex raw trivia envs
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
-/// `sageblock`) plus fancyvrb `verbatim*` / `Verbatim`, moreverb
-/// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, and the
-/// `comment` package env (tree-sitter `comment_environment`: raw through
-/// matching `\end{comment}`). Overleaf `verbatimEnvNames` is Verbatim,
-/// boxedverbatim, tcblisting, codeexample.
+/// `sageblock`) plus fancyvrb `verbatim*` / `Verbatim` / `BVerbatim` /
+/// `LVerbatim`, moreverb `boxedverbatim`, tcolorbox `tcblisting` /
+/// `codeexample`, and the `comment` package env (tree-sitter
+/// `comment_environment`: raw through matching `\end{comment}`).
+/// Overleaf `verbatimEnvNames` is Verbatim, boxedverbatim, tcblisting,
+/// codeexample. fancyvrb `BVerbatim` / `LVerbatim` are the same raw
+/// class as `Verbatim` (GitHub #209).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
@@ -140,6 +142,8 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "verbatim"
             | "verbatim*"
             | "Verbatim"
+            | "BVerbatim"
+            | "LVerbatim"
             | "boxedverbatim"
             | "tcblisting"
             | "codeexample"
@@ -2335,6 +2339,67 @@ Some text.
         );
         assert_eq!(out, input, "Verbatim env must be identity, got:\n{out}");
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #209): fancyvrb BVerbatim and LVerbatim
+    /// are the same raw class as Verbatim.
+    #[test]
+    fn fancyvrb_bverbatim_lverbatim_are_code_not_prose() {
+        use crate::format_text;
+
+        for name in ["BVerbatim", "LVerbatim"] {
+            let input = format!(
+                "\\begin{{document}}\nBefore the listing. More before.\n\\begin{{{name}}}\nThis is a long sentence that must not reflow as prose inside {name}.\n\\end{{{name}}}\nAfter the listing. Second sentence.\n\\end{{document}}\n"
+            );
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Code { body, .. }
+                        if body.contains("This is a long sentence that must not reflow as prose")
+                )),
+                "{name} body must be Code, got: {regions:?}"
+            );
+            assert!(
+                !regions.iter().any(|r| matches!(
+                    r,
+                    Region::Prose(p)
+                        if p.contains("This is a long sentence that must not reflow as prose")
+                )),
+                "{name} body must not leak into Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&format!("\\begin{{{name}}}"))
+                    && out.contains(&format!("\\end{{{name}}}")),
+                "{name} begin/end must stay, got:\n{out}"
+            );
+            assert!(
+                out.contains(&format!(
+                    "This is a long sentence that must not reflow as prose inside {name}."
+                )),
+                "{name} body must not reflow, got:\n{out}"
+            );
+            assert!(
+                !out.contains("This is a long sentence that must not reflow as prose inside\n"),
+                "{name} must stay one source line, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the listing.\nSecond sentence."),
+                "prose after {name} must still split, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+            // Two interior sentences must stay one source line (default
+            // max_width=0 only splits Prose).
+            let two = format!("\\begin{{{name}}}\nFirst line. Second line.\n\\end{{{name}}}\n");
+            let two_out = format_text(&two, &latex_cfg()).unwrap();
+            assert_eq!(two_out, two, "{name} env must be identity, got:\n{two_out}");
+            assert!(
+                !two_out.contains("First line.\nSecond line."),
+                "{name} two-sentence body must not split, got:\n{two_out}"
+            );
+        }
     }
 
     #[test]

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -1,4 +1,5 @@
 //! snapper-3tj3 / GitHub #98: Overleaf verbatimEnvNames are Code, not prose.
+//! GitHub #209: fancyvrb BVerbatim / LVerbatim are the same.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -71,6 +72,72 @@ fn boxedverbatim_tcblisting_codeexample_do_not_reflow() {
         assert!(
             !out.contains("First line.\nSecond line."),
             "{name} must not reflow as prose, got:\n{out}"
+        );
+    }
+}
+
+/// Ticket fixture (GitHub #209): fancyvrb BVerbatim and LVerbatim
+/// bodies stay Code; following prose still splits.
+#[test]
+fn bverbatim_lverbatim_fixture_is_code_and_does_not_reflow() {
+    for name in ["BVerbatim", "LVerbatim"] {
+        let input = format!(
+            concat!(
+                "\\begin{{document}}\n",
+                "Before the listing. More before.\n",
+                "\\begin{{{name}}}\n",
+                "This is a long sentence that must not reflow as prose inside {name}.\n",
+                "\\end{{{name}}}\n",
+                "After the listing. Second sentence.\n",
+                "\\end{{document}}\n",
+            ),
+            name = name
+        );
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. }
+                    if body.contains("This is a long sentence that must not reflow as prose")
+            )),
+            "{name} body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains("This is a long sentence that must not reflow as prose")
+            )),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&format!("\\begin{{{name}}}"))
+                && out.contains(&format!("\\end{{{name}}}")),
+            "{name} begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains(&format!(
+                "This is a long sentence that must not reflow as prose inside {name}."
+            )),
+            "{name} body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("must not reflow as prose inside\n"),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the listing.\nSecond sentence."),
+            "prose after {name} must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let two = format!("\\begin{{{name}}}\nFirst line. Second line.\n\\end{{{name}}}\n");
+        let two_out = format_text(&two, &latex_cfg()).unwrap();
+        assert_eq!(two_out, two, "{name} env must be identity, got:\n{two_out}");
+        assert!(
+            !two_out.contains("First line.\nSecond line."),
+            "{name} two-sentence body must not split, got:\n{two_out}"
         );
     }
 }


### PR DESCRIPTION
vissue: snapper-wvkc (parent snapper-etv7). Closes #209.

fancyvrb BVerbatim and LVerbatim are the same raw class as Verbatim
but were missing from is_builtin_code_env, so listing bodies reflowed
as prose. Classify them as builtin Code through the matching \end.
Following prose still splits.

## Test plan
- rustc tests in tests/latex_verbatim_envs.rs (`bverbatim_lverbatim_fixture_is_code_and_does_not_reflow`)
- `parser::latex::tests::fancyvrb_bverbatim_lverbatim_are_code_not_prose`
- native CLI ticket fixture: body stays one line; `After the listing.` / `Second sentence.`