### PR TITLE
fix(org): keep backslash-backslash line breaks as structure

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -33,6 +33,7 @@ The classification depends on the format.
 - List item markers (=-=, =+=, =1.=); continuation sentences hang at the marker width
 - LaTeX environments (=\begin{equation}= ... =\end{equation}=, =\begin{align}=, etc.)
 - Display math (=\[= ... =\]=)
+- Line breaks (org-element-line-break-parser: =\\= plus optional spaces or tabs at end of line)
 - Inline export snippets (=@@latex:\newpage@@=, =@@html:<br>@@=)
 
 *** Code regions (=#+BEGIN_SRC= ... =#+END_SRC=)

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -72,6 +72,33 @@ pub(crate) fn org_caption_marker_len(line: &str) -> Option<usize> {
     Some(lead + i)
 }
 
+/// org-element-line-break-parser `\\\\[ \t]*$`.
+///
+/// Byte offset of the `\\` that starts the line-break object. Trailing
+/// spaces or tabs after `\\` stay on the object. `\\[2ex]` is not a match.
+pub(crate) fn org_line_break_at(line: &str) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut end = bytes.len();
+    while end > 0 && (bytes[end - 1] == b' ' || bytes[end - 1] == b'\t') {
+        end -= 1;
+    }
+    if end >= 2 && bytes[end - 2] == b'\\' && bytes[end - 1] == b'\\' {
+        Some(end - 2)
+    } else {
+        None
+    }
+}
+
+/// True when `s` is a spliced org line-break Structure (`\\` plus optional
+/// `[ \t]*` and the line terminator).
+pub(crate) fn is_org_line_break_structure(s: &str) -> bool {
+    let body = s
+        .strip_suffix("\r\n")
+        .or_else(|| s.strip_suffix('\n'))
+        .unwrap_or(s);
+    org_line_break_at(body) == Some(0)
+}
+
 /// org-element / org-mode display math (`$$` or `\[`).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum DisplayMathDelim {
@@ -425,6 +452,162 @@ impl OrgParser {
         }
     }
 
