### PR TITLE
fix(latex): treat lstlisting star as a code environment

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,8 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut=, and =alltt=.
+Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut=, and =alltt=.
+
 Adding an unlisted name stops reflow of that environment.
 
 ** structure_envs (latex)

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -97,8 +97,9 @@ These tokens within prose are not split across lines:
 - =\\begin{...}= / =\\end{...}= lines are structure
 - fancyvrb =Verbatim= / =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut= are built-in code regions (same FV@Scan class)
 - =alltt= (standard =alltt.sty=) is a built-in code region (raw line breaks)
+- listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
 - Extra names from =[latex].verbatim_envs= are code regions too
-- Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= =language== option)
+- Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= / =lstlisting*= =language== option)
 - Inline =\verb= / =\lstinline= (and extra =[latex].verbatim_commands=, for example =\Verb=) stay atomic; inner =.!?%= do not split or comment
 
 *** Prose regions (reflowed)

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub struct FormatOverrides {
     pub max_width: Option<usize>,
     /// Extra LaTeX environments treated as code (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
-    /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
+    /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut, and
     /// alltt; entries are added to it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! - **Org-mode**: drawers, tables, keywords preserved; `#+BEGIN_SRC` is
 //!   `Region::Code` (comment reflow via `[code.<lang>]`, optional formatters)
-//! - **LaTeX**: preamble and math preserved; `minted` / `lstlisting` are code regions
+//! - **LaTeX**: preamble and math preserved; `minted` / `lstlisting` / `lstlisting*` are code regions
 //! - **Markdown**: front matter and headings preserved; fenced blocks are code regions
 //! - **RST**: directives and literals preserved; admonition/figure/topic/sidebar/container bodies reflow; `.. code-block::` is a code region
 //! - **Plaintext**: everything treated as prose
@@ -114,7 +114,7 @@ pub struct FormatConfig {
     /// and assert the oracle themselves.
     pub render_backstop: bool,
     /// Extra LaTeX environments treated as code (no reflow), added to
-    /// minted/lstlisting/verbatim/comment, filecontents, tree-sitter
+    /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut, and
     /// alltt. Empty keeps the built-in list.

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -117,9 +117,10 @@ fn is_float_env(name: &str) -> bool {
 static MINTED_LANG_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\\begin\{minted\}\s*(?:\[[^\]]*\])?\s*\{([^}]+)\}").unwrap());
 
-/// `\begin{lstlisting}[language=LANG, ...]` -- language is an option key.
+/// `\begin{lstlisting}[language=LANG, ...]` / `\begin{lstlisting*}[...]`.
+/// listings.sty `\lstnewenvironment{lstlisting}` defines both names.
 static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"\\begin\{lstlisting\}\s*\[[^\]]*language\s*=\s*([A-Za-z0-9_+.\-]+)").unwrap()
+    Regex::new(r"\\begin\{lstlisting\*?\}\s*\[[^\]]*language\s*=\s*([A-Za-z0-9_+.\-]+)").unwrap()
 });
 
 /// Built-in source-code environments whose body is `Region::Code`.
@@ -136,12 +137,15 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Overleaf `verbatimEnvNames` is Verbatim, boxedverbatim, tcblisting,
 /// codeexample. fancyvrb `BVerbatim` / `LVerbatim` are the same raw
 /// class as `Verbatim` (GitHub #209). `SaveVerbatim` / `VerbatimOut`
-/// are the same `FV@Scan` class (GitHub #213).
+/// are the same `FV@Scan` class (GitHub #213). listings.sty
+/// `\lstnewenvironment{lstlisting}` also defines `lstlisting*` (same
+/// raw body scan; GitHub #234).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
         "minted"
             | "lstlisting"
+            | "lstlisting*"
             | "verbatim"
             | "verbatim*"
             | "Verbatim"
@@ -745,7 +749,7 @@ impl<'a> ParseState<'a> {
             MINTED_LANG_RE
                 .captures(header_src)
                 .map(|c| c.get(1).unwrap().as_str().to_string())
-        } else if env_name == "lstlisting" {
+        } else if env_name == "lstlisting" || env_name == "lstlisting*" {
             LSTLISTING_LANG_RE
                 .captures(header_src)
                 .map(|c| c.get(1).unwrap().as_str().to_string())
@@ -2546,6 +2550,125 @@ Some text.
             "prose after alltt must still split, got:\n{two_out}"
         );
         assert_eq!(format_text(&two_out, &latex_cfg()).unwrap(), two_out);
