### PR TITLE
fix(md): treat GFM alert type markers as Structure

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -116,6 +116,7 @@ These tokens within prose are not split across lines:
 - Setext headings (title line plus ====== or ------ underline)
 - List item markers (=-=, =*=, =+=, =1.=); continuation sentences hang at the marker width
 - Blockquote markers (=>= / nested => > =); continuation sentences repeat the quote prefix
+- GFM alert type markers (=[!NOTE]= / =[!TIP]= / =[!WARNING]= / =[!CAUTION]= / =[!IMPORTANT]=); the body hangs and splits like a quote
 - Hard line breaks (two trailing spaces, or a trailing backslash)
 - HTML comments (=<!-- ... -->=, including multiline); =<!-- snapper:off -->= / =<!-- snapper:on -->= remain pragmas
 - Pipe tables

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -719,6 +719,27 @@ fn is_indented_code_line(line: &str) -> bool {
     prefix.contains('\t') || prefix.len() >= 4
 }
 
+/// pulldown `ENABLE_GFM` `scan_blockquote_tag`: after the `>` prefix, a
+/// line that is only `[!NOTE]` / `[!TIP]` / `[!IMPORTANT]` / `[!WARNING]` /
+/// `[!CAUTION]` (case-insensitive, trailing space ok). Extra text on the
+/// same line is a regular quote, not an alert.
+fn is_gfm_alert_marker(text: &str) -> bool {
+    let t = text.trim();
+    let Some(rest) = t.strip_prefix("[!") else {
+        return false;
+    };
+    let Some(close) = rest.find(']') else {
+        return false;
+    };
+    if close + 1 != rest.len() {
+        return false;
+    }
+    matches!(
+        rest[..close].to_ascii_uppercase().as_str(),
+        "NOTE" | "TIP" | "IMPORTANT" | "WARNING" | "CAUTION"
+    )
+}
+
 /// Count CommonMark blockquote markers at the start of `line`.
 /// Each marker is `>` plus an optional space. Leading whitespace is skipped.
 fn quote_marker_depth(line: &str) -> usize {
@@ -1538,6 +1559,13 @@ impl FormatParser for MarkdownParser {
                 let marker = caps.get(1).unwrap().as_str();
                 let text = caps.get(2).unwrap().as_str();
                 if text.trim().is_empty() {
+                    regions.push(SpannedRegion::structure(input, line.span()));
+                    i += 1;
+                    continue;
+                }
+                // pulldown ENABLE_GFM: the type marker is not quote Prose.
+                // Whole line stays Structure so it is not joined onto the body.
+                if is_gfm_alert_marker(text) {
                     regions.push(SpannedRegion::structure(input, line.span()));
                     i += 1;
                     continue;
@@ -2618,6 +2646,73 @@ mod tests {
         assert_eq!(regions[2], Region::Structure("\n".to_string()));
         assert_eq!(regions[3], Region::Structure("> ".to_string()));
         assert_eq!(regions[4], Region::Prose("Two.".to_string()));
+    }
+
+    #[test]
+    fn gfm_alert_type_marker_is_structure() {
+        let input = concat!(
+            "> [!NOTE]\n",
+            "> This is a long alert sentence that must reflow. Second sentence.\n",
+            "\n",
+            "After the alert. Next.\n",
+        );
+        let regions = MarkdownParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("[!NOTE]")
+            )),
+            "[!NOTE] must stay Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("[!NOTE]")
+            )),
+            "[!NOTE] must not join quote Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains("This is a long alert sentence that must reflow.")
+                        && p.contains("Second sentence.")
+            )),
+            "alert body must stay Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After the alert.") && p.contains("Next.")
+            )),
+            "prose after the alert must stay Prose, got: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn gfm_alert_same_line_extra_is_not_a_marker() {
+        // pulldown scan_blockquote_tag: text after `]` is a regular quote.
+        let regions = MarkdownParser.parse("> [!NOTE] Extra sentence. Another.\n");
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("[!NOTE]") && p.contains("Extra sentence.")
+            )),
+            "same-line body is quote Prose, not an alert marker, got: {regions:?}"
+        );
+    }
+
+    #[test]
+    fn gfm_alert_marker_matches_pulldown_scan() {
+        assert!(is_gfm_alert_marker("[!NOTE]"));
+        assert!(is_gfm_alert_marker("  [!tip]  "));
+        assert!(is_gfm_alert_marker("[!Important]"));
+        assert!(is_gfm_alert_marker("[!WARNING]"));
+        assert!(is_gfm_alert_marker("[!CAUTION]"));
+        assert!(!is_gfm_alert_marker("[!NOTE] extra"));
+        assert!(!is_gfm_alert_marker("[!FIXME]"));
+        assert!(!is_gfm_alert_marker("[NOTE]"));
+        assert!(!is_gfm_alert_marker("NOTE"));
     }
 
     #[test]

