### PR TITLE
fix(md): hang definition-list bodies at the colon marker

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -116,6 +116,7 @@ These tokens within prose are not split across lines:
 - Full ATX heading lines (=#= … =######= including title text)
 - Setext headings (title line plus ====== or ------ underline)
 - List item markers (=-=, =*=, =+=, =1.=); continuation sentences hang at the marker width
+- Definition-list terms and =: = markers (pulldown =ENABLE_DEFINITION_LIST=); the body hangs at the marker width
 - Blockquote markers (=>= / nested => > =); continuation sentences repeat the quote prefix
 - GFM alert type markers (=[!NOTE]= / =[!TIP]= / =[!WARNING]= / =[!CAUTION]= / =[!IMPORTANT]=); the body hangs and splits like a quote
 - Hard line breaks (two trailing spaces, or a trailing backslash)
@@ -136,6 +137,7 @@ These tokens within prose are not split across lines:
 :END:
 - Paragraph text
 - List item text (after the marker); continuation sentences hang at the marker width
+- Definition-list body (after the =: = marker); continuation sentences hang at the marker width
 - Blockquote inner text (after the =>= marker); continuation sentences repeat the quote prefix
 
 *** Inline tokens (kept atomic)

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -232,6 +232,7 @@ fn md_html(src: &str) -> String {
     opts.insert(Options::ENABLE_FOOTNOTES);
     opts.insert(Options::ENABLE_STRIKETHROUGH);
     opts.insert(Options::ENABLE_TASKLISTS);
+    opts.insert(Options::ENABLE_DEFINITION_LIST);
     let parser = Parser::new_ext(src, opts);
     let mut html_output = String::new();
     html::push_html(&mut html_output, parser);
@@ -359,6 +360,18 @@ mod tests {
             !matches(Format::Markdown, "* 0. A.", "* 0.\n  A."),
             "nested 0. vs hung continuation must stay a leftover"
         );
+    }
+
+    #[test]
+    fn hung_md_definition_list_matches_source_item() {
+        // pulldown lazy-continues an unindented second sentence inside the
+        // <dd>, so both the hung form and a column-0 split are render-safe.
+        // The formatter still hangs; this only checks the hung form.
+        assert!(matches(
+            Format::Markdown,
+            "Term\n: This is a long definition sentence that must hang. Second sentence.\n",
+            "Term\n: This is a long definition sentence that must hang.\n  Second sentence.\n"
+        ));
     }
 
     #[test]

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -491,6 +491,36 @@ fn md_leaf_rest(line: &str) -> Option<&str> {
     Some(&line[i..])
 }
 
+/// pulldown `scan_definition_list_definition_marker_with_indent`
+/// (`ENABLE_DEFINITION_LIST`): 0–3 spaces, `:`, then following spaces.
+/// Five or more spaces after `:` keep only one (same padding rule as
+/// list markers). Hang width is the whole marker, including the colon.
+pub(crate) fn md_definition_list_marker_len(line: &str) -> Option<usize> {
+    let rest = md_leaf_rest(line)?;
+    let indent = line.len() - rest.len();
+    let after = rest.strip_prefix(':')?;
+    let spaces = after.bytes().take_while(|&b| b == b' ').count();
+    let consumed = if spaces >= 5 { 1 } else { spaces };
+    Some(indent + 1 + consumed)
+}
+
+/// Reclassify pending paragraph text as a definition-list title.
+fn flush_prose_as_structure(
+    prose: &mut String,
+    prose_span: &mut Option<ByteSpan>,
+    input: &str,
+    regions: &mut Vec<SpannedRegion>,
+) {
+    if prose.is_empty() {
+        return;
+    }
+    let span = prose_span.take().unwrap_or(ByteSpan::new(0, 0));
+    prose.clear();
+    if !span.is_empty() {
+        regions.push(SpannedRegion::structure(input, span));
+    }
+}
+
 /// Label length inside `[...]` (bytes after the opening `[`).
 /// CommonMark: at least one non-space, at most 999 chars, no unescaped `[`.
 fn scan_md_link_label(after_open: &str) -> Option<usize> {
@@ -1031,6 +1061,7 @@ impl FormatParser for MarkdownParser {
         let mut list_hang: Option<usize> = None;
         let mut list_after_blank = false;
         let mut list_term: Option<ByteSpan> = None;
+        let mut last_was_def_term = false;
         let mut in_display_math = false;
         let mut pragma_off = false;
 
@@ -1636,6 +1667,79 @@ impl FormatParser for MarkdownParser {
                 i += 1;
                 continue;
             }
+
+            // pulldown ENABLE_DEFINITION_LIST: a `: ` marker on the next
+            // line turns this paragraph into a definition title. The
+            // title stays Structure so interior periods do not split.
+            if i + 1 < total
+                && md_definition_list_marker_len(lines[i + 1].text).is_some()
+                && md_definition_list_marker_len(line_text).is_none()
+                && !line_text.trim().is_empty()
+                && !is_indented_code_line(line_text)
+            {
+                let hang_cont =
+                    in_list_item && list_hang.is_some_and(|hang| line_indent(line_text) >= hang);
+                if !hang_cont {
+                    close_list_item(
+                        &mut in_list_item,
+                        &mut list_hang,
+                        &mut current_prose,
+                        &mut prose_span,
+                        &mut list_term,
+                        input,
+                        &mut regions,
+                    );
+                    flush_prose_as_structure(
+                        &mut current_prose,
+                        &mut prose_span,
+                        input,
+                        &mut regions,
+                    );
+                    regions.push(SpannedRegion::structure(input, line.span()));
+                    last_was_def_term = true;
+                    i += 1;
+                    continue;
+                }
+            }
+
+            // pulldown scan_definition_list_definition_marker_with_indent:
+            // `: ` (0–3 space indent) is the definition marker. Body hangs.
+            if let Some(marker_len) = md_definition_list_marker_len(line_text) {
+                if last_was_def_term {
+                    last_was_def_term = false;
+                    close_list_item(
+                        &mut in_list_item,
+                        &mut list_hang,
+                        &mut current_prose,
+                        &mut prose_span,
+                        &mut list_term,
+                        input,
+                        &mut regions,
+                    );
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                    let marker_span = ByteSpan::new(line.start, line.start + marker_len);
+                    regions.push(SpannedRegion::structure(input, marker_span));
+                    in_list_item = true;
+                    list_hang = Some(marker_len);
+                    list_after_blank = false;
+                    append_piece(
+                        &mut ProseAcc {
+                            text: &mut current_prose,
+                            span: &mut prose_span,
+                            term: &mut list_term,
+                        },
+                        line,
+                        marker_len,
+                        false,
+                        false,
+                        input,
+                        &mut regions,
+                    );
+                    i += 1;
+                    continue;
+                }
+            }
+            last_was_def_term = false;
 
             // Regular prose (also serves as list-item continuation when in_list_item)
             if in_list_item {
@@ -4255,6 +4359,90 @@ mod tests {
         assert!(
             !out.contains("[^1]: Footnote text.\nSecond sentence."),
             "footnote must not leak a shorter body, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+
+        let cfg = FormatConfig {
+            format: Format::Markdown,
+            ..Default::default()
+        };
+        let guarded = format_text(input, &cfg).unwrap();
+        assert_eq!(guarded, out, "oracle-on path must match, got:\n{guarded}");
+        assert_eq!(format_text(&guarded, &cfg).unwrap(), guarded);
+    }
+
+    /// GitHub #210 / snapper-r9tq: pulldown ENABLE_DEFINITION_LIST.
+    fn ticket_definition_list_fixture() -> &'static str {
+        "Term\n: This is a long definition sentence that must hang. Second sentence.\n"
+    }
+
+    #[test]
+    fn definition_list_marker_matches_pulldown_scan() {
+        assert_eq!(md_definition_list_marker_len(": This is"), Some(2));
+        assert_eq!(md_definition_list_marker_len("  : def"), Some(4));
+        assert_eq!(md_definition_list_marker_len("   : def"), Some(5));
+        assert_eq!(md_definition_list_marker_len(":    def"), Some(5));
+        assert_eq!(md_definition_list_marker_len(":     def"), Some(2));
+        assert_eq!(md_definition_list_marker_len(":"), Some(1));
+        assert_eq!(md_definition_list_marker_len("    : def"), None);
+        assert_eq!(md_definition_list_marker_len("Term"), None);
+        assert_eq!(md_definition_list_marker_len("[foo]: /url"), None);
+        assert_eq!(md_definition_list_marker_len("[^1]: note"), None);
+        assert_eq!(md_definition_list_marker_len("- item"), None);
+    }
+
+    #[test]
+    fn definition_list_term_and_marker_are_structure() {
+        let regions = MarkdownParser.parse(ticket_definition_list_fixture());
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "Term\n")),
+            "Term must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == ": ")),
+            ":  marker must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("This is a long definition sentence that must hang.")
+                        && s.contains("Second sentence.")
+            )),
+            "definition body must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("Term") || s.starts_with(": ")
+            )),
+            "term and : marker must not be Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn definition_list_body_hangs_and_splits() {
+        use crate::format::Format;
+        use crate::{format_text, FormatConfig};
+
+        let input = ticket_definition_list_fixture();
+        let out = format_text(input, &md_cfg()).unwrap();
+        assert_eq!(
+            out,
+            concat!(
+                "Term\n",
+                ": This is a long definition sentence that must hang.\n",
+                "  Second sentence.\n",
+            ),
+            "body must hang and split, got:\n{out}"
+        );
+        assert!(
+            !out.lines().any(|l| l == "Second sentence."),
+            "must not emit a column-0 second sentence, got:\n{out}"
         );
         assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
 

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1100,6 +1100,11 @@ fn hanging_indent_width(s: &str) -> usize {
     if crate::parser::org::org_caption_marker_len(s) == Some(s.len()) {
         return s.chars().count();
     }
+    // Markdown definition marker (`: ` / `  : `): hang at marker width
+    // so the body stays inside the definition (GitHub #210).
+    if crate::parser::markdown::md_definition_list_marker_len(s) == Some(s.len()) {
+        return s.chars().count();
+    }
     // Parser markers are `core` plus one or more trailing spaces; leading
     // indent is part of the hang so nested `   - ` continues at column 5.
     // Extra spaces after `*` (`*  Candidate:`) stay in the hang so a
@@ -1261,11 +1266,15 @@ mod tests {
         assert_eq!(hanging_prefix("i. "), "   ");
         assert_eq!(hanging_prefix("\\item "), "      ");
         assert_eq!(hanging_prefix("  "), "  ");
+        assert_eq!(hanging_prefix(": "), "  ");
+        assert_eq!(hanging_prefix("  : "), "    ");
         assert_eq!(hanging_indent_width("  "), 0);
         assert_eq!(hanging_indent_width("> "), 0);
         assert_eq!(hanging_indent_width("- "), 2);
         assert_eq!(hanging_indent_width("#. "), 3);
         assert_eq!(hanging_indent_width("\\item "), 6);
+        assert_eq!(hanging_indent_width(": "), 2);
+        assert_eq!(hanging_indent_width("  : "), 4);
     }
 
     #[test]
@@ -1737,6 +1746,10 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_prefix("i. "), "   ");
         assert_eq!(hanging_prefix("\\item "), "      ");
         assert_eq!(hanging_prefix("  "), "  ");
