### PR TITLE
fix(sentence): keep markdown reference links atomic

### DIFF
--- a/docs/orgmode/reference/abbreviations.org
+++ b/docs/orgmode/reference/abbreviations.org
@@ -127,7 +127,7 @@ Periods inside inline tokens never trigger sentence breaks, regardless of abbrev
 - Org radio / angle targets: =<<<the Fourier. transform>>>=, =<<sec. intro>>=
 - LaTeX math: =$x = 3.14$=
 - LaTeX commands: =\cite{smith.2024}=
-- Markdown links: =[Example Inc.](url)=
+- Markdown links: =[Example Inc.](url)=, =[the Fourier. transform][wiki]=
 - Inline code: =~std.io.Read~=, src_bash{`path.to.file`}
 
 These tokens get replaced with safe placeholders before sentence detection and restored afterward.

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2215,6 +2215,16 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_does_not_glue_shortcut_to_full_reference() {
+        let token = "[See also][ref]";
+        let sentence = "See [important] [See also][ref] for details today.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 24, clause);
+            assert_atomic_token(&wrapped, token);
+        }
+    }
+
+    #[test]
     fn max_width_keeps_markdown_image_atomic() {
         let token = "![alt text here](https://img.example.com/a.png)";
         let sentence = "Look at ![alt text here](https://img.example.com/a.png) now please.";

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2205,6 +2205,16 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_markdown_reference_link_atomic() {
+        let token = "[the Fourier. transform][wiki]";
+        let sentence = "See [the Fourier. transform][wiki] for details.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 28, clause);
+            assert_atomic_token(&wrapped, token);
+        }
+    }
+
+    #[test]
     fn max_width_keeps_markdown_image_atomic() {
         let token = "![alt text here](https://img.example.com/a.png)";
         let sentence = "Look at ![alt text here](https://img.example.com/a.png) now please.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -27,6 +27,11 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             r"<<[^<>\n]+>>",
             r"\[[^\]]+\]\([^)]+\)",    // Markdown links: [text](url)
             r"!\[[^\]]*\]\([^)]+\)",   // Markdown images: ![alt](url)
+            // CommonMark 0.31.2 §6.3 full / collapsed reference links.
+            // The label must follow the text immediately. Shortcut `[text]`
+            // is not matched: that would swallow every bracket group.
+            r"!\[[^\]]*\]\[[^\]]*\]", // Markdown reference images: ![alt][ref]
+            r"\[[^\]]+\]\[[^\]]*\]",  // Markdown reference links: [text][ref]
             r"\$\$[^$\n]+\$\$",        // Display math: $$...$$
             r"\$[^$\n]+\$",            // Inline math: $...$
             r"\\\([^\\\n]+\\\)",       // LaTeX inline math: \(...\)
@@ -593,8 +598,8 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 }
 
 /// Byte ranges of inline tokens that wrapping must not split (links, images,
-/// inline code, autolinks, math, Org `[[...]]`, Org `[cite...]`,
-/// Org `<<<...>>>` / `<<...>>`, paired spans).
+/// reference links `[text][ref]`, inline code, autolinks, math, Org `[[...]]`,
+/// Org `[cite...]`, Org `<<<...>>>` / `<<...>>`, paired spans).
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.
@@ -1517,6 +1522,60 @@ mod tests {
                 "Visit [Example Inc.](https://example.com) now.",
                 "Then read more."
             ]
+        );
+    }
+
+    #[test]
+    fn inline_markdown_reference_link_interior_punct_is_not_a_sentence_boundary() {
+        // GitHub #215 / snapper-e8g6: CM 6.3 `[text][ref]` must stay one
+        // token so an interior period is not a sentence boundary.
+        let link = "[the Fourier. transform][wiki]";
+        let text = "See [the Fourier. transform][wiki] for details. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == link),
+            "reference link must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == link),
+            "reference link must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See [the Fourier. transform][wiki] for details.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_markdown_collapsed_reference_link_interior_punct() {
+        let link = "[the Fourier. transform][]";
+        let text = "See [the Fourier. transform][] for details. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == link),
+            "collapsed reference must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See [the Fourier. transform][] for details.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn markdown_link_reference_definition_is_not_an_inline_token() {
+        let text = "[wiki]: https://example.org/fourier";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            !placeholders.iter().any(|p| p.contains("[wiki]:")),
+            "LRD must not be swallowed as [text][ref], got {placeholders:?}"
         );
     }
 

