### PR TITLE
fix(org): hang and reflow #+CAPTION values

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -25,7 +25,8 @@ The classification depends on the format.
 - Special-block interiors (NOTE, ABSTRACT, WARNING, ...) reflow as prose
 - =:PROPERTIES:= ...
 =:END:= drawers
-- =#+KEYWORD:= directives (TITLE, AUTHOR, DATE, OPTIONS, etc.)
+- =#+KEYWORD:= directives (TITLE, AUTHOR, DATE, OPTIONS, NAME, ATTR_*, etc.); =#+CAPTION:= / =#+CAPTION[short]:= opener only
+- Standalone bracket-link lines (=[[file:plot.png]]=)
 - Table rows (lines starting with =|=)
 - Comment lines (starting with =#= but not =#+= )
 - Full headline lines (stars, optional TODO keyword, and title text)
@@ -50,6 +51,7 @@ The classification depends on the format.
 - Paragraph text
 - List item text (after the marker); continuation sentences hang at the marker width so Org rejoins the item
 - Quote, verse, center, and special-block inner text (verse stays line-preserving)
+- =#+CAPTION:= value (org-element-parsed-keywords); continuation sentences hang at the opener width. Dual =#+CAPTION[short]:= keeps the short title on the opener
 
 *** Inline tokens (kept atomic)
 :PROPERTIES:

--- a/src/check.rs
+++ b/src/check.rs
@@ -463,6 +463,38 @@ mod tests {
     }
 
     #[test]
+    fn org_caption_value_is_fused_name_attr_are_not() {
+        let input = concat!(
+            "#+NAME: First sentence. Second sentence.\n",
+            "#+ATTR_LATEX: :width 0.9 :alt First sentence. Second sentence.\n",
+            "#+CAPTION: This is a long figure caption that must reflow as prose. Second sentence.\n",
+            "[[file:plot.png]]\n",
+            "After the figure. More.\n",
+        );
+        let splitter = UnicodeSentenceSplitter::new();
+        let found =
+            collect_diagnostics(input, Format::Org, &splitter, DEFAULT_LONG_THRESHOLD, None);
+        assert_no_kind_on(
+            &found,
+            DiagnosticKind::Fused,
+            &[1, 2, 4],
+            "org NAME/ATTR/link must not be fused",
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 3 && d.kind == DiagnosticKind::Fused),
+            "org CAPTION value should be fused prose, got {found:?}"
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 5 && d.kind == DiagnosticKind::Fused),
+            "prose after the figure should still be fused, got {found:?}"
+        );
+    }
+
+    #[test]
     fn markdown_front_matter_and_setext_are_not_prose() {
         let input = concat!(
             "---\n",

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -39,6 +39,39 @@ pub(crate) fn org_footnote_definition_marker_len(line: &str) -> Option<usize> {
     FOOTNOTE_DEFINITION_RE.find(line).map(|m| m.end())
 }
 
+/// org-element-keyword-re / org-element--affiliated-re (case-fold):
+/// `^[ \t]*#\+CAPTION(?:\[(.*)\])?\+?:[ \t]*`.
+///
+/// `org-element-parsed-keywords` is CAPTION only, so only this opener
+/// splits: the keyword plus optional `[short]` (dual form) and trailing
+/// spaces after `:` are Structure; the value hangs as Prose.
+/// `#+NAME:` / `#+ATTR_*` stay whole-line Structure.
+pub(crate) fn org_caption_marker_len(line: &str) -> Option<usize> {
+    let lead = line.len() - line.trim_start_matches([' ', '\t']).len();
+    let rest = &line[lead..];
+    const KEY: &str = "#+CAPTION";
+    if rest.len() < KEY.len() || !rest[..KEY.len()].eq_ignore_ascii_case(KEY) {
+        return None;
+    }
+    let mut i = KEY.len();
+    let bytes = rest.as_bytes();
+    if i < bytes.len() && bytes[i] == b'[' {
+        let close = rest[i + 1..].find(']')?;
+        i = i + 1 + close + 1;
+    }
+    if i < bytes.len() && bytes[i] == b'+' {
+        i += 1;
+    }
+    if i >= bytes.len() || bytes[i] != b':' {
+        return None;
+    }
+    i += 1;
+    while i < bytes.len() && (bytes[i] == b' ' || bytes[i] == b'\t') {
+        i += 1;
+    }
+    Some(lead + i)
+}
+
 /// org-element / org-mode display math (`$$` or `\[`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DisplayMathDelim {
@@ -204,6 +237,27 @@ impl OrgParser {
     /// Check if a line is a table row
     fn is_table_row(line: &str) -> bool {
         line.trim_start().starts_with('|')
+    }
+
+    /// A line that is only an org bracket link (`[[file:plot.png]]`).
+    /// Figure payloads stay Structure so following prose does not join.
+    fn is_standalone_org_link(line: &str) -> bool {
+        let t = line.trim();
+        let Some(inner) = t.strip_prefix("[[").and_then(|s| s.strip_suffix("]]")) else {
+            return false;
+        };
+        if inner.is_empty() {
+            return false;
+        }
+        match inner.split_once("][") {
+            None => !inner.contains(['[', ']']),
+            Some((link, desc)) => {
+                !link.is_empty()
+                    && !desc.is_empty()
+                    && !link.contains(['[', ']'])
+                    && !desc.contains(['[', ']'])
+            }
+        }
     }
 
     /// Check if a line starts a LaTeX environment (\begin{...})
@@ -643,7 +697,29 @@ impl FormatParser for OrgParser {
                 continue;
             }
 
-            // Keyword/directive
+            // Affiliated CAPTION: org-element-parsed-keywords is CAPTION
+            // only. Opener (optional [short] / append `+`) is Structure;
+            // value hangs. `#+NAME:` / `#+ATTR_*` stay whole-line.
+            if let Some(marker_len) = org_caption_marker_len(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                list_item_indent = Some(marker_len);
+                let marker_span = ByteSpan::new(line.start, line.start + marker_len);
+                regions.push(SpannedRegion::structure(input, marker_span));
+                if line_text.len() > marker_len {
+                    let text = &line_text[marker_len..];
+                    regions.push(SpannedRegion::prose(
+                        text.to_string(),
+                        ByteSpan::new(line.start + marker_len, line.start + line_text.len()),
+                    ));
+                }
+                let term = line.terminator_span();
+                if !term.is_empty() {
+                    regions.push(SpannedRegion::structure(input, term));
+                }
+                continue;
+            }
+
+            // Keyword/directive (`#+NAME:`, `#+ATTR_*`, `#+TITLE:`, …)
             if Self::is_keyword(line_text) {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 regions.push(SpannedRegion::structure(input, line.span()));
@@ -668,8 +744,10 @@ impl FormatParser for OrgParser {
             if line_text.trim_start().starts_with("file:")
                 || line_text.trim_start().starts_with("http://")
                 || line_text.trim_start().starts_with("https://")
+                || Self::is_standalone_org_link(line_text)
             {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                list_item_indent = None;
                 regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
             }
@@ -2637,6 +2715,215 @@ mod tests {
         assert_eq!(
             out, "[fn:note] Footnote text.\n          Second sentence.\n",
             "[fn:note] body must hang and split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (Format::Org / GitHub #204): org-element-parsed-keywords
+    /// is CAPTION only. Opener is Structure; value hangs and splits.
+    fn caption_fixture() -> &'static str {
+        concat!(
+            "#+CAPTION: This is a long figure caption that must reflow as prose. Second sentence.\n",
+            "[[file:plot.png]]\n",
+            "After the figure. More.\n",
+        )
+    }
+
+    #[test]
+    fn caption_marker_follows_org_element_keyword_re() {
+        assert_eq!(org_caption_marker_len("#+CAPTION: "), Some(11));
+        assert_eq!(org_caption_marker_len("#+CAPTION:"), Some(10));
+        assert_eq!(org_caption_marker_len("#+caption: text"), Some(11));
+        assert_eq!(
+            org_caption_marker_len("#+CAPTION[Short. Title.]: "),
+            Some("#+CAPTION[Short. Title.]: ".len())
+        );
+        assert_eq!(
+            org_caption_marker_len(
+                "#+CAPTION: This is a long figure caption that must reflow as prose."
+            ),
+            Some(11)
+        );
+        assert_eq!(org_caption_marker_len("  #+CAPTION: x"), Some(13));
+        assert_eq!(org_caption_marker_len("#+CAPTION+: x"), Some(12));
+        assert_eq!(org_caption_marker_len("#+CAPTION[s]+: x"), Some(15));
+        assert_eq!(org_caption_marker_len("#+NAME: fig"), None);
+        assert_eq!(org_caption_marker_len("#+ATTR_HTML: :alt x"), None);
+        assert_eq!(org_caption_marker_len("#+ATTR_LATEX: :width 1"), None);
+        assert_eq!(org_caption_marker_len("#+TITLE: x"), None);
+        assert_eq!(org_caption_marker_len("#+CAPTIONS: x"), None);
+        assert_eq!(org_caption_marker_len("#+BEGIN_SRC rust"), None);
+        assert_eq!(org_caption_marker_len("See #+CAPTION: x"), None);
+        assert_eq!(org_caption_marker_len("#+CAPTION : x"), None);
+    }
+
+    #[test]
+    fn caption_opener_is_structure_value_is_hung_prose() {
+        let regions = OrgParser.parse(caption_fixture());
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "#+CAPTION: ")),
+            "#+CAPTION: must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("This is a long figure caption that must reflow as prose.")
+                        && s.contains("Second sentence.")
+            )),
+            "CAPTION value must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("This is a long figure caption")
+            )),
+            "CAPTION value must not stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("[[file:plot.png]]")
+            )),
+            "figure link line must stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("After the figure.") && s.contains("More.")
+            )),
+            "following prose must still be Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn caption_fixture_value_splits_and_hangs() {
+        use crate::format_text;
+
+        let input = caption_fixture();
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert_eq!(
+            out,
+            concat!(
+                "#+CAPTION: This is a long figure caption that must reflow as prose.\n",
+                "           Second sentence.\n",
+                "[[file:plot.png]]\n",
+                "After the figure.\n",
+                "More.\n",
+            ),
+            "CAPTION opener stays; value hangs and splits, got:\n{out}"
+        );
+        assert!(
+            !out.lines().any(|l| l == "Second sentence."),
+            "must not emit a column-0 second caption sentence, got:\n{out}"
+        );
+        assert!(
+            !out.contains("[[file:plot.png]] After the figure."),
+            "link line must not join following prose, got:\n{out}"
+        );
+        assert_eq!(
+            format_text(&out, &org_cfg()).unwrap(),
+            out,
+            "hung CAPTION must be identity, got:\n{out}"
+        );
+    }
+
+    #[test]
+    fn caption_dual_short_title_stays_structure() {
+        use crate::format_text;
+
+        let input = "#+CAPTION[Short. Title.]: Long caption. Second.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s == "#+CAPTION[Short. Title.]: "
+            )),
+            "dual [short] must stay in the Structure opener, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("Long caption.") && s.contains("Second.")
+            )),
+            "dual long value must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("Short. Title.")
+            )),
+            "short title must not be Prose, got {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert_eq!(
+            out,
+            concat!(
+                "#+CAPTION[Short. Title.]: Long caption.\n",
+                "                          Second.\n",
+            ),
+            "dual short stays; long value hangs and splits, got:\n{out}"
+        );
+        assert!(
+            out.contains("#+CAPTION[Short. Title.]:"),
+            "Short. Title. must not split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn name_and_attr_stay_whole_line_structure() {
+        use crate::format_text;
+
+        let input = concat!(
+            "#+NAME: First sentence. Second sentence.\n",
+            "#+ATTR_HTML: :alt First sentence. Second.\n",
+            "#+ATTR_LATEX: :width 0.9 :alt First sentence. Second sentence.\n",
+            "#+CAPTION: Long caption. Second.\n",
+            "[[file:plot.png]]\n",
+            "After the figure. More.\n",
+        );
+        let regions = OrgParser.parse(input);
+        for needle in [
+            "#+NAME: First sentence. Second sentence.",
+            "#+ATTR_HTML: :alt First sentence. Second.",
+            "#+ATTR_LATEX: :width 0.9 :alt First sentence. Second sentence.",
+        ] {
+            assert!(
+                regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Structure(s) if s.contains(needle))),
+                "{needle} must stay Structure, got {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(s) if s.contains(needle))),
+                "{needle} must not be Prose, got {regions:?}"
+            );
+        }
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("#+NAME: First sentence. Second sentence.\n"),
+            "#+NAME: must stay whole-line, got:\n{out}"
+        );
+        assert!(
+            out.contains("#+ATTR_HTML: :alt First sentence. Second.\n"),
+            "#+ATTR_HTML: must stay whole-line, got:\n{out}"
+        );
+        assert!(
+            out.contains("#+ATTR_LATEX: :width 0.9 :alt First sentence. Second sentence.\n"),
+            "#+ATTR_LATEX: must stay whole-line, got:\n{out}"
+        );
+        assert!(
+            out.contains("#+CAPTION: Long caption.\n           Second.\n"),
+            "CAPTION value must still hang, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the figure.\nMore."),
+            "following prose must still split, got:\n{out}"
         );
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1095,6 +1095,11 @@ fn hanging_indent_width(s: &str) -> usize {
     if crate::parser::org::org_footnote_definition_marker_len(s) == Some(s.len()) {
         return s.chars().count();
     }
+    // Org CAPTION (`#+CAPTION: `, `#+CAPTION[short]: `): hang at
+    // opener width so the value stays a hung paragraph (GitHub #204).
+    if crate::parser::org::org_caption_marker_len(s) == Some(s.len()) {
+        return s.chars().count();
+    }
     // Parser markers are `core` plus one or more trailing spaces; leading
     // indent is part of the hang so nested `   - ` continues at column 5.
     // Extra spaces after `*` (`*  Candidate:`) stay in the hang so a
@@ -1761,6 +1766,19 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_indent_width("[fn:note] "), 10);
         assert_eq!(hanging_prefix("[fn:1] "), "       ");
         assert_eq!(hanging_prefix("[fn:note] "), "          ");