+    /// Hung list/caption/footnote text: prose, then an org line-break
+    /// Structure (`\\[ \t]*$` plus terminator) or a lone terminator.
+    fn emit_hung_text(
+        input: &str,
+        line: &Line<'_>,
+        text_from: usize,
+        regions: &mut Vec<SpannedRegion>,
+    ) {
+        let text = &line.text[text_from..];
+        if let Some(rel) = org_line_break_at(text) {
+            if rel > 0 {
+                regions.push(SpannedRegion::prose(
+                    text[..rel].to_string(),
+                    ByteSpan::new(line.start + text_from, line.start + text_from + rel),
+                ));
+            }
+            let hard = ByteSpan::new(line.start + text_from + rel, line.end);
+            if !hard.is_empty() {
+                regions.push(SpannedRegion::structure(input, hard));
+            }
+            return;
+        }
+        if !text.is_empty() {
+            regions.push(SpannedRegion::prose(
+                text.to_string(),
+                ByteSpan::new(line.start + text_from, line.start + line.text.len()),
+            ));
+        }
+        let term = line.terminator_span();
+        if !term.is_empty() {
+            regions.push(SpannedRegion::structure(input, term));
+        }
+    }
+
+    /// Append `line.text[from..]` to the running prose buffer.
+    ///
+    /// An org line break flushes prose and emits `\\` plus trailing
+    /// `[ \t]*` and the terminator as Structure so splice copies those
+    /// source bytes (GitHub #232).
+    fn push_prose_or_line_break(
+        input: &str,
+        line: &Line<'_>,
+        from: usize,
+        current_prose: &mut String,
+        prose_span: &mut Option<ByteSpan>,
+        regions: &mut Vec<SpannedRegion>,
+        join_space: bool,
+    ) {
+        let piece = &line.text[from..];
+        if let Some(rel) = org_line_break_at(piece) {
+            if !piece[..rel].trim().is_empty() {
+                let lead = Line {
+                    start: line.start + from,
+                    end: line.start + from + rel,
+                    text: &piece[..rel],
+                };
+                push_prose_line(current_prose, prose_span, &lead, join_space, false);
+            }
+            flush_prose_spanned(current_prose, prose_span, regions);
+            let hard = ByteSpan::new(line.start + from + rel, line.end);
+            if !hard.is_empty() {
+                regions.push(SpannedRegion::structure(input, hard));
+            }
+            return;
+        }
+        if from == 0 {
+            push_prose_line(current_prose, prose_span, line, join_space, true);
+            return;
+        }
+        let rest = Line {
+            start: line.start + from,
+            end: line.end,
+            text: piece,
+        };
+        push_prose_line(current_prose, prose_span, &rest, join_space, true);
+    }
+
+    /// Split same-line `\[CONTENTS\]` into Structure islands (Kang / org-syntax 5.2).
+    /// Glue space before `\[` stays on the island so reflow does not break
+    /// `The root is \[ x = a.b \]`. Leftover-start indent stays on the island.
+    /// Returns true when at least one same-line pair was emitted.
+    fn emit_same_line_bracket_fragments(
+        input: &str,
+        line: &Line<'_>,
+        current_prose: &mut String,
+        prose_span: &mut Option<ByteSpan>,
+        regions: &mut Vec<SpannedRegion>,
+    ) -> bool {
+        let mut rel = 0;
+        let mut found = false;
+        while let Some((open, after_close)) = Self::same_line_bracket_fragment(&line.text[rel..]) {
+            found = true;
+            let open_abs = rel + open;
+            let end_abs = rel + after_close;
+            let prefix = &line.text[rel..open_abs];
+            let lead_glue = if prefix.trim().is_empty() {
+                0
+            } else {
+                prefix.len() - prefix.trim_end_matches([' ', '\t']).len()
+            };
+            // Prose span must stop before the glue space; splice copies
+            // Structure from source and overlapping ranges drop the space.
+            // Whitespace-only leftover-start indent is not prose: pushing
+            // it writes prose_span then flush skips take(), so the next
+            // line extends over the math and splice drops it.
+            if !prefix.trim().is_empty() && prefix.len() > lead_glue {
+                let lead = Line {
+                    start: line.start + rel,
+                    end: line.start + open_abs - lead_glue,
+                    text: &line.text[rel..open_abs - lead_glue],
+                };
+                push_prose_line(current_prose, prose_span, &lead, true, false);
+            }
+            flush_prose_spanned(current_prose, prose_span, regions);
+            let island_start = if prefix.trim().is_empty() {
+                line.start + rel
+            } else {
+                line.start + open_abs - lead_glue
+            };
+            let rest_after = &line.text[end_abs..];
+            let trail_glue = if rest_after.trim().is_empty() {
+                0
+            } else {
+                rest_after.len() - rest_after.trim_start_matches([' ', '\t']).len()
+            };
+            let island_end = if rest_after.trim().is_empty() {
+                line.end
+            } else {
+                line.start + end_abs + trail_glue
+            };
+            regions.push(SpannedRegion::structure(
+                input,
+                ByteSpan::new(island_start, island_end),
+            ));
+            rel = end_abs + trail_glue;
+            if rest_after.trim().is_empty() {
+                return true;
+            }
+        }
+        if !found {
+            return false;
+        }
+        if rel < line.text.len() && !line.text[rel..].trim().is_empty() {
+            Self::push_prose_or_line_break(
+                input,
+                line,
+                rel,
+                current_prose,
+                prose_span,
+                regions,
+                true,
+            );
+        }
+        true
+    }
+
     fn inside_opaque(stack: &[OpenGreater]) -> bool {
         stack.iter().any(|b| b.kind == GreaterKind::Opaque)
     }
