### PR TITLE
fix(org): keep radio targets atomic across sentence punct

### DIFF
--- a/docs/orgmode/reference/abbreviations.org
+++ b/docs/orgmode/reference/abbreviations.org
@@ -124,6 +124,7 @@ These merge with the built-in list at runtime.
 Periods inside inline tokens never trigger sentence breaks, regardless of abbreviation lists:
 
 - Org links: =[[https://example.com][Ex. Site]]=
+- Org radio / angle targets: =<<<the Fourier. transform>>>=, =<<sec. intro>>=
 - LaTeX math: =$x = 3.14$=
 - LaTeX commands: =\cite{smith.2024}=
 - Markdown links: =[Example Inc.](url)=

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -64,6 +64,8 @@ These tokens within prose are not split across lines:
 - A =~code~= or ===verbatim=== span may contain the marker character; pairing matches pandoc's org reader, so =x = 1= stays one span
 - Markdown inline code: a run of =n= backticks closes on the next run of the same length (CommonMark / pandoc), so a double span can hold a single backtick
 - Inline export snippets: =@@backend:value@@=
+- Radio targets: =<<<contents>>>= (org-element-radio-target-parser)
+- Angle targets: =<<contents>>= (org-element-target-parser)
 - URLs: =https://...= (trailing sentence punctuation not swallowed)
 
 ** LaTeX (=--format latex=)

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -2456,6 +2456,88 @@ mod tests {
         assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
     }
 
+    /// Ticket fixture (Format::Org / GitHub #211): org-element radio
+    /// targets stay one token so an interior period is not a sentence
+    /// boundary. `Next sentence.` still splits.
+    fn radio_target_fixture() -> &'static str {
+        "See <<<the Fourier. transform>>> in the text. Next sentence.\n"
+    }
+
+    #[test]
+    fn org_radio_target_interior_punct_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let radio = "<<<the Fourier. transform>>>";
+        let input = radio_target_fixture();
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains(radio) && p.contains("Next sentence.")
+            )),
+            "radio target stays inline Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("See <<<the Fourier. transform>>> in the text.\nNext sentence."),
+            "sentence after the radio target must reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("Fourier.\n") && !out.contains("<<<the Fourier.\ntransform>>>"),
+            "must not split inside the radio target, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+        let wrap_cfg = crate::FormatConfig {
+            format: crate::format::Format::Org,
+            max_width: 28,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let wrapped = format_text(input, &wrap_cfg).unwrap();
+        assert!(
+            wrapped.lines().any(|l| l.contains(radio)),
+            "wrap must not cut inside the radio target, got:\n{wrapped}"
+        );
+        assert!(
+            !wrapped.contains("Fourier.\ntransform"),
+            "must not wrap on the interior period, got:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("Next sentence."),
+            "sentence after the radio target must still reflow, got:\n{wrapped}"
+        );
+        assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+    }
+
+    #[test]
+    fn org_angle_target_interior_punct_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let target = "<<sec. intro>>";
+        let input = "See <<sec. intro>> in the text. Next sentence.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains(target) && p.contains("Next sentence.")
+            )),
+            "angle target stays inline Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("See <<sec. intro>> in the text.\nNext sentence."),
+            "sentence after the angle target must reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("sec.\nintro"),
+            "must not split inside the angle target, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
     /// Ticket fixture (Format::Org / GitHub #177): org-comment-regexp
     /// requires space or EOL after `#`. `#foo` is prose.
     fn hash_comment_space_or_eol_fixture() -> &'static str {

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2249,6 +2249,34 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_org_radio_target_atomic() {
+        let token = "<<<the Fourier. transform>>>";
+        let sentence = "See <<<the Fourier. transform>>> in the text. Next sentence.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 28, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("Fourier.\ntransform"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_keeps_org_angle_target_atomic() {
+        let token = "<<sec. intro>>";
+        let sentence = "See <<sec. intro>> in the text. Next sentence.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 20, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("sec.\nintro"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn max_width_keeps_math_atomic() {
         let token = "$E = m c^{2}$";
         let sentence = "The identity $E = m c^{2}$ holds in this frame.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -19,6 +19,12 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             // org-element 5.5 citation: [cite/style:prefix;@key p. 7;suffix]
             // Must be atomic so a page locator is not a sentence boundary.
             r"\[cite(?:/[-a-zA-Z0-9_/]*)?:[^\]]*\]",
+            // org-element-radio-target-parser / org-radio-target-regexp:
+            // <<<contents>>> with no <, >, or newline. Must precede <<...>>
+            // so the triple-angle form stays one token (GitHub #211).
+            r"<<<[^<>\n]+>>>",
+            // org-element-target-parser / org-target-regexp: <<contents>>
+            r"<<[^<>\n]+>>",
             r"\[[^\]]+\]\([^)]+\)",    // Markdown links: [text](url)
             r"!\[[^\]]*\]\([^)]+\)",   // Markdown images: ![alt](url)
             r"\$\$[^$\n]+\$\$",        // Display math: $$...$$
@@ -587,7 +593,8 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 }
 
 /// Byte ranges of inline tokens that wrapping must not split (links, images,