+        assert_eq!(hanging_indent_width("#+CAPTION: "), 11);
+        assert_eq!(hanging_prefix("#+CAPTION: "), "           ");
+        assert_eq!(
+            hanging_indent_width("#+CAPTION[Short. Title.]: "),
+            "#+CAPTION[Short. Title.]: ".len()
+        );
+        assert_eq!(
+            hanging_prefix("#+CAPTION[Short. Title.]: "),
+            "                          "
+        );
+        assert_eq!(hanging_indent_width("#+NAME: "), 0);
+        assert_eq!(hanging_indent_width("#+ATTR_HTML: "), 0);
+        assert_eq!(hanging_indent_width("#+ATTR_LATEX: "), 0);
     }
 
     #[test]
@@ -1786,6 +1804,25 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(
             result,
             "[fn:1] This is a long footnote sentence that must stay inside the definition.\n       Second sentence.\n"
+        );
+    }
+
+    #[test]
+    fn org_caption_hangs_second_sentence() {
+        let result = reflow_regions(vec![
+            Region::Structure("#+CAPTION: ".to_string()),
+            Region::Prose(
+                "This is a long figure caption that must reflow as prose. Second sentence."
+                    .to_string(),
+            ),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            concat!(
+                "#+CAPTION: This is a long figure caption that must reflow as prose.\n",
+                "           Second sentence.\n",
+            )
         );
     }
 

--- a/tests/org_caption.rs
+++ b/tests/org_caption.rs
@@ -1,0 +1,180 @@
+//! snapper-62f5 / GitHub #204: Org `#+CAPTION:` values reflow; NAME/ATTR do not.
+//!
+//! `org-element-parsed-keywords` is CAPTION only. The `#+CAPTION:` opener
+//! (optional `[short]`) is Structure; the value hangs and splits.
+//! `#+NAME:` and `#+ATTR_*` stay whole-line Structure.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture: affiliated CAPTION, figure link, following prose.
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "#+CAPTION: This is a long figure caption that must reflow as prose. Second sentence.\n",
+        "[[file:plot.png]]\n",
+        "After the figure. More.\n",
+    )
+}
+
+#[test]
+fn caption_opener_is_structure_value_is_hung_prose() {
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "#+CAPTION: ")),
+        "#+CAPTION: must be Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("This is a long figure caption that must reflow as prose.")
+                    && s.contains("Second sentence.")
+        )),
+        "CAPTION value must be Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("This is a long figure caption")
+        )),
+        "CAPTION value must not stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("[[file:plot.png]]")
+        )),
+        "figure link line must stay Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn caption_fixture_value_splits_and_hangs() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "#+CAPTION: This is a long figure caption that must reflow as prose.\n",
+            "           Second sentence.\n",
+            "[[file:plot.png]]\n",
+            "After the figure.\n",
+            "More.\n",
+        ),
+        "CAPTION opener stays; value hangs and splits, got:\n{out}"
+    );
+    assert!(
+        !out.lines().any(|l| l == "Second sentence."),
+        "must not emit a column-0 second caption sentence, got:\n{out}"
+    );
+    assert!(
+        !out.contains("[[file:plot.png]] After the figure."),
+        "link line must not join following prose, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &org_cfg()).unwrap(),
+        out,
+        "hung CAPTION must be identity, got:\n{out}"
+    );
+}
+
+#[test]
+fn caption_dual_short_title_stays_structure() {
+    let input = "#+CAPTION[Short. Title.]: Long caption. Second.\n";
+    let regions = OrgParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s == "#+CAPTION[Short. Title.]: "
+        )),
+        "dual [short] must stay in the Structure opener, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains("Short. Title.")
+        )),
+        "short title must not be Prose, got {regions:?}"
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "#+CAPTION[Short. Title.]: Long caption.\n",
+            "                          Second.\n",
+        ),
+        "dual short stays; long value hangs and splits, got:\n{out}"
+    );
+    assert!(
+        !out.contains("Short.\n"),
+        "Short. Title. must not split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn name_and_attr_stay_whole_line_structure() {
+    let input = concat!(
+        "#+NAME: First sentence. Second sentence.\n",
+        "#+ATTR_HTML: :alt First sentence. Second.\n",
+        "#+ATTR_LATEX: :width 0.9 :alt First sentence. Second sentence.\n",
+        "#+CAPTION: Long caption. Second.\n",
+        "[[file:fig.png]]\n",
+        "\n",
+        "After the figure. Next.\n",
+    );
+    let regions = OrgParser.parse(input);
+    for needle in [
+        "#+NAME: First sentence. Second sentence.",
+        "#+ATTR_HTML: :alt First sentence. Second.",
+        "#+ATTR_LATEX: :width 0.9 :alt First sentence. Second sentence.",
+    ] {
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains(needle))),
+            "{needle} must stay Structure, got {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(s) if s.contains(needle))),
+            "{needle} must not be Prose, got {regions:?}"
+        );
+    }
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("#+NAME: First sentence. Second sentence.\n"),
+        "#+NAME: must stay whole-line, got:\n{out}"
+    );
+    assert!(
+        out.contains("#+ATTR_HTML: :alt First sentence. Second.\n"),
+        "#+ATTR_HTML: must stay whole-line, got:\n{out}"
+    );
+    assert!(
+        out.contains("#+ATTR_LATEX: :width 0.9 :alt First sentence. Second sentence.\n"),
+        "#+ATTR_LATEX: must stay whole-line, got:\n{out}"
+    );
+    assert!(
+        out.contains("#+CAPTION: Long caption.\n           Second.\n"),
+        "CAPTION value must still hang, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the figure.\nNext.\n"),
+        "following prose must still reflow, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
vissue: snapper-62f5 (parent snapper-etv7). GitHub #204.

unanimous-green-87 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

org-element-parsed-keywords is CAPTION only. #+CAPTION: (optional
[short]) is Structure; the value hangs and splits. #+NAME: and
#+ATTR_* stay whole-line Structure.

## Test plan
- rustc tests in tests/org_caption.rs
- terra: cargo test parser::org