+        assert_eq!(hanging_prefix(": "), "  ");
+        assert_eq!(hanging_prefix("  : "), "    ");
+        assert_eq!(hanging_indent_width(": "), 2);
+        assert_eq!(hanging_indent_width("  : "), 4);
         assert_eq!(hanging_indent_width("  "), 0);
         assert_eq!(hanging_indent_width("\n"), 0);
         assert_eq!(hanging_indent_width("#+TITLE: Test\n"), 0);
@@ -1789,6 +1802,30 @@ They are endowed with reason and conscience and should act towards one another i
             Region::Structure("\n".to_string()),
         ]);
         assert_eq!(result, "- One.\n  Two.\n");
+    }
+
+    #[test]
+    fn md_definition_list_hangs_second_sentence() {
+        let result = reflow_regions(vec![
+            Region::Structure("Term\n".to_string()),
+            Region::Structure(": ".to_string()),
+            Region::Prose(
+                "This is a long definition sentence that must hang. Second sentence.".to_string(),
+            ),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            concat!(
+                "Term\n",
+                ": This is a long definition sentence that must hang.\n",
+                "  Second sentence.\n",
+            )
+        );
+        assert!(
+            !result.contains("\nSecond sentence."),
+            "second sentence must not land at column 0, got:\n{result}"
+        );
     }
 
     #[test]

--- a/tests/md_definition_lists.rs
+++ b/tests/md_definition_lists.rs
@@ -1,0 +1,164 @@
+//! GitHub #210 / snapper-r9tq: Markdown definition lists hang.
+//!
+//! pulldown `ENABLE_DEFINITION_LIST` / `scan_definition_list_definition_marker_with_indent`.
+//! Term is Structure. `: ` is Structure. The body hangs and splits.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::markdown::MarkdownParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{format_text, FormatConfig};
+
+fn md_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Markdown,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Markdown).
+fn ticket_fixture() -> &'static str {
+    "Term\n: This is a long definition sentence that must hang. Second sentence.\n"
+}
+
+#[test]
+fn term_is_structure_marker_is_structure() {
+    let regions = MarkdownParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "Term\n")),
+        "Term must be Structure, got {regions:?}"
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == ": ")),
+        ":  marker must be Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("This is a long definition sentence that must hang.")
+                    && s.contains("Second sentence.")
+        )),
+        "definition body must be Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn definition_body_hangs_and_splits() {
+    let input = ticket_fixture();
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Term\n",
+            ": This is a long definition sentence that must hang.\n",
+            "  Second sentence.\n",
+        ),
+        "Term stays; :  stays; body hangs and splits, got:\n{out}"
+    );
+    assert!(
+        !out.lines().any(|l| l == "Second sentence."),
+        "must not emit a column-0 second sentence, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+}
+
+#[test]
+fn definition_list_survives_safety_backstops() {
+    let input = ticket_fixture();
+    let cfg = FormatConfig {
+        format: Format::Markdown,
+        max_width: 0,
+        ..Default::default()
+    };
+    let out = format_text(input, &cfg).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Term\n",
+            ": This is a long definition sentence that must hang.\n",
+            "  Second sentence.\n",
+        ),
+        "CLI backstops must not revert the hang, got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Markdown, input, &out),
+        "oracle must accept the reflow\n in={input:?}\n out={out:?}"
+    );
+    assert_eq!(format_text(&out, &cfg).unwrap(), out);
+}
+
+#[test]
+fn following_prose_after_definition_still_splits() {
+    let input = concat!(
+        "Term\n",
+        ": This is a long definition sentence that must hang. Second sentence.\n",
+        "\n",
+        "After the list. Next.\n",
+    );
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Term\n",
+            ": This is a long definition sentence that must hang.\n",
+            "  Second sentence.\n",
+            "\n",
+            "After the list.\n",
+            "Next.\n",
+        ),
+        "following prose must still reflow, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+}
+
+#[test]
+fn indented_definition_marker_hangs_at_marker_width() {
+    let input = "Term\n  : This is a long definition sentence that must hang. Second sentence.\n";
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "  : ")),
+        "indented :  marker must be Structure, got {regions:?}"
+    );
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Term\n",
+            "  : This is a long definition sentence that must hang.\n",
+            "    Second sentence.\n",
+        ),
+        "indented marker must hang at width 4, got:\n{out}"
+    );
+    assert!(
+        !out.lines().any(|l| l == "Second sentence."),
+        "must not emit a column-0 second sentence, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+}
+
+#[test]
+fn lone_colon_line_is_not_a_definition() {
+    let input = ": This is a long definition sentence that must hang. Second sentence.\n";
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(": This is a long definition sentence")
+        )),
+        "a leading `: ` without a term is prose, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == ": ")),
+        "lone `: ` must not invent a definition marker, got: {regions:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-r9tq (parent snapper-etv7). GitHub #210.

unanimous-green-91 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

pulldown ENABLE_DEFINITION_LIST. Term and :  are Structure; the
body hangs and splits; no column-0 second sentence.

## Test plan
- rustc tests in tests/md_definition_lists.rs
- terra: cargo test parser::markdown