-/// inline code, autolinks, math, Org `[[...]]`, Org `[cite...]`, paired spans).
+/// inline code, autolinks, math, Org `[[...]]`, Org `[cite...]`,
+/// Org `<<<...>>>` / `<<...>>`, paired spans).
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.
@@ -1405,6 +1412,64 @@ mod tests {
             vec![
                 "See [[https://example.com][Ex. Site]] for details.",
                 "Then continue."
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_radio_target_interior_punct_is_not_a_sentence_boundary() {
+        // GitHub #211 / snapper-gz10: org-element radio targets
+        // `<<<contents>>>` stay one token so an interior period is not
+        // a sentence boundary. `Next sentence.` still splits.
+        let radio = "<<<the Fourier. transform>>>";
+        let text = "See <<<the Fourier. transform>>> in the text. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == radio),
+            "radio target must be one token, got {placeholders:?}"
+        );
+        assert!(
+            !placeholders
+                .iter()
+                .any(|p| p == "<<the Fourier. transform>>"),
+            "radio must not collapse to the inner angle target, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == radio),
+            "radio target must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See <<<the Fourier. transform>>> in the text.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_angle_target_interior_punct_is_not_a_sentence_boundary() {
+        // Same class as radio: org-element-target-parser `<<sec. intro>>`.
+        let target = "<<sec. intro>>";
+        let text = "See <<sec. intro>> in the text. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == target),
+            "angle target must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == target),
+            "angle target must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See <<sec. intro>> in the text.".to_string(),
+                "Next sentence.".to_string()
             ]
         );
     }

--- a/tests/org_radio_targets.rs
+++ b/tests/org_radio_targets.rs
@@ -1,0 +1,86 @@
+//! GitHub #211 / snapper-gz10: org-element radio targets (`<<<...>>>`)
+//! and angle targets (`<<...>>`) stay one inline token. Interior
+//! punctuation is not a sentence boundary. The use stays Prose.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "See <<<the Fourier. transform>>> in the text. Next sentence.\n"
+}
+
+#[test]
+fn ticket_radio_use_stays_prose() {
+    let radio = "<<<the Fourier. transform>>>";
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(radio) && s.contains("Next sentence.")
+        )),
+        "radio target must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_radio_span_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("<<<the Fourier. transform>>>"),
+        "radio target must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("<<<the Fourier.\n") && !out.contains("Fourier.\ntransform>>>"),
+        "must not split inside the radio target, got:\n{out}"
+    );
+    assert!(
+        out.contains("in the text.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("in the text. Next sentence."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn angle_target_stays_one_span() {
+    let input = "See <<sec. intro>> in the text. Next sentence.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("<<sec. intro>>"),
+        "angle target must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("sec.\nintro"),
+        "must not split inside the angle target, got:\n{out}"
+    );
+    assert!(
+        out.contains("in the text.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
vissue: snapper-gz10 (parent snapper-etv7). GitHub #211.

unanimous-green-94 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

org-element-radio-target-parser. <<<the Fourier. transform>>> stays
one token; Next sentence. still splits. <<sec. intro>> is the same class.

## Test plan
- rustc tests in tests/org_radio_targets.rs
- terra: cargo test sentence::unicode parser::org