--- a/tests/md_gfm_alerts.rs
+++ b/tests/md_gfm_alerts.rs
@@ -1,0 +1,127 @@
+//! GitHub #205 / snapper-4zt5: GFM alert type markers stay Structure.
+//! `> [!NOTE]` is not quote Prose. The body hangs and splits. After the
+//! alert still reflows.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::markdown::MarkdownParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn md_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Markdown,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Markdown).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "> [!NOTE]\n",
+        "> This is a long alert sentence that must reflow. Second sentence.\n",
+        "\n",
+        "After the alert. Next.\n",
+    )
+}
+
+#[test]
+fn note_alert_type_marker_is_structure() {
+    let input = ticket_fixture();
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("[!NOTE]")
+        )),
+        "[!NOTE] must stay Structure, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("[!NOTE]")
+        )),
+        "[!NOTE] must not join the body as Prose, got: {regions:?}"
+    );
+}
+
+#[test]
+fn note_alert_body_hangs_and_following_prose_splits() {
+    let input = ticket_fixture();
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "> [!NOTE]\n",
+            "> This is a long alert sentence that must reflow.\n",
+            "> Second sentence.\n",
+            "\n",
+            "After the alert.\n",
+            "Next.\n",
+        ),
+        "NOTE stays; body hangs and splits; following prose reflows, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+}
+
+#[test]
+fn note_alert_survives_safety_backstops() {
+    let input = ticket_fixture();
+    let cfg = FormatConfig {
+        format: Format::Markdown,
+        max_width: 0,
+        ..Default::default()
+    };
+    let out = format_text(input, &cfg).unwrap();
+    assert!(
+        out.contains("> This is a long alert sentence that must reflow.\n> Second sentence."),
+        "CLI backstops must not revert the split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the alert.\nNext."),
+        "following prose must still split under backstops, got:\n{out}"
+    );
+    assert!(
+        !out.contains("[!NOTE] This is a long"),
+        "type marker must not join the body, got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Markdown, input, &out),
+        "oracle must accept the reflow\n in={input:?}\n out={out:?}"
+    );
+    assert_eq!(format_text(&out, &cfg).unwrap(), out);
+}
+
+#[test]
+fn leftover_alert_types_reflow_like_note() {
+    for name in ["TIP", "WARNING", "CAUTION", "IMPORTANT"] {
+        let input = format!(
+            "> [!{name}]\n> This is a long alert sentence that must reflow. Second sentence.\n\nAfter the alert. Next.\n"
+        );
+        let regions = MarkdownParser.parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(&format!("[!{name}]"))
+            )),
+            "[!{name}] must stay Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(&format!("[!{name}]"))
+            )),
+            "[!{name}] must not join the body as Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &md_cfg()).unwrap();
+        assert_eq!(
+            out,
+            format!(
+                "> [!{name}]\n> This is a long alert sentence that must reflow.\n> Second sentence.\n\nAfter the alert.\nNext.\n"
+            ),
+            "{name} is the same alert class as NOTE, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+    }
+}


### PR DESCRIPTION
vissue: snapper-4zt5 (parent snapper-etv7). GitHub #205.

unanimous-green-88 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

> [!NOTE] / TIP / WARNING / CAUTION / IMPORTANT stay Structure.
The body hangs and splits. Following prose still reflows.

## Test plan
- rustc tests in tests/md_gfm_alerts.rs
- terra: cargo test parser::markdown