@@ -705,17 +888,7 @@ impl FormatParser for OrgParser {
                 list_item_indent = Some(marker_len);
                 let marker_span = ByteSpan::new(line.start, line.start + marker_len);
                 regions.push(SpannedRegion::structure(input, marker_span));
-                if line_text.len() > marker_len {
-                    let text = &line_text[marker_len..];
-                    regions.push(SpannedRegion::prose(
-                        text.to_string(),
-                        ByteSpan::new(line.start + marker_len, line.start + line_text.len()),
-                    ));
-                }
-                let term = line.terminator_span();
-                if !term.is_empty() {
-                    regions.push(SpannedRegion::structure(input, term));
-                }
+                Self::emit_hung_text(input, &line, marker_len, &mut regions);
                 continue;
             }
 
@@ -776,17 +949,7 @@ impl FormatParser for OrgParser {
                 list_item_indent = Some(marker_len);
                 let marker_span = ByteSpan::new(line.start, line.start + marker_len);
                 regions.push(SpannedRegion::structure(input, marker_span));
-                if line_text.len() > marker_len {
-                    let text = &line_text[marker_len..];
-                    regions.push(SpannedRegion::prose(
-                        text.to_string(),
-                        ByteSpan::new(line.start + marker_len, line.start + line_text.len()),
-                    ));
-                }
-                let term = line.terminator_span();
-                if !term.is_empty() {
-                    regions.push(SpannedRegion::structure(input, term));
-                }
+                Self::emit_hung_text(input, &line, marker_len, &mut regions);
                 continue;
             }
 
@@ -794,33 +957,11 @@ impl FormatParser for OrgParser {
             if let Some(caps) = LIST_ITEM_RE.captures(line_text) {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 let marker = caps.get(1).unwrap().as_str();
-                let text = caps.get(2).unwrap().as_str();
                 // Track indent for continuation detection: text starts at marker length
                 list_item_indent = Some(marker.len());
                 let marker_span = ByteSpan::new(line.start, line.start + marker.len());
                 regions.push(SpannedRegion::structure(input, marker_span));
-                if Self::find_unescaped_display_bracket(text, 0, b'[').is_some() {
-                    Self::emit_bracket_math_text(
-                        input,
-                        line.start + marker.len(),
-                        text,
-                        line.end,
-                        Some(line.terminator_span()),
-                        &mut regions,
-                        &mut in_display_math,
-                    );
-                    continue;
-                }
-                if !text.is_empty() {
-                    regions.push(SpannedRegion::prose(
-                        text.to_string(),
-                        ByteSpan::new(line.start + marker.len(), line.start + line_text.len()),
-                    ));
-                }
-                let term = line.terminator_span();
-                if !term.is_empty() {
-                    regions.push(SpannedRegion::structure(input, term));
-                }
+                Self::emit_hung_text(input, &line, marker.len(), &mut regions);
                 continue;
             }
 
@@ -841,21 +982,57 @@ impl FormatParser for OrgParser {
                             ..
                         }) if s == "\n"
                     );