--- a/tests/md_ref_link_interior_punct.rs
+++ b/tests/md_ref_link_interior_punct.rs
@@ -101,6 +101,48 @@ fn ticket_fixture_keeps_reference_span_and_splits_next() {
 }
 
 #[test]
+fn consecutive_shortcuts_are_not_one_reference() {
+    // CM 0.31.2 §6.3 examples 542–543: no spaces or line endings between
+    // link text and label. `[foo] [bar]` / `[foo]\n[bar]` stay two tokens.
+    let spaced = concat!(
+        "See [foo] [bar] for details. Next sentence.\n",
+        "\n",
+        "[foo]: https://example.org/foo\n",
+        "[bar]: https://example.org/bar\n",
+    );
+    let spaced_out = format_text(spaced, &md_cfg()).unwrap();
+    assert!(
+        spaced_out.contains("[foo] [bar]"),
+        "spaced consecutive shortcuts must stay two tokens, got:\n{spaced_out}"
+    );
+    assert!(
+        spaced_out.contains("for details.\nNext sentence."),
+        "following sentence must still split, got:\n{spaced_out}"
+    );
+
+    let lined = concat!(
+        "See [important]\n",
+        "[See also][ref] for details. Next sentence.\n",
+        "\n",
+        "[ref]: https://example.org/x\n",
+    );
+    let lined_out = format_text(lined, &md_cfg()).unwrap();
+    assert!(
+        lined_out.contains("[See also][ref]"),
+        "full reference after a newline shortcut must stay one token, got:\n{lined_out}"
+    );
+    assert!(
+        lined_out.contains("[important]"),
+        "prior shortcut must remain, got:\n{lined_out}"
+    );
+    assert!(
+        lined_out.contains("for details.\nNext sentence."),
+        "following sentence must still split, got:\n{lined_out}"
+    );
+    assert_eq!(format_text(&lined_out, &md_cfg()).unwrap(), lined_out);
+}
+
+#[test]
 fn collapsed_reference_link_stays_one_span() {
     let input = concat!(
         "See [the Fourier. transform][] for details. Next sentence.\n",

--- a/tests/md_ref_link_interior_punct.rs
+++ b/tests/md_ref_link_interior_punct.rs
@@ -1,0 +1,120 @@
+//! GitHub #215 / snapper-e8g6: CommonMark 0.31.2 §6.3 full/collapsed
+//! reference links must stay one inline token. Interior punctuation
+//! is not a sentence boundary. The use stays Prose; the LRD stays
+//! Structure.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::markdown::MarkdownParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn md_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Markdown,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "See [the Fourier. transform][wiki] for details. Next sentence.\n",
+        "\n",
+        "[wiki]: https://example.org/fourier\n",
+    )
+}
+
+#[test]
+fn ticket_lrd_is_structure_not_prose() {
+    let regions = MarkdownParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("[wiki]: https://example.org/fourier")
+        )),
+        "LRD must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(s) if s.contains("[wiki]:"))),
+        "LRD must not be Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_reference_use_stays_prose() {
+    let regions = MarkdownParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains("[the Fourier. transform][wiki]")
+        )),
+        "reference use must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_reference_span_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert!(
+        out.contains("[the Fourier. transform][wiki]"),
+        "reference span must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("[the Fourier.\n") && !out.contains("[the Fourier.\ntransform]"),
+        "must not split inside the reference text, got:\n{out}"
+    );
+    assert!(
+        out.contains("for details.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("for details. Next sentence."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert!(
+        out.contains("[wiki]: https://example.org/fourier"),
+        "LRD must stay its own Structure line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("Next sentence. [wiki]:"),
+        "must not glue dest onto the previous sentence, got:\n{out}"
+    );
+    assert!(
+        out.contains("Next sentence.\n\n[wiki]: https://example.org/fourier"),
+        "blank before the LRD must stay, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Markdown,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn collapsed_reference_link_stays_one_span() {
+    let input = concat!(
+        "See [the Fourier. transform][] for details. Next sentence.\n",
+        "\n",
+        "[the Fourier. transform]: https://example.org/fourier\n",
+    );
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert!(
+        out.contains("[the Fourier. transform][]"),
+        "collapsed span must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("for details.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &md_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
vissue: snapper-e8g6 (parent snapper-etv7). GitHub #215.

unanimous-green-93 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

CommonMark 6.3 [text][ref] and [text][] stay one token. The label
follows immediately (no optional whitespace) so [foo] [bar] stays
two tokens. Shortcut [text] is not matched.

## Test plan
- rustc tests in tests/md_ref_link_interior_punct.rs
- terra: cargo test sentence::unicode