### PR TITLE
fix(org): keep inline footnote references atomic

### DIFF
--- a/docs/orgmode/reference/abbreviations.org
+++ b/docs/orgmode/reference/abbreviations.org
@@ -126,6 +126,7 @@ Periods inside inline tokens never trigger sentence breaks, regardless of abbrev
 - Org links: =[[https://example.com][Ex. Site]]=
 - Org macros: ={{{cite(Smith. 2020)}}}=, ={{{title}}}=
 - Org radio / angle targets: =<<<the Fourier. transform>>>=, =<<sec. intro>>=
+- Org inline footnotes: =[fn:: the Fourier. transform]=, =[fn:note: the Fourier. transform]=
 - LaTeX math: =$x = 3.14$=
 - LaTeX commands: =\cite{smith.2024}=
 - Markdown links: =[Example Inc.](url)=, =[the Fourier. transform][wiki]=

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -67,6 +67,7 @@ These tokens within prose are not split across lines:
 - Radio targets: =<<<contents>>>= (org-element-radio-target-parser)
 - Angle targets: =<<contents>>= (org-element-target-parser)
 - Macros: ={{{name}}}= / ={{{name(args)}}}= (org-element-macro-parser)
+- Inline footnotes: =[fn:: def]= / =[fn:name: def]= (org-element-footnote-reference-parser)
 - URLs: =https://...= (trailing sentence punctuation not swallowed)
 
 ** LaTeX (=--format latex=)

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -2593,6 +2593,88 @@ mod tests {
         assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
     }
 
+    /// Ticket fixture (Format::Org / GitHub #231): org-element inline
+    /// footnote references stay one token so an interior period is not
+    /// a sentence boundary. `Next sentence.` still splits.
+    fn inline_footnote_fixture() -> &'static str {
+        "See [fn:: the Fourier. transform] in the notes. Next sentence.\n"
+    }
+
+    #[test]
+    fn org_inline_footnote_interior_punct_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let note = "[fn:: the Fourier. transform]";
+        let input = inline_footnote_fixture();
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains(note) && p.contains("Next sentence.")
+            )),
+            "inline footnote stays inline Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("See [fn:: the Fourier. transform] in the notes.\nNext sentence."),
+            "sentence after the inline footnote must reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("Fourier.\n") && !out.contains("[fn:: the Fourier.\ntransform]"),
+            "must not split inside the inline footnote, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+        let wrap_cfg = crate::FormatConfig {
+            format: crate::format::Format::Org,
+            max_width: 28,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let wrapped = format_text(input, &wrap_cfg).unwrap();
+        assert!(
+            wrapped.lines().any(|l| l.contains(note)),
+            "wrap must not cut inside the inline footnote, got:\n{wrapped}"
+        );
+        assert!(
+            !wrapped.contains("Fourier.\ntransform"),
+            "must not wrap on the interior period, got:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("Next sentence."),
+            "sentence after the inline footnote must still reflow, got:\n{wrapped}"
+        );
+        assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+    }
+
+    #[test]
+    fn named_inline_footnote_interior_punct_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let note = "[fn:note: the Fourier. transform]";
+        let input = "See [fn:note: the Fourier. transform] in the notes. Next sentence.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains(note) && p.contains("Next sentence.")
+            )),
+            "named inline footnote stays inline Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("See [fn:note: the Fourier. transform] in the notes.\nNext sentence."),
+            "sentence after the named inline footnote must reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("Fourier.\n") && !out.contains("[fn:note: the Fourier.\ntransform]"),
+            "must not split inside the named inline footnote, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
     /// Ticket fixture (Format::Org / GitHub #177): org-comment-regexp
     /// requires space or EOL after `#`. `#foo` is prose.
     fn hash_comment_space_or_eol_fixture() -> &'static str {

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2311,6 +2311,20 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_org_inline_footnote_atomic() {
+        let token = "[fn:: the Fourier. transform]";
+        let sentence = "See [fn:: the Fourier. transform] in the notes. Next sentence.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 28, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("Fourier.\ntransform"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn max_width_keeps_math_atomic() {
         let token = "$E = m c^{2}$";
         let sentence = "The identity $E = m c^{2}$ holds in this frame.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -19,6 +19,10 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             // org-element 5.5 citation: [cite/style:prefix;@key p. 7;suffix]
             // Must be atomic so a page locator is not a sentence boundary.
             r"\[cite(?:/[-a-zA-Z0-9_/]*)?:[^\]]*\]",
+            // org-element-footnote-reference-parser / org-footnote-re
+            // inline arm: [fn::def] / [fn:LABEL:def]. First ] closes.
+            // Standard [fn:LABEL] is not a token (GitHub #231).
+            r"\[fn:(?:[-_\w]+)?:[^\]]*\]",
             // org-element-radio-target-parser / org-radio-target-regexp:
             // <<<contents>>> with no <, >, or newline. Must precede <<...>>
             // so the triple-angle form stays one token (GitHub #211).
@@ -152,7 +156,10 @@ pub fn protect_inline_tokens_with(
 ) -> (String, Vec<String>) {
     let mut placeholders: Vec<String> = Vec::new();
     let after_verb = protect_latex_verbatim(text, &mut placeholders, extra_verbatim_commands);
-    let after_spans = protect_paired_spans(&after_verb, &mut placeholders);
+    // Footnote references before paired spans so a nested `[[link]]`
+    // closer does not end `[fn:: …]` early (GitHub #231).
+    let after_fn = protect_org_footnote_references(&after_verb, &mut placeholders);
+    let after_spans = protect_paired_spans(&after_fn, &mut placeholders);
     let protected = INLINE_TOKEN_RE.replace_all(&after_spans, |caps: &regex::Captures| {
         let idx = placeholders.len();
         placeholders.push(caps[0].to_string());
@@ -326,6 +333,78 @@ fn find_unescaped_brace_close(text: &str, mut i: usize) -> Option<usize> {
         }
         if bytes[i] == b'}' {
             return Some(i + 1);
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Protect `[fn::def]` / `[fn:LABEL:def]` before paired spans.
+fn protect_org_footnote_references(text: &str, placeholders: &mut Vec<String>) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < text.len() {
+        if let Some(end) = org_footnote_reference_span_end(text, i) {
+            push_placeholder(&mut out, placeholders, &text[i..end]);
+            i = end;
+            continue;
+        }
+        let ch = text[i..].chars().next().expect("i is in range");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+
+/// org-footnote-re inline arm + org-element-footnote-reference-parser.
+///
+/// `[fn::def]` and `[fn:LABEL:def]` only. Standard `[fn:LABEL]` stays
+/// prose so `See the claim.[fn:1]` is not split at `claim.`.
+/// Closing `]` is scan-lists on `[]` (nested brackets). A newline
+/// ends the object (org-footnote-re `.` / org-element successor
+/// `line-end-position`).
+fn org_footnote_reference_span_end(text: &str, at: usize) -> Option<usize> {
+    let rest = text.get(at..)?;
+    if !rest.starts_with("[fn:") {
+        return None;
+    }
+    let bytes = text.as_bytes();
+    let mut i = at + 4;
+    while i < bytes.len() {
+        let ch = text[i..].chars().next()?;
+        if ch == '-' || ch == '_' || ch.is_alphanumeric() {
+            i += ch.len_utf8();
+        } else {
+            break;
+        }
+    }
+    if i >= bytes.len() || bytes[i] != b':' {
+        return None;
+    }
+    org_scan_lists_same_line(text, at, b'[', b']')
+}
+
+/// `scan-lists` on one pair, stopped at newline.
+fn org_scan_lists_same_line(text: &str, open_at: usize, open: u8, close: u8) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if bytes.get(open_at) != Some(&open) {
+        return None;
+    }
+    let mut depth = 1usize;
+    let mut i = open_at + 1;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'\n' {
+            return None;
+        }
+        if b == open {
+            depth += 1;
+        } else if b == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i + 1);
+            }
         }
         i += 1;
     }
@@ -604,8 +683,8 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 
 /// Byte ranges of inline tokens that wrapping must not split (links, images,
 /// reference links `[text][ref]`, inline code, autolinks, math, Org `[[...]]`,
-/// Org `[cite...]`, Org `<<<...>>>` / `<<...>>`, Org `{{{name}}}` /
-/// `{{{name(args)}}}`, paired spans).
+/// Org `[cite...]`, Org `[fn::…]` / `[fn:LABEL:…]`, Org `<<<...>>>` /
+/// `<<...>>`, Org `{{{name}}}` / `{{{name(args)}}}`, paired spans).
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.
@@ -614,6 +693,11 @@ pub fn atomic_inline_spans(text: &str) -> Vec<(usize, usize)> {
     let bytes = text.as_bytes();
     let mut i = 0;
     while i < text.len() {
+        if let Some(end) = org_footnote_reference_span_end(text, i) {
+            spans.push((i, end));
+            i = end;
+            continue;
+        }
         if bytes[i] == b'`' {
             if let Some(end) = find_md_code_span(text, i) {
                 spans.push((i, end));
@@ -1597,6 +1681,125 @@ mod tests {
             split(text),
             vec![
                 "See [cite/t:see;@foo p. 7;@bar pp. 4;by foo].".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_footnote_reference_interior_punct_is_not_a_sentence_boundary() {
+        // GitHub #231 / snapper-gjkj: org-element-footnote-reference-parser
+        // `[fn:: …]` stays one token so an interior period is not a
+        // sentence boundary. `Next sentence.` still splits.
+        let note = "[fn:: the Fourier. transform]";
+        let text = "See [fn:: the Fourier. transform] in the notes. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == note),
+            "inline footnote must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == note),
+            "inline footnote must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See [fn:: the Fourier. transform] in the notes.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn named_inline_org_footnote_reference_is_one_token() {
+        let note = "[fn:note: the Fourier. transform]";
+        let text = "See [fn:note: the Fourier. transform] in the notes. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == note),
+            "named inline footnote must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See [fn:note: the Fourier. transform] in the notes.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+        let hyphen = "[fn:foo-bar: the Fourier. transform]";
+        let hyphen_text = "See [fn:foo-bar: the Fourier. transform] in the notes. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(hyphen_text);
+        assert!(
+            placeholders.iter().any(|p| p == hyphen),
+            "hyphen label must stay one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(hyphen_text),
+            vec![
+                "See [fn:foo-bar: the Fourier. transform] in the notes.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn standard_org_footnote_reference_is_not_an_inline_token() {
+        // `[fn:1]` is org-footnote-re standard, not the inline arm.
+        // Protecting it would split `See the claim.[fn:1]` at `claim.`.
+        let text = "See the claim.[fn:1] Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            !placeholders.iter().any(|p| p == "[fn:1]"),
+            "standard [fn:1] must not be a token, got {placeholders:?}"
+        );
+        let parts = split(text);
+        assert!(
+            parts.iter().any(|p| p.contains("See the claim.[fn:1]")),
+            "standard ref must stay on the preceding sentence, got {parts:?}"
+        );
+    }
+
+    #[test]
+    fn unclosed_inline_org_footnote_is_not_an_inline_token() {
+        let text = "See [fn:: the Fourier. transform in the notes. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            !placeholders.iter().any(|p| p.contains("[fn::")),
+            "unclosed inline footnote must not swallow the sentence, got {placeholders:?}"
+        );
+    }
+
+    #[test]
+    fn nested_bracket_inline_org_footnote_is_one_token() {
+        // org-element scan-lists on [] so `[fig. 1]` and `[[link]]` stay inside.
+        let note = "[fn:: see [fig. 1]]";
+        let text = "See [fn:: see [fig. 1]] in the notes. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == note),
+            "nested-bracket footnote must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See [fn:: see [fig. 1]] in the notes.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+        let link = "[fn:: see [[https://ex.com][ex. site]]]";
+        let link_text = "See [fn:: see [[https://ex.com][ex. site]]] in the notes. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(link_text);
+        assert!(
+            placeholders.iter().any(|p| p == link),
+            "nested [[link]] must stay inside the footnote, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(link_text),
+            vec![
+                "See [fn:: see [[https://ex.com][ex. site]]] in the notes.".to_string(),
                 "Next sentence.".to_string()
             ]
         );

--- a/tests/org_inline_footnotes.rs
+++ b/tests/org_inline_footnotes.rs
@@ -1,0 +1,112 @@
+//! GitHub #231 / snapper-gjkj: org-element footnote references
+//! (`[fn:: …]` / `[fn:note: …]`) stay one inline token. Interior
+//! punctuation is not a sentence boundary. The use stays Prose.
+//! Sibling of snapper-s5la (column-0 `[fn:LABEL]` definitions).
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "See [fn:: the Fourier. transform] in the notes. Next sentence.\n"
+}
+
+#[test]
+fn ticket_inline_footnote_stays_prose() {
+    let note = "[fn:: the Fourier. transform]";
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(note) && s.contains("Next sentence.")
+        )),
+        "inline footnote must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_footnote_span_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("[fn:: the Fourier. transform]"),
+        "inline footnote must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("[fn:: the Fourier.\n") && !out.contains("Fourier.\ntransform]"),
+        "must not split inside the inline footnote, got:\n{out}"
+    );
+    assert!(
+        out.contains("in the notes.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("in the notes. Next sentence."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+
+    // Bracket-depth merge can glue a UAX split at width 0. Wrap still
+    // cuts on `Fourier.` unless [fn::…] is an atomic inline token.
+    let wrap_cfg = FormatConfig {
+        format: Format::Org,
+        max_width: 28,
+        ..Default::default()
+    }
+    .without_safety_backstops();
+    let wrapped = format_text(input, &wrap_cfg).unwrap();
+    assert!(
+        wrapped
+            .lines()
+            .any(|l| l.contains("[fn:: the Fourier. transform]")),
+        "wrap must not cut inside the inline footnote, got:\n{wrapped}"
+    );
+    assert!(
+        !wrapped.contains("Fourier.\ntransform"),
+        "must not wrap on the interior period, got:\n{wrapped}"
+    );
+    assert!(
+        wrapped.contains("Next sentence."),
+        "sentence after the footnote must still reflow, got:\n{wrapped}"
+    );
+    assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+}
+
+#[test]
+fn named_inline_footnote_stays_one_span() {
+    let input = "See [fn:note: the Fourier. transform] in the notes. Next sentence.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("[fn:note: the Fourier. transform]"),
+        "named inline footnote must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("Fourier.\ntransform"),
+        "must not split inside the named inline footnote, got:\n{out}"
+    );
+    assert!(
+        out.contains("in the notes.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
vissue: snapper-gjkj (parent snapper-etv7). GitHub #231.

unanimous-green-98 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

org-element-footnote-reference-parser. [fn:: the Fourier. transform]
stays one token; Next sentence. still splits. Does not land src_/call_
(snapper-pdtw is still open).

## Test plan
- rustc tests in tests/org_inline_footnotes.rs
- terra: cargo test sentence::unicode parser::org