### PR TITLE
fix(latex): treat SaveVerbatim and VerbatimOut as code

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,8 +165,8 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting=, =verbatim=, =comment=.
-Adding =Verbatim= (fancyvrb) stops reflow of that environment.
+Built-in: =minted=, =lstlisting=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, and fancyvrb =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut=.
+Adding an unlisted name stops reflow of that environment.
 
 ** structure_envs (latex)
 :PROPERTIES:

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -91,7 +91,8 @@ These tokens within prose are not split across lines:
 :CUSTOM_ID: latex-code
 :END:
 - =\\begin{...}= / =\\end{...}= lines are structure
-- Extra names from =[latex].verbatim_envs= (for example fancyvrb =Verbatim=) are code regions too
+- fancyvrb =Verbatim= / =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut= are built-in code regions (same FV@Scan class)
+- Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= =language== option)
 - Inline =\verb= / =\lstinline= (and extra =[latex].verbatim_commands=, for example =\Verb=) stay atomic; inner =.!?%= do not split or comment
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,8 @@ pub struct FormatOverrides {
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
     /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// and fancyvrb BVerbatim/LVerbatim; entries are added to it.
+    /// and fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut;
+    /// entries are added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,8 @@ pub struct FormatConfig {
     /// Extra LaTeX environments treated as code (no reflow), added to
     /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// and fancyvrb BVerbatim/LVerbatim. Empty keeps the built-in list.
+    /// and fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut.
+    /// Empty keeps the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -128,12 +128,14 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// (`filecontents`, `filecontents*`) and tree-sitter-latex raw trivia envs
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
 /// `sageblock`) plus fancyvrb `verbatim*` / `Verbatim` / `BVerbatim` /
-/// `LVerbatim`, moreverb `boxedverbatim`, tcolorbox `tcblisting` /
-/// `codeexample`, and the `comment` package env (tree-sitter
-/// `comment_environment`: raw through matching `\end{comment}`).
-/// Overleaf `verbatimEnvNames` is Verbatim, boxedverbatim, tcblisting,
-/// codeexample. fancyvrb `BVerbatim` / `LVerbatim` are the same raw
-/// class as `Verbatim` (GitHub #209).
+/// `LVerbatim` / `SaveVerbatim` / `VerbatimOut`, moreverb
+/// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, and the
+/// `comment` package env (tree-sitter `comment_environment`: raw
+/// through matching `\end{comment}`). Overleaf `verbatimEnvNames` is
+/// Verbatim, boxedverbatim, tcblisting, codeexample. fancyvrb
+/// `BVerbatim` / `LVerbatim` are the same raw class as `Verbatim`
+/// (GitHub #209). `SaveVerbatim` / `VerbatimOut` are the same
+/// `FV@Scan` class (GitHub #213).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
@@ -144,6 +146,8 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "Verbatim"
             | "BVerbatim"
             | "LVerbatim"
+            | "SaveVerbatim"
+            | "VerbatimOut"
             | "boxedverbatim"
             | "tcblisting"
             | "codeexample"
@@ -2399,6 +2403,76 @@ Some text.
                 !two_out.contains("First line.\nSecond line."),
                 "{name} two-sentence body must not split, got:\n{two_out}"
             );
