### PR TITLE
fix(org): keep macros atomic across sentence punct

### DIFF
--- a/docs/orgmode/reference/abbreviations.org
+++ b/docs/orgmode/reference/abbreviations.org
@@ -124,6 +124,7 @@ These merge with the built-in list at runtime.
 Periods inside inline tokens never trigger sentence breaks, regardless of abbreviation lists:
 
 - Org links: =[[https://example.com][Ex. Site]]=
+- Org macros: ={{{cite(Smith. 2020)}}}=, ={{{title}}}=
 - Org radio / angle targets: =<<<the Fourier. transform>>>=, =<<sec. intro>>=
 - LaTeX math: =$x = 3.14$=
 - LaTeX commands: =\cite{smith.2024}=

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -66,6 +66,7 @@ These tokens within prose are not split across lines:
 - Inline export snippets: =@@backend:value@@=
 - Radio targets: =<<<contents>>>= (org-element-radio-target-parser)
 - Angle targets: =<<contents>>= (org-element-target-parser)
+- Macros: ={{{name}}}= / ={{{name(args)}}}= (org-element-macro-parser)
 - URLs: =https://...= (trailing sentence punctuation not swallowed)
 
 ** LaTeX (=--format latex=)

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -2538,6 +2538,61 @@ mod tests {
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }
 
+    /// Ticket fixture (Format::Org / GitHub #212): org-element macros
+    /// stay one token so an interior period is not a sentence boundary.
+    /// `Next sentence.` still splits.
+    fn org_macro_fixture() -> &'static str {
+        "See {{{cite(Smith. 2020)}}} for the source. Next sentence.\n"
+    }
+
+    #[test]
+    fn org_macro_interior_punct_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let mac = "{{{cite(Smith. 2020)}}}";
+        let input = org_macro_fixture();
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains(mac) && p.contains("Next sentence.")
+            )),
+            "macro stays inline Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("See {{{cite(Smith. 2020)}}} for the source.\nNext sentence."),
+            "sentence after the macro must reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("Smith.\n") && !out.contains("{{{cite(Smith.\n2020)}}}"),
+            "must not split inside the macro, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+        let wrap_cfg = crate::FormatConfig {
+            format: crate::format::Format::Org,
+            max_width: 28,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let wrapped = format_text(input, &wrap_cfg).unwrap();
+        assert!(
+            wrapped.lines().any(|l| l.contains(mac)),
+            "wrap must not cut inside the macro, got:\n{wrapped}"
+        );
+        assert!(
+            !wrapped.contains("Smith.\n2020"),
+            "must not wrap on the interior period, got:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("Next sentence."),
+            "sentence after the macro must still reflow, got:\n{wrapped}"
+        );
+        assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+    }
+
     /// Ticket fixture (Format::Org / GitHub #177): org-comment-regexp
     /// requires space or EOL after `#`. `#foo` is prose.
     fn hash_comment_space_or_eol_fixture() -> &'static str {

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2297,6 +2297,20 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_org_macro_atomic() {
+        let token = "{{{cite(Smith. 2020)}}}";
+        let sentence = "See {{{cite(Smith. 2020)}}} for the source. Next sentence.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 28, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("Smith.\n2020") && !wrapped.contains("cite(Smith.\n"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn max_width_keeps_math_atomic() {
         let token = "$E = m c^{2}$";
         let sentence = "The identity $E = m c^{2}$ holds in this frame.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -25,6 +25,11 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             r"<<<[^<>\n]+>>>",
             // org-element-target-parser / org-target-regexp: <<contents>>
             r"<<[^<>\n]+>>",
+            // org-element-macro-parser / org-macro.el:
+            // {{{name}}} or {{{name(args)}}}. Name is
+            // [a-zA-Z][-a-zA-Z0-9_]*; args are non-greedy and may
+            // span lines. Two-brace {{...}} is not a macro (GitHub #212).
+            r"\{\{\{[a-zA-Z][-a-zA-Z0-9_]*(?:\((?:.|\n)*?\))?\}\}\}",
             r"\[[^\]]+\]\([^)]+\)",    // Markdown links: [text](url)
             r"!\[[^\]]*\]\([^)]+\)",   // Markdown images: ![alt](url)
             // CommonMark 0.31.2 §6.3 full / collapsed reference links.
@@ -599,7 +604,8 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 
 /// Byte ranges of inline tokens that wrapping must not split (links, images,
 /// reference links `[text][ref]`, inline code, autolinks, math, Org `[[...]]`,
-/// Org `[cite...]`, Org `<<<...>>>` / `<<...>>`, paired spans).
+/// Org `[cite...]`, Org `<<<...>>>` / `<<...>>`, Org `{{{name}}}` /
+/// `{{{name(args)}}}`, paired spans).
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.
@@ -1474,6 +1480,96 @@ mod tests {
             split(text),
             vec![
                 "See <<sec. intro>> in the text.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_macro_interior_punct_is_not_a_sentence_boundary() {
+        // GitHub #212 / snapper-aunh: org-element-macro-parser
+        // {{{name}}} / {{{name(args)}}} stay one token so an interior
+        // period is not a sentence boundary. `Next sentence.` still splits.
+        let mac = "{{{cite(Smith. 2020)}}}";
+        let text = "See {{{cite(Smith. 2020)}}} for the source. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == mac),
+            "org macro must be one token, got {placeholders:?}"
+        );
+        assert!(
+            !placeholders.iter().any(|p| p == "{{cite(Smith. 2020)}}"),
+            "two-brace form is not a macro, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == mac),
+            "macro must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See {{{cite(Smith. 2020)}}} for the source.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_macro_without_args_is_one_token() {
+        let mac = "{{{title}}}";
+        let text = "See {{{title}}} for the source. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == mac),
+            "no-arg macro must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See {{{title}}} for the source.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn two_brace_form_is_not_an_org_macro() {
+        let text = "See {{cite(Smith. 2020)}} for the source. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            !placeholders
+                .iter()
+                .any(|p| p.contains("{{cite") || p.contains("Smith. 2020")),
+            "two-brace {{...}} must not be a macro token, got {placeholders:?}"
+        );
+    }
+
+    #[test]
+    fn unclosed_org_macro_is_not_an_inline_token() {
+        let text = "See {{{cite(Smith. 2020 for the source. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            !placeholders.iter().any(|p| p.contains("{{{cite")),
+            "unclosed macro must not swallow the sentence, got {placeholders:?}"
+        );
+    }
+
+    #[test]
+    fn inline_org_macro_args_may_span_lines() {
+        // org-element-macro-parser args are `(?:.|\n)*?`.
+        let mac = "{{{cite(Smith.\n2020)}}}";
+        let text = "See {{{cite(Smith.\n2020)}}} for the source. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == mac),
+            "multiline-arg macro must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See {{{cite(Smith.\n2020)}}} for the source.".to_string(),
                 "Next sentence.".to_string()
             ]
         );

--- a/tests/org_macros.rs
+++ b/tests/org_macros.rs
@@ -1,0 +1,82 @@
+//! GitHub #212 / snapper-aunh: org-element macros (`{{{name}}}` /
+//! `{{{name(args)}}}`) stay one inline token. Interior punctuation is
+//! not a sentence boundary. The use stays Prose.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "See {{{cite(Smith. 2020)}}} for the source. Next sentence.\n"
+}
+
+#[test]
+fn ticket_macro_use_stays_prose() {
+    let mac = "{{{cite(Smith. 2020)}}}";
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(mac) && s.contains("Next sentence.")
+        )),
+        "macro must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_macro_span_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("{{{cite(Smith. 2020)}}}"),
+        "macro must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("{{{cite(Smith.\n") && !out.contains("Smith.\n2020}}}"),
+        "must not split inside the macro, got:\n{out}"
+    );
+    assert!(
+        out.contains("for the source.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("for the source. Next sentence."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn no_arg_macro_stays_one_span() {
+    let input = "See {{{title}}} for the source. Next sentence.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("{{{title}}}"),
+        "no-arg macro must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("for the source.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
vissue: snapper-aunh (parent snapper-etv7). GitHub #212.

unanimous-green-95 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

org-element-macro-parser. {{{cite(Smith. 2020)}}} stays one token;
Next sentence. still splits.

## Test plan
- rustc tests in tests/org_macros.rs
- terra: cargo test sentence::unicode parser::org