+                    let is_hard = matches!(
+                        regions.last(),
+                        Some(SpannedRegion {
+                            region: Region::Structure(s),
+                            ..
+                        }) if is_org_line_break_structure(s)
+                    );
                     if is_term {
                         regions.pop();
-                        if let Some(prev) = regions.last_mut() {
-                            if let Region::Prose(prose) = &mut prev.region {
-                                join_prose_gap(prose);
-                                prose.push_str(line_text.trim());
+                        if let Some(break_at) = org_line_break_at(line_text) {
+                            let content = line_text[..break_at].trim();
+                            if !content.is_empty() {
+                                if let Some(prev) = regions.last_mut() {
+                                    if let Region::Prose(prose) = &mut prev.region {
+                                        join_prose_gap(prose);
+                                        prose.push_str(content);
+                                    }
+                                    if let Some(RegionOrigin::Whole(span)) = &mut prev.origin {
+                                        span.end = line.start + break_at;
+                                    }
+                                }
                             }
-                            if let Some(RegionOrigin::Whole(span)) = &mut prev.origin {
-                                span.end = line.start + line_text.len();
+                            let hard = ByteSpan::new(line.start + break_at, line.end);
+                            if !hard.is_empty() {
+                                regions.push(SpannedRegion::structure(input, hard));
+                            }
+                        } else {
+                            if let Some(prev) = regions.last_mut() {
+                                if let Region::Prose(prose) = &mut prev.region {
+                                    join_prose_gap(prose);
+                                    prose.push_str(line_text.trim());
+                                }
+                                if let Some(RegionOrigin::Whole(span)) = &mut prev.origin {
+                                    span.end = line.start + line_text.len();
+                                }
+                            }
+                            let term = line.terminator_span();
+                            if !term.is_empty() {
+                                regions.push(SpannedRegion::structure(input, term));
                             }
                         }
-                        let term = line.terminator_span();
-                        if !term.is_empty() {
-                            regions.push(SpannedRegion::structure(input, term));
+                        continue;
+                    }
+                    if is_hard {
+                        if leading > 0 {
+                            regions.push(SpannedRegion::structure(
+                                input,
+                                ByteSpan::new(line.start, line.start + leading),
+                            ));
                         }
+                        Self::emit_hung_text(input, &line, leading, &mut regions);
                         continue;
                     }
                 }
@@ -878,13 +1055,19 @@ impl FormatParser for OrgParser {
                 continue;
             }
 
-            // Regular prose line -- accumulate. Verse stays line-preserving.
-            if Self::innermost_container(&block_stack) == Some("VERSE") {
+            // Regular prose line -- accumulate. Verse keeps physical lines.
+            // Org `\\` at EOL is a line-break object, not a join (GitHub #232).
+            Self::push_prose_or_line_break(
+                input,
+                &line,
+                0,
+                &mut current_prose,
+                &mut prose_span,
+                &mut regions,
+                true,
+            );
+            if Self::in_verse_block(&block_stack) {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-                push_prose_line(&mut current_prose, &mut prose_span, &line, true, true);
-                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-            } else {
-                push_prose_line(&mut current_prose, &mut prose_span, &line, true, true);
             }
         }
 
@@ -1138,6 +1321,25 @@ mod tests {
             ..Default::default()
         }
         .without_safety_backstops()
+    }
+
+    #[test]
+    fn org_line_break_at_matches_element_parser() {
+        assert_eq!(org_line_break_at(r"sentence.\\"), Some(9));
+        assert_eq!(org_line_break_at("sentence.\\\\  \t"), Some(9));
+        assert_eq!(org_line_break_at(r"\\"), Some(0));
+        assert_eq!(org_line_break_at("foo\\"), None);
+        assert_eq!(org_line_break_at(r"foo\\[2ex]"), None);
+        assert_eq!(org_line_break_at("no break"), None);
+        assert_eq!(org_line_break_at(r"words \\ inside"), None);
+        assert_eq!(org_line_break_at(r"display \["), None);
+        // Last two backslashes are the break; the first pair stays in prose.
+        assert_eq!(org_line_break_at(r"sentence.\\\\"), Some(11));
+        assert!(is_org_line_break_structure("\\\\\n"));
+        assert!(is_org_line_break_structure("\\\\  \n"));
+        assert!(is_org_line_break_structure("\\\\\r\n"));
+        assert!(!is_org_line_break_structure("\\\n"));
+        assert!(!is_org_line_break_structure("\\\\[2ex]\n"));
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1138,8 +1138,12 @@ fn is_latex_item_core(core: &str) -> bool {
     rest.starts_with('[') && rest.ends_with(']') && !rest[1..rest.len() - 1].contains(['[', ']'])
 }
 
-/// Markdown hard break payloads: two or more spaces plus newline, or `\\\n`.
+/// Hard-break Structure payloads: Markdown two-or-more spaces plus
+/// newline, Markdown `\\\n`, or Org `\\\\[ \t]*$` plus the terminator.
 fn is_hard_break_structure(s: &str) -> bool {
+    if crate::parser::org::is_org_line_break_structure(s) {
+        return true;
+    }
     let Some(body) = s.strip_suffix('\n') else {
         return false;
     };

--- a/tests/org_line_breaks.rs
+++ b/tests/org_line_breaks.rs
@@ -1,0 +1,169 @@
+//! snapper-2xhr / GitHub #232: org-element-line-break-parser
+//! `\\\\[ \t]*$` is Structure. The next physical line is not joined
+//! onto `\\`. `Next claim.` still splits.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "This is a long first sentence.\\\\\n",
+        "This is the second sentence after the break. Next claim.\n",
+    )
+}
+
+#[test]
+fn line_break_backslash_pair_is_structure() {
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "\\\\\n")),
+        "\\\\ plus EOL must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains("This is a long first sentence.")
+                && !s.contains("second sentence")
+        )),
+        "first sentence must not join the next line, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("This is the second sentence after the break.")
+                    && s.contains("Next claim.")
+        )),
+        "line after \\\\ must be its own prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_break_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "This is a long first sentence.\\\\\n",
+            "This is the second sentence after the break.\n",
+            "Next claim.\n",
+        ),
+        "\\\\ plus EOL stays; next line is its own sentence; Next claim. still splits, got:\n{out}"
+    );
+    assert!(
+        !out.contains("sentence.\\\\ This") && !out.contains("sentence.\\\\This"),
+        "must not join the next line onto \\\\, got:\n{out}"
+    );
+    assert!(
+        !out.contains("the break. Next claim."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn trailing_spaces_after_line_break_stay_structure() {
+    let input = "First sentence.\\\\  \nSecond sentence. Next claim.\n";
+    let regions = OrgParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "\\\\  \n")),
+        "\\\\ plus trailing spaces plus EOL must stay Structure, got {regions:?}"
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("First sentence.\\\\  \nSecond sentence.\nNext claim."),
+        "trailing spaces after \\\\ must survive and Next claim. split, got:\n{out}"
+    );
+}
+
+#[test]
+fn latex_linebreak_skip_is_not_org_line_break() {
+    let input = "Keep this as one line\\\\[2ex] still prose. Next claim.\n";
+    let regions = OrgParser.parse(input);
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.starts_with("\\\\"))),
+        "\\\\[2ex] must not be a line-break Structure, got {regions:?}"
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("\\\\[2ex]"),
+        "\\\\[2ex] must stay in prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("still prose.\nNext claim."),
+        "Next claim. must still split, got:\n{out}"
+    );
+}
+
+#[test]
+fn mid_line_backslash_backslash_is_not_a_break() {
+    let input = "Words with \\\\ inside. Next claim.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out, "Words with \\\\ inside.\nNext claim.\n",
+        "mid-line \\\\ is not a line-break, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn same_line_math_then_line_break_still_splits() {
+    let input = "The root is \\[ x = a.b \\] today.\\\\\nAfter the break. Next claim.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("\\[ x = a.b \\]"),
+        "same-line math must stay intact, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\\\\\nAfter the break.\nNext claim.\n"),
+        "\\\\ after same-line math must stay a break, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn list_item_line_break_hangs_continuation() {
+    let input = concat!(
+        "- First sentence.\\\\\n",
+        "  Second sentence. Next claim.\n",
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "- First sentence.\\\\\n",
+            "  Second sentence.\n",
+            "  Next claim.\n",
+        ),
+        "list item \\\\ stays; next line hangs and Next claim. still splits, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
vissue: snapper-2xhr (parent snapper-etv7). GitHub #232.

unanimous-green-100 4/4 GREEN (impl-A, impl-B, rev-1, rev-2).

org-element-line-break-parser. \\\\ plus EOL stays Structure; the
next line is its own sentence.

## Test plan
- rustc tests in tests/org_line_breaks.rs
- terra: cargo test parser::org