+        }
+    }
+
+    /// Ticket fixture (GitHub #213): fancyvrb SaveVerbatim and
+    /// VerbatimOut are the same FV@Scan class as Verbatim. The required
+    /// `{name}` / `{file}` argument stays on the begin header.
+    #[test]
+    fn fancyvrb_saveverbatim_verbatimout_are_code_not_prose() {
+        use crate::format_text;
+
+        for name in ["SaveVerbatim", "VerbatimOut"] {
+            let input = format!(
+                concat!(
+                    "\\begin{{{name}}}{{foo}}\n",
+                    "First line. Second line.\n",
+                    "\\end{{{name}}}\n",
+                    "After the block. Next.\n",
+                ),
+                name = name
+            );
+            let regions = LatexParser::default().parse(&input);
+            let code = regions.iter().find_map(|r| match r {
+                Region::Code {
+                    header,
+                    body,
+                    footer,
+                    ..
+                } => Some((header.as_str(), body.as_str(), footer.as_str())),
+                _ => None,
+            });
+            let Some((header, body, footer)) = code else {
+                panic!("{name} must be Code, got: {regions:?}");
+            };
+            assert!(
+                header.contains(&format!("\\begin{{{name}}}{{foo}}")),
+                "{name} required arg must stay on the begin header, got header={header:?}"
+            );
+            assert!(
+                body.contains("First line. Second line."),
+                "{name} body must keep both sentences, got body={body:?}"
+            );
+            assert!(
+                footer.contains(&format!("\\end{{{name}}}")),
+                "{name} footer must be \\end{{{name}}}, got footer={footer:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+                "{name} body must not leak into Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&format!("\\begin{{{name}}}{{foo}}"))
+                    && out.contains(&format!("\\end{{{name}}}")),
+                "{name} begin/end must stay, got:\n{out}"
+            );
+            assert!(
+                out.contains("First line. Second line."),
+                "{name} body must stay one source line, got:\n{out}"
+            );
+            assert!(
+                !out.contains("First line.\nSecond line."),
+                "{name} must not reflow as prose, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the block.\nNext."),
+                "prose after {name} must still split, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
         }
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -1,5 +1,6 @@
 //! snapper-3tj3 / GitHub #98: Overleaf verbatimEnvNames are Code, not prose.
 //! GitHub #209: fancyvrb BVerbatim / LVerbatim are the same.
+//! GitHub #213: fancyvrb SaveVerbatim / VerbatimOut are the same FV@Scan class.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -139,5 +140,73 @@ fn bverbatim_lverbatim_fixture_is_code_and_does_not_reflow() {
             !two_out.contains("First line.\nSecond line."),
             "{name} two-sentence body must not split, got:\n{two_out}"
         );
+    }
+}
+
+/// Ticket fixture (GitHub #213): fancyvrb SaveVerbatim and VerbatimOut
+/// bodies stay Code; the required `{foo}` arg stays on begin; following
+/// prose still splits.
+#[test]
+fn saveverbatim_verbatimout_fixture_is_code_and_does_not_reflow() {
+    for name in ["SaveVerbatim", "VerbatimOut"] {
+        let input = format!(
+            concat!(
+                "\\begin{{{name}}}{{foo}}\n",
+                "First line. Second line.\n",
+                "\\end{{{name}}}\n",
+                "After the block. Next.\n",
+            ),
+            name = name
+        );
+        let regions = LatexParser::default().parse(&input);
+        let code = regions.iter().find_map(|r| match r {
+            Region::Code {
+                header,
+                body,
+                footer,
+                ..
+            } => Some((header.as_str(), body.as_str(), footer.as_str())),
+            _ => None,
+        });
+        let Some((header, body, footer)) = code else {
+            panic!("{name} must be Code, got: {regions:?}");
+        };
+        assert!(
+            header.contains(&format!("\\begin{{{name}}}{{foo}}")),
+            "{name} required arg must stay on the begin header, got header={header:?}"
+        );
+        assert!(
+            body.contains("First line. Second line."),
+            "{name} body must be Code, got body={body:?}"
+        );
+        assert!(
+            footer.contains(&format!("\\end{{{name}}}")),
+            "{name} footer must stay, got footer={footer:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&format!("\\begin{{{name}}}{{foo}}"))
+                && out.contains(&format!("\\end{{{name}}}")),
+            "{name} begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "{name} body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after {name} must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
 }


### PR DESCRIPTION
vissue: snapper-4wgu (parent snapper-etv7). GitHub #213.

unanimous-green-92 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

fancyvrb SaveVerbatim/VerbatimOut are the same FV@Scan class as
Verbatim. Bodies stay Code; surrounding prose still splits.

## Test plan
- rustc tests in tests/latex_verbatim_envs.rs
- terra: cargo test parser::latex