### PR TITLE
fix(latex): treat alltt as code so listing bodies do not reflow as prose

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, and fancyvrb =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut=.
+Built-in: =minted=, =lstlisting=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut=, and =alltt=.
 Adding an unlisted name stops reflow of that environment.
 
 ** structure_envs (latex)

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -95,6 +95,7 @@ These tokens within prose are not split across lines:
 :END:
 - =\\begin{...}= / =\\end{...}= lines are structure
 - fancyvrb =Verbatim= / =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut= are built-in code regions (same FV@Scan class)
+- =alltt= (standard =alltt.sty=) is a built-in code region (raw line breaks)
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= =language== option)
 - Inline =\verb= / =\lstinline= (and extra =[latex].verbatim_commands=, for example =\Verb=) stay atomic; inner =.!?%= do not split or comment

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,8 +16,8 @@ pub struct FormatOverrides {
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
     /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// and fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut;
-    /// entries are added to it.
+    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut, and
+    /// alltt; entries are added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,8 +116,8 @@ pub struct FormatConfig {
     /// Extra LaTeX environments treated as code (no reflow), added to
     /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// and fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut.
-    /// Empty keeps the built-in list.
+    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut, and
+    /// alltt. Empty keeps the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -129,13 +129,14 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
 /// `sageblock`) plus fancyvrb `verbatim*` / `Verbatim` / `BVerbatim` /
 /// `LVerbatim` / `SaveVerbatim` / `VerbatimOut`, moreverb
-/// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, and the
-/// `comment` package env (tree-sitter `comment_environment`: raw
-/// through matching `\end{comment}`). Overleaf `verbatimEnvNames` is
-/// Verbatim, boxedverbatim, tcblisting, codeexample. fancyvrb
-/// `BVerbatim` / `LVerbatim` are the same raw class as `Verbatim`
-/// (GitHub #209). `SaveVerbatim` / `VerbatimOut` are the same
-/// `FV@Scan` class (GitHub #213).
+/// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, the
+/// standard `alltt` package env (raw line breaks, some macros still
+/// expand; GitHub #230), and the `comment` package env (tree-sitter
+/// `comment_environment`: raw through matching `\end{comment}`).
+/// Overleaf `verbatimEnvNames` is Verbatim, boxedverbatim, tcblisting,
+/// codeexample. fancyvrb `BVerbatim` / `LVerbatim` are the same raw
+/// class as `Verbatim` (GitHub #209). `SaveVerbatim` / `VerbatimOut`
+/// are the same `FV@Scan` class (GitHub #213).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
@@ -148,6 +149,7 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "LVerbatim"
             | "SaveVerbatim"
             | "VerbatimOut"
+            | "alltt"
             | "boxedverbatim"
             | "tcblisting"
             | "codeexample"
@@ -2474,6 +2476,76 @@ Some text.
             );
             assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
         }
+    }
+
+    /// Ticket fixture (GitHub #230): alltt.sty is a standard
+    /// verbatim-like env. Body stays Code; following prose still splits.
+    #[test]
+    fn alltt_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{document}\n",
+            "Before. More.\n",
+            "\\begin{alltt}\n",
+            "First line. Second line.\n",
+            "\\end{alltt}\n",
+            "After the block. Next.\n",
+            "\\end{document}\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "alltt body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "alltt body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\begin{alltt}") && out.contains("\\end{alltt}"),
+            "alltt begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "alltt body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "alltt must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after alltt must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let two = concat!(
+            "\\begin{alltt}\n",
+            "First line. Second line.\n",
+            "\\end{alltt}\n",
+            "After the block. Next.\n",
+        );
+        let two_out = format_text(two, &latex_cfg()).unwrap();
+        assert!(
+            two_out.contains("First line. Second line."),
+            "alltt two-sentence body must stay one source line, got:\n{two_out}"
+        );
+        assert!(
+            !two_out.contains("First line.\nSecond line."),
+            "alltt two-sentence body must not split, got:\n{two_out}"
+        );
+        assert!(
+            two_out.contains("After the block.\nNext."),
+            "prose after alltt must still split, got:\n{two_out}"
+        );
+        assert_eq!(format_text(&two_out, &latex_cfg()).unwrap(), two_out);
     }
 
     #[test]

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -1,6 +1,7 @@
 //! snapper-3tj3 / GitHub #98: Overleaf verbatimEnvNames are Code, not prose.
 //! GitHub #209: fancyvrb BVerbatim / LVerbatim are the same.
 //! GitHub #213: fancyvrb SaveVerbatim / VerbatimOut are the same FV@Scan class.
+//! GitHub #230: alltt.sty is a standard verbatim-like env (raw line breaks).
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -209,4 +210,72 @@ fn saveverbatim_verbatimout_fixture_is_code_and_does_not_reflow() {
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
+}
+
+/// Ticket fixture (GitHub #230): alltt.sty bodies stay Code; following
+/// prose still splits.
+#[test]
+fn alltt_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{document}\n",
+        "Before. More.\n",
+        "\\begin{alltt}\n",
+        "First line. Second line.\n",
+        "\\end{alltt}\n",
+        "After the block. Next.\n",
+        "\\end{document}\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Code { body, .. } if body.contains("First line. Second line.")
+        )),
+        "alltt body must be Code, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "alltt body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\begin{alltt}") && out.contains("\\end{alltt}"),
+        "alltt begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "alltt body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "alltt must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after alltt must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let two = concat!(
+        "\\begin{alltt}\n",
+        "First line. Second line.\n",
+        "\\end{alltt}\n",
+        "After the block. Next.\n",
+    );
+    let two_out = format_text(two, &latex_cfg()).unwrap();
+    assert!(
+        two_out.contains("First line. Second line."),
+        "alltt two-sentence body must stay one source line, got:\n{two_out}"
+    );
+    assert!(
+        !two_out.contains("First line.\nSecond line."),
+        "alltt two-sentence body must not split, got:\n{two_out}"
+    );
+    assert!(
+        two_out.contains("After the block.\nNext."),
+        "prose after alltt must still split, got:\n{two_out}"
+    );
+    assert_eq!(format_text(&two_out, &latex_cfg()).unwrap(), two_out);
 }


### PR DESCRIPTION
## Summary

`alltt.sty` is a standard verbatim-like environment (some macros still expand; line breaks stay raw). It was missing from `is_builtin_code_env`, so unknown-env bodies were classified as Prose and reflowed.

Classify `alltt` as builtin Code through the matching `\end`. Following prose still splits.

Closes #230

## Fixture

```tex
\begin{document}
Before. More.
\begin{alltt}
First line. Second line.
\end{alltt}
After the block. Next.
\end{document}
```

Native `--format latex`: alltt body stays `First line. Second line.`; `After the block.` still splits.

## Test plan

- [x] `cargo test --offline --lib parser::latex` (76 passed) on rg.terra
- [x] `cargo test --offline --test latex_verbatim_envs` (5 passed)
- [x] `cargo clippy --offline --lib -- -D warnings`
- [x] Native CLI fixture: body identity; `After the block.` / `Next.` split