+    }
+
+    /// Ticket fixture (GitHub #234): listings.sty `lstlisting*` is the
+    /// starred twin of `lstlisting`. Body stays Code; following prose
+    /// still splits.
+    #[test]
+    fn lstlisting_star_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{lstlisting*}\n",
+            "First line. Second line.\n",
+            "\\end{lstlisting*}\n",
+            "After the block. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "lstlisting* body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "lstlisting* body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\begin{lstlisting*}") && out.contains("\\end{lstlisting*}"),
+            "lstlisting* begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "lstlisting* body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "lstlisting* must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after lstlisting* must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let lang = concat!(
+            "\\begin{lstlisting*}[language=Python]\n",
+            "print(1) # First. Second.\n",
+            "\\end{lstlisting*}\n",
+            "After the block. Next.\n",
+        );
+        let lang_regions = LatexParser::default().parse(lang);
+        let lang_code = lang_regions.iter().find_map(|r| match r {
+            Region::Code {
+                lang, body, header, ..
+            } => Some((lang.as_deref(), body.as_str(), header.as_str())),
+            _ => None,
+        });
+        let Some((got_lang, body, header)) = lang_code else {
+            panic!("lstlisting* with language= must be Code, got: {lang_regions:?}");
+        };
+        assert_eq!(
+            got_lang,
+            Some("Python"),
+            "lstlisting* language= must parse like lstlisting, got lang={got_lang:?}"
+        );
+        assert!(
+            header.contains(r"\begin{lstlisting*}[language=Python]"),
+            "optional language= must stay on the begin header, got header={header:?}"
+        );
+        assert!(
+            body.contains("print(1) # First. Second."),
+            "lstlisting* language= body must stay Code, got body={body:?}"
+        );
+        let lang_out = format_text(lang, &latex_cfg()).unwrap();
+        assert!(
+            lang_out.contains("print(1) # First. Second."),
+            "lstlisting* language= body must not reflow, got:\n{lang_out}"
+        );
+        assert!(
+            lang_out.contains("After the block.\nNext."),
+            "prose after lstlisting* language= must still split, got:\n{lang_out}"
+        );
+        assert_eq!(format_text(&lang_out, &latex_cfg()).unwrap(), lang_out);
+
+        let raw = concat!(
+            "\\begin{lstlisting*}\n",
+            "print(1) % \\end{lstlisting*}\n",
+            "After the block. Next.\n",
+        );
+        let raw_regions = LatexParser::default().parse(raw);
+        let raw_code = raw_regions.iter().find_map(|r| match r {
+            Region::Code { body, footer, .. } => Some((body.as_str(), footer.as_str())),
+            _ => None,
+        });
+        let (raw_body, raw_footer) = raw_code.expect(&format!(
+            "lstlisting* must stay Code on %, got: {raw_regions:?}"
+        ));
+        assert!(
+            raw_body.contains("print(1)"),
+            "lstlisting* raw scan must keep source before %, got body={raw_body:?}"
+        );
+        assert!(
+            !raw_body.contains("After the block"),
+            "% must not hide \\end{{lstlisting*}}; after-text is not listing body, got body={raw_body:?}"
+        );
+        assert!(
+            raw_footer.contains(r"\end{lstlisting*}"),
+            "lstlisting* footer must close on raw \\end, got footer={raw_footer:?}"
+        );
+        assert!(
+            raw_regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("After the block"))),
+            "prose after lstlisting* % closer must resume, got: {raw_regions:?}"
+        );
     }
 
     #[test]

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -2,6 +2,7 @@
 //! GitHub #209: fancyvrb BVerbatim / LVerbatim are the same.
 //! GitHub #213: fancyvrb SaveVerbatim / VerbatimOut are the same FV@Scan class.
 //! GitHub #230: alltt.sty is a standard verbatim-like env (raw line breaks).
+//! GitHub #234: listings.sty lstlisting* is the same raw scan as lstlisting.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -278,4 +279,48 @@ fn alltt_fixture_is_code_and_does_not_reflow() {
         "prose after alltt must still split, got:\n{two_out}"
     );
     assert_eq!(format_text(&two_out, &latex_cfg()).unwrap(), two_out);
+}
+
+/// Ticket fixture (GitHub #234): listings.sty lstlisting* bodies stay
+/// Code; following prose still splits.
+#[test]
+fn lstlisting_star_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{lstlisting*}\n",
+        "First line. Second line.\n",
+        "\\end{lstlisting*}\n",
+        "After the block. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Code { body, .. } if body.contains("First line. Second line.")
+        )),
+        "lstlisting* body must be Code, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "lstlisting* body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\begin{lstlisting*}") && out.contains("\\end{lstlisting*}"),
+        "lstlisting* begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "lstlisting* body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "lstlisting* must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after lstlisting* must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 }


### PR DESCRIPTION
vissue: snapper-tfw6 (parent snapper-etv7). GitHub #234.

unanimous-green-99 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

listings.sty lstlisting* uses the same raw scan as lstlisting.
The body stays Code; After the block. still splits.

## Test plan
- rustc tests in tests/latex_verbatim_envs.rs
- terra: cargo test parser::latex