### PR TITLE
fix(org): keep inline src_ and call_ atomic

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -52,7 +52,8 @@ The classification depends on the format.
 - Paragraph text
 - List item text (after the marker); continuation sentences hang at the marker width so Org rejoins the item
 - Quote, verse, center, and special-block inner text (verse stays line-preserving)
-- =#+CAPTION:= value (org-element-parsed-keywords); continuation sentences hang at the opener width. Dual =#+CAPTION[short]:= keeps the short title on the opener
+- =#+CAPTION:= value (org-element-parsed-keywords); continuation sentences hang at the opener width.
+  Dual =#+CAPTION[short]:= keeps the short title on the opener
 
 *** Inline tokens (kept atomic)
 :PROPERTIES:

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -68,6 +68,8 @@ These tokens within prose are not split across lines:
 - Radio targets: =<<<contents>>>= (org-element-radio-target-parser)
 - Angle targets: =<<contents>>= (org-element-target-parser)
 - Macros: ={{{name}}}= / ={{{name(args)}}}= (org-element-macro-parser)
+- Inline source: =src_lang{...}= / =src_lang[headers]{...}= (org-element-inline-src-block-parser; =\<src_= is word-start. After a word, =_src_= is a subscript, so =foo_src_python{...}= is not an object; =_src_python{...}= after space is)
+- Inline babel call: =call_name(...)= / =call_name[inside](...)[end]= (org-element-inline-babel-call-parser; same =\<call_= / subscript rule)
 - Inline footnotes: =[fn:: def]= / =[fn:name: def]= (org-element-footnote-reference-parser)
 - URLs: =https://...= (trailing sentence punctuation not swallowed)
 

--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -996,7 +996,6 @@ fn setext_heading_start(lines: &[Line<'_>], last: usize, prose_span: Option<Byte
         .unwrap_or(last)
 }
 
-
 /// Pandoc / academic Markdown display math: a line that starts with `$$`.
 fn display_math_open(line: &str) -> bool {
     line.trim().starts_with("$$")
@@ -4758,7 +4757,7 @@ mod tests {
     #[test]
     fn definition_list_body_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = ticket_definition_list_fixture();
         let out = format_text(input, &md_cfg()).unwrap();

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -2,8 +2,8 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::parser::{
-    ByteSpan, FormatParser, Region, RegionOrigin, SpannedRegion, flush_prose_spanned, iter_lines,
-    join_prose_gap, push_prose_line,
+    ByteSpan, FormatParser, Line, Region, RegionOrigin, SpannedRegion, flush_prose_spanned,
+    iter_lines, join_prose_gap, push_prose_line,
 };
 
 static HEADLINE_RE: LazyLock<Regex> =
@@ -529,85 +529,6 @@ impl OrgParser {
         push_prose_line(current_prose, prose_span, &rest, join_space, true);
     }
 
-    /// Split same-line `\[CONTENTS\]` into Structure islands (Kang / org-syntax 5.2).
-    /// Glue space before `\[` stays on the island so reflow does not break
-    /// `The root is \[ x = a.b \]`. Leftover-start indent stays on the island.
-    /// Returns true when at least one same-line pair was emitted.
-    fn emit_same_line_bracket_fragments(
-        input: &str,
-        line: &Line<'_>,
-        current_prose: &mut String,
-        prose_span: &mut Option<ByteSpan>,
-        regions: &mut Vec<SpannedRegion>,
-    ) -> bool {
-        let mut rel = 0;
-        let mut found = false;
-        while let Some((open, after_close)) = Self::same_line_bracket_fragment(&line.text[rel..]) {
-            found = true;
-            let open_abs = rel + open;
-            let end_abs = rel + after_close;
-            let prefix = &line.text[rel..open_abs];
-            let lead_glue = if prefix.trim().is_empty() {
-                0
-            } else {
-                prefix.len() - prefix.trim_end_matches([' ', '\t']).len()
-            };
-            // Prose span must stop before the glue space; splice copies
-            // Structure from source and overlapping ranges drop the space.
-            // Whitespace-only leftover-start indent is not prose: pushing
-            // it writes prose_span then flush skips take(), so the next
-            // line extends over the math and splice drops it.
-            if !prefix.trim().is_empty() && prefix.len() > lead_glue {
-                let lead = Line {
-                    start: line.start + rel,
-                    end: line.start + open_abs - lead_glue,
-                    text: &line.text[rel..open_abs - lead_glue],
-                };
-                push_prose_line(current_prose, prose_span, &lead, true, false);
-            }
-            flush_prose_spanned(current_prose, prose_span, regions);
-            let island_start = if prefix.trim().is_empty() {
-                line.start + rel
-            } else {
-                line.start + open_abs - lead_glue
-            };
-            let rest_after = &line.text[end_abs..];
-            let trail_glue = if rest_after.trim().is_empty() {
-                0
-            } else {
-                rest_after.len() - rest_after.trim_start_matches([' ', '\t']).len()
-            };
-            let island_end = if rest_after.trim().is_empty() {
-                line.end
-            } else {
-                line.start + end_abs + trail_glue
-            };
-            regions.push(SpannedRegion::structure(
-                input,
-                ByteSpan::new(island_start, island_end),
-            ));
-            rel = end_abs + trail_glue;
-            if rest_after.trim().is_empty() {
-                return true;
-            }
-        }
-        if !found {
-            return false;
-        }
-        if rel < line.text.len() && !line.text[rel..].trim().is_empty() {
-            Self::push_prose_or_line_break(
-                input,
-                line,
-                rel,
-                current_prose,
-                prose_span,
-                regions,
-                true,
-            );
-        }
-        true
-    }
-
     fn inside_opaque(stack: &[OpenGreater]) -> bool {
         stack.iter().any(|b| b.kind == GreaterKind::Opaque)
     }
@@ -1066,7 +987,7 @@ impl FormatParser for OrgParser {
                 &mut regions,
                 true,
             );
-            if Self::in_verse_block(&block_stack) {
+            if Self::innermost_container(&block_stack) == Some("VERSE") {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
             }
         }
@@ -2791,6 +2712,157 @@ mod tests {
         assert!(
             wrapped.contains("Next sentence."),
             "sentence after the macro must still reflow, got:\n{wrapped}"
+        );
+        assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+    }
+
+    /// Ticket fixture (Format::Org / GitHub #214): org-element inline
+    /// `src_lang{...}` stays one token so an interior period is not a
+    /// sentence boundary. `Next sentence.` still splits. Same class:
+    /// `call_name(...)`.
+    fn inline_src_fixture() -> &'static str {
+        "Use src_python{print(1. 2)} today. Next sentence.\n"
+    }
+
+    #[test]
+    fn org_inline_src_interior_punct_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let src = "src_python{print(1. 2)}";
+        let input = inline_src_fixture();
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains(src) && p.contains("Next sentence.")
+            )),
+            "inline src stays inline Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("Use src_python{print(1. 2)} today.\nNext sentence."),
+            "sentence after the inline src must reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("1.\n") && !out.contains("print(1.\n2)"),
+            "must not split inside the inline src, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+        let wrap_cfg = crate::FormatConfig {
+            format: crate::format::Format::Org,
+            max_width: 20,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let wrapped = format_text(input, &wrap_cfg).unwrap();
+        assert!(
+            wrapped.lines().any(|l| l.contains(src)),
+            "wrap must not cut inside the inline src, got:\n{wrapped}"
+        );
+        assert!(
+            !wrapped.contains("1.\n2"),
+            "must not wrap on the interior period, got:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("Next sentence."),
+            "sentence after the inline src must still reflow, got:\n{wrapped}"
+        );
+        assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+    }
+
+    #[test]
+    fn org_inline_call_interior_punct_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let call = "call_name(1. 2)";
+        let input = "Use call_name(1. 2) today. Next sentence.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains(call) && p.contains("Next sentence.")
+            )),
+            "inline babel call stays inline Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("Use call_name(1. 2) today.\nNext sentence."),
+            "sentence after the inline call must reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("1.\n") && !out.contains("call_name(1.\n2)"),
+            "must not split inside the inline call, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn org_inline_src_after_leading_underscore_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let src = "src_python{print(1. 2)}";
+        for input in [
+            "See _src_python{print(1. 2)} today. Next sentence.\n",
+            "See foo-src_python{print(1. 2)} today. Next sentence.\n",
+        ] {
+            let regions = OrgParser.parse(input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Prose(p)
+                        if p.contains(src) && p.contains("Next sentence.")
+                )),
+                "src after leading _ or hyphen stays inline Prose, got: {regions:?}"
+            );
+            let out = format_text(input, &org_cfg()).unwrap();
+            assert!(
+                out.contains("today.\nNext sentence."),
+                "sentence after leading-_ src must reflow, got:\n{out}"
+            );
+            assert!(
+                !out.contains("1.\n") && !out.contains("print(1.\n2)"),
+                "must not split inside src after leading _ or hyphen, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+        }
+    }
+
+    #[test]
+    fn org_inline_src_after_word_underscore_is_subscript() {
+        use crate::format_text;
+
+        let src = "src_python{print(1. 2)}";
+        let input = "See foo_src_python{print(1. 2)} today. Next sentence.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains(src) && p.contains("Next sentence.")
+            )),
+            "foo_src leftover stays inline Prose, got: {regions:?}"
+        );
+        let wrap_cfg = crate::FormatConfig {
+            format: crate::format::Format::Org,
+            max_width: 20,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let wrapped = format_text(input, &wrap_cfg).unwrap();
+        assert!(
+            !wrapped.lines().any(|l| l.contains(src)),
+            "foo_src leftover braces must not stay atomic, got:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("1.\n2"),
+            "interior period may wrap after word-underscore subscript, got:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("Next sentence."),
+            "following sentence must still reflow, got:\n{wrapped}"
         );
         assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
     }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2329,6 +2329,93 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_org_inline_src_atomic() {
+        let token = "src_python{print(1. 2)}";
+        let sentence = "Use src_python{print(1. 2)} today. Next sentence.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 20, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("1.\n2"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_keeps_org_inline_src_after_leading_underscore_atomic() {
+        let token = "src_python{print(1. 2)}";
+        for sentence in [
+            "See _src_python{print(1. 2)} today. Next sentence.",
+            "See foo-src_python{print(1. 2)} today. Next sentence.",
+        ] {
+            for clause in [false, true] {
+                let wrapped = wrap_sentence(sentence, 20, clause);
+                assert_atomic_token(&wrapped, token);
+                assert!(
+                    !wrapped.contains("1.\n2"),
+                    "must not wrap on the interior period after leading _ or hyphen, got:\n{wrapped}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn max_width_may_wrap_org_src_after_word_underscore() {
+        // Subscript `_src` leaves `{print(1. 2)}` as prose, so wrap may
+        // cut on the interior period. Inverse of the leading-`_` object.
+        let token = "src_python{print(1. 2)}";
+        let sentence = "See foo_src_python{print(1. 2)} today. Next sentence.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 20, clause);
+            assert!(
+                !wrapped.lines().any(|l| l.contains(token)),
+                "foo_src_ leftover braces must not stay atomic, got:\n{wrapped}"
+            );
+            assert!(
+                wrapped.contains("1.\n2"),
+                "interior period may wrap after word-underscore subscript, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_keeps_org_inline_call_atomic() {
+        let token = "call_name(1. 2)";
+        for sentence in [
+            "Use call_name(1. 2) today. Next sentence.",
+            "See _call_name(1. 2) today. Next sentence.",
+            "See foo-call_name(1. 2) today. Next sentence.",
+        ] {
+            for clause in [false, true] {
+                let wrapped = wrap_sentence(sentence, 16, clause);
+                assert_atomic_token(&wrapped, token);
+                assert!(
+                    !wrapped.contains("1.\n2"),
+                    "must not wrap on the interior period, got:\n{wrapped}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn max_width_may_wrap_org_call_after_word_underscore() {
+        let token = "call_name(1. 2)";
+        let sentence = "See foo_call_name(1. 2) today. Next sentence.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 16, clause);
+            assert!(
+                !wrapped.lines().any(|l| l.contains(token)),
+                "foo_call leftover parens must not stay atomic, got:\n{wrapped}"
+            );
+            assert!(
+                wrapped.contains("1.\n2"),
+                "interior period may wrap after word-underscore subscript, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn max_width_keeps_math_atomic() {
         let token = "$E = m c^{2}$";
         let sentence = "The identity $E = m c^{2}$ holds in this frame.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -34,17 +34,17 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             // [a-zA-Z][-a-zA-Z0-9_]*; args are non-greedy and may
             // span lines. Two-brace {{...}} is not a macro (GitHub #212).
             r"\{\{\{[a-zA-Z][-a-zA-Z0-9_]*(?:\((?:.|\n)*?\))?\}\}\}",
-            r"\[[^\]]+\]\([^)]+\)",    // Markdown links: [text](url)
-            r"!\[[^\]]*\]\([^)]+\)",   // Markdown images: ![alt](url)
+            r"\[[^\]]+\]\([^)]+\)",  // Markdown links: [text](url)
+            r"!\[[^\]]*\]\([^)]+\)", // Markdown images: ![alt](url)
             // CommonMark 0.31.2 §6.3 full / collapsed reference links.
             // The label must follow the text immediately. Shortcut `[text]`
             // is not matched: that would swallow every bracket group.
             r"!\[[^\]]*\]\[[^\]]*\]", // Markdown reference images: ![alt][ref]
             r"\[[^\]]+\]\[[^\]]*\]",  // Markdown reference links: [text][ref]
-            r"\$\$[^$\n]+\$\$",        // Display math: $$...$$
-            r"\$[^$\n]+\$",            // Inline math: $...$
-            r"\\\([^\\\n]+\\\)",       // LaTeX inline math: \(...\)
-            r"\\\[[^\n]+?\\\]",        // Org / LaTeX display math fragment: \[...\]
+            r"\$\$[^$\n]+\$\$",       // Display math: $$...$$
+            r"\$[^$\n]+\$",           // Inline math: $...$
+            r"\\\([^\\\n]+\\\)",      // LaTeX inline math: \(...\)
+            r"\\\[[^\n]+?\\\]",       // Org / LaTeX display math fragment: \[...\]
             r"\\([a-zA-Z]+)\{[^}]*\}", // LaTeX commands: \cmd{arg}
             // Org emphasis must be protected before sentence splits so a line
             // cannot begin with `*rest` (false headline) or leave markers open.
@@ -156,10 +156,12 @@ pub fn protect_inline_tokens_with(
 ) -> (String, Vec<String>) {
     let mut placeholders: Vec<String> = Vec::new();
     let after_verb = protect_latex_verbatim(text, &mut placeholders, extra_verbatim_commands);
-    // Footnote references before paired spans so a nested `[[link]]`
+    // org-element inline src / babel-call before paired `=`/`~` so a body
+    // like `src_python{~x~}` stays one object, not an Org code span.
+    // Footnote references run in the same walk so a nested `[[link]]`
     // closer does not end `[fn:: …]` early (GitHub #231).
-    let after_fn = protect_org_footnote_references(&after_verb, &mut placeholders);
-    let after_spans = protect_paired_spans(&after_fn, &mut placeholders);
+    let after_org = protect_org_inline_src_and_call(&after_verb, &mut placeholders);
+    let after_spans = protect_paired_spans(&after_org, &mut placeholders);
     let protected = INLINE_TOKEN_RE.replace_all(&after_spans, |caps: &regex::Captures| {
         let idx = placeholders.len();
         placeholders.push(caps[0].to_string());
@@ -339,12 +341,17 @@ fn find_unescaped_brace_close(text: &str, mut i: usize) -> Option<usize> {
     None
 }
 
-/// Protect `[fn::def]` / `[fn:LABEL:def]` before paired spans.
-fn protect_org_footnote_references(text: &str, placeholders: &mut Vec<String>) -> String {
+/// org-element-inline-src-block-parser / org-element-inline-babel-call-parser.
+/// `src_LANG[headers]{body}` and `call_NAME[inside](args)[end]` stay one
+/// object so an interior period is not a sentence or wrap boundary.
+/// Footnote references run in the same walk (GitHub #231).
+fn protect_org_inline_src_and_call(text: &str, placeholders: &mut Vec<String>) -> String {
     let mut out = String::with_capacity(text.len());
     let mut i = 0;
     while i < text.len() {
-        if let Some(end) = org_footnote_reference_span_end(text, i) {
+        if let Some(end) = org_inline_src_or_call_span_end(text, i)
+            .or_else(|| org_footnote_reference_span_end(text, i))
+        {
             push_placeholder(&mut out, placeholders, &text[i..end]);
             i = end;
             continue;
@@ -356,6 +363,9 @@ fn protect_org_footnote_references(text: &str, placeholders: &mut Vec<String>) -
     out
 }
 
+fn org_inline_src_or_call_span_end(text: &str, at: usize) -> Option<usize> {
+    org_inline_src_span_end(text, at).or_else(|| org_inline_call_span_end(text, at))
+}
 
 /// org-footnote-re inline arm + org-element-footnote-reference-parser.
 ///
@@ -409,6 +419,115 @@ fn org_scan_lists_same_line(text: &str, open_at: usize, open: u8, close: u8) -> 
         i += 1;
     }
     None
+}
+
+/// `\<` in org-element-inline-src-block-parser / inline-babel-call-parser
+/// (`looking-at` `\<src_` / `\<call_`). Word-start, not symbol-start.
+///
+/// `org-element--object-lex` matches `[_^][-{(*+.,[:alnum:]]` first, so
+/// after a word the subscript parser consumes `_src` / `_call` and the
+/// leftover braces stay prose. `_src_` / `_call_` at BOL or after
+/// whitespace is still an object (`\<` matches at `s`). Hyphen is not a
+/// subscript opener here, so `foo-src_python` is an object. Word
+/// characters (`asrc_`, `1src_`) are not.
+fn org_inline_object_start(text: &str, at: usize) -> bool {
+    if at == 0 {
+        return true;
+    }
+    let mut prevs = text[..at].chars().rev();
+    let prev = prevs.next().expect("at > 0");
+    if prev.is_ascii_alphanumeric() {
+        return false;
+    }
+    if prev == '_' {
+        if let Some(before) = prevs.next() {
+            if before.is_ascii_alphanumeric() {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// org-element `scan-lists` on a one-pair syntax table. Newlines are
+/// allowed (org-element 2015). Unmatched opener is not an object.
+fn org_scan_lists(text: &str, open_at: usize, open: u8, close: u8) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if bytes.get(open_at) != Some(&open) {
+        return None;
+    }
+    let mut depth = 1usize;
+    let mut i = open_at + 1;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == open {
+            depth += 1;
+        } else if b == close {
+            depth -= 1;
+            if depth == 0 {
+                return Some(i + 1);
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// `src_LANG` then optional `[parameters]` then required `{body}`.
+/// `case-fold-search` is nil; language is `[^ \t\n[{]+`.
+fn org_inline_src_span_end(text: &str, at: usize) -> Option<usize> {
+    let rest = text.get(at..)?;
+    if !rest.starts_with("src_") || !org_inline_object_start(text, at) {
+        return None;
+    }
+    let bytes = text.as_bytes();
+    let mut i = at + 4;
+    let lang_start = i;
+    while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t' | b'\n' | b'[' | b'{') {
+        i += 1;
+    }
+    if i == lang_start {
+        return None;
+    }
+    if i < bytes.len() && bytes[i] == b'[' {
+        i = org_scan_lists(text, i, b'[', b']')?;
+    }
+    if i >= bytes.len() || bytes[i] != b'{' {
+        return None;
+    }
+    org_scan_lists(text, i, b'{', b'}')
+}
+
+/// `call_NAME` then optional `[inside-header]`, required `(arguments)`,
+/// optional `[end-header]`. Name is `[^ \t\n[(]+`. An unmatched end-header
+/// is not part of the object (org-element looking-at).
+fn org_inline_call_span_end(text: &str, at: usize) -> Option<usize> {
+    let rest = text.get(at..)?;
+    if !rest.starts_with("call_") || !org_inline_object_start(text, at) {
+        return None;
+    }
+    let bytes = text.as_bytes();
+    let mut i = at + 5;
+    let name_start = i;
+    while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t' | b'\n' | b'[' | b'(') {
+        i += 1;
+    }
+    if i == name_start {
+        return None;
+    }
+    if i < bytes.len() && bytes[i] == b'[' {
+        i = org_scan_lists(text, i, b'[', b']')?;
+    }
+    if i >= bytes.len() || bytes[i] != b'(' {
+        return None;
+    }
+    i = org_scan_lists(text, i, b'(', b')')?;
+    if i < bytes.len() && bytes[i] == b'[' {
+        if let Some(end) = org_scan_lists(text, i, b'[', b']') {
+            i = end;
+        }
+    }
+    Some(i)
 }
 
 /// Org `=`/`~`, Markdown backtick spans, CommonMark `*`/`**`, and GFM `~~`,
@@ -684,15 +803,23 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 /// Byte ranges of inline tokens that wrapping must not split (links, images,
 /// reference links `[text][ref]`, inline code, autolinks, math, Org `[[...]]`,
 /// Org `[cite...]`, Org `[fn::…]` / `[fn:LABEL:…]`, Org `<<<...>>>` /
-/// `<<...>>`, Org `{{{name}}}` / `{{{name(args)}}}`, paired spans).
+/// `<<...>>`, Org `{{{name}}}` / `{{{name(args)}}}`, Org `src_lang{...}` /
+/// `call_name(...)`, paired spans).
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.
 pub fn atomic_inline_spans(text: &str) -> Vec<(usize, usize)> {
     let mut spans = Vec::new();
+    let mut org_src_call_spans = Vec::new();
     let bytes = text.as_bytes();
     let mut i = 0;
     while i < text.len() {
+        if let Some(end) = org_inline_src_or_call_span_end(text, i) {
+            spans.push((i, end));
+            org_src_call_spans.push((i, end));
+            i = end;
+            continue;
+        }
         if let Some(end) = org_footnote_reference_span_end(text, i) {
             spans.push((i, end));
             i = end;
@@ -716,7 +843,18 @@ pub fn atomic_inline_spans(text: &str) -> Vec<(usize, usize)> {
         i += ch.len_utf8();
     }
     for m in INLINE_TOKEN_RE.find_iter(text) {
-        spans.push((m.start(), m.end()));
+        let (ms, me) = (m.start(), m.end());
+        // Org `\<src_` / `\<call_` wins over the underline regex `_src_` /
+        // `_call_` when `_src_python{...}` is an object (BOL / after
+        // whitespace). Keep a regex match only when it wraps the whole
+        // object (a link around the src).
+        let steals_org = org_src_call_spans
+            .iter()
+            .any(|&(s, e)| ms < e && me > s && !(ms <= s && me >= e));
+        if steals_org {
+            continue;
+        }
+        spans.push((ms, me));
     }
     merge_byte_ranges(spans)
 }
@@ -1657,6 +1795,271 @@ mod tests {
                 "Next sentence.".to_string()
             ]
         );
+    }
+
+    #[test]
+    fn inline_org_src_interior_punct_is_not_a_sentence_boundary() {
+        // GitHub #214 / snapper-pdtw: org-element-inline-src-block-parser
+        // `src_lang{...}` stays one token. `Next sentence.` still splits.
+        let src = "src_python{print(1. 2)}";
+        let text = "Use src_python{print(1. 2)} today. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == src),
+            "inline src must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == src),
+            "inline src must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "Use src_python{print(1. 2)} today.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_src_headers_and_nested_braces_stay_one_token() {
+        let src = "src_python[:results output]{d = {1. 2}}";
+        let text = "Use src_python[:results output]{d = {1. 2}} today. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == src),
+            "header + nested braces must stay one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "Use src_python[:results output]{d = {1. 2}} today.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_call_interior_punct_is_not_a_sentence_boundary() {
+        // Same class: org-element-inline-babel-call-parser `call_name(...)`.
+        let call = "call_name(1. 2)";
+        let text = "Use call_name(1. 2) today. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == call),
+            "inline babel call must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == call),
+            "inline babel call must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "Use call_name(1. 2) today.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_call_headers_and_nested_parens_stay_one_token() {
+        let call = "call_name[:results output](f(1. 2))[:results html]";
+        let text = "Use call_name[:results output](f(1. 2))[:results html] today. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == call),
+            "call headers + nested parens must stay one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "Use call_name[:results output](f(1. 2))[:results html] today.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn ordinary_call_parens_are_not_an_inline_org_call() {
+        // `call_name(...)` is the babel object. Bare `print(1. 2)` is prose
+        // and must not become an atomic wrap span.
+        let text = "Use print(1. 2) today. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            !placeholders.iter().any(|p| p.contains("print(1. 2)")),
+            "ordinary parens must not be an inline call, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            !spans
+                .iter()
+                .any(|&(s, e)| text[s..e].contains("print(1. 2)")),
+            "ordinary parens must not be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        let parts = split(text);
+        assert_eq!(parts.last().map(String::as_str), Some("Next sentence."));
+        assert!(
+            parts.iter().any(|p| p.contains("today.")),
+            "prose after the parens must stay in the first sentence, got {parts:?}"
+        );
+    }
+
+    #[test]
+    fn inline_org_src_matches_after_leading_underscore() {
+        // `_src_` at BOL / after space is `\<src_`. Hyphen is not a
+        // subscript opener here, so `foo-src_python` is an object.
+        let src = "src_python{print(1. 2)}";
+        for (text, first) in [
+            (
+                "See _src_python{print(1. 2)} today. Next sentence.",
+                "See _src_python{print(1. 2)} today.",
+            ),
+            (
+                "See foo-src_python{print(1. 2)} today. Next sentence.",
+                "See foo-src_python{print(1. 2)} today.",
+            ),
+        ] {
+            let (_, placeholders) = protect_inline_tokens(text);
+            assert!(
+                placeholders.iter().any(|p| p == src),
+                "src_ after leading _ or hyphen must be one token, got {placeholders:?} for {text:?}"
+            );
+            let spans = atomic_inline_spans(text);
+            assert!(
+                spans.iter().any(|&(s, e)| &text[s..e] == src),
+                "src_ after leading _ or hyphen must be an atomic wrap span, got {:?} for {text:?}",
+                spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+            );
+            assert_eq!(
+                split(text),
+                vec![first.to_string(), "Next sentence.".to_string()]
+            );
+        }
+    }
+
+    #[test]
+    fn inline_org_src_after_word_underscore_is_subscript() {
+        // org-element--object-regexp matches the subscript first, so
+        // `foo_src_` / `x_src_` are not inline-src-block. Leftover braces
+        // stay prose.
+        let src = "src_python{print(1. 2)}";
+        for text in [
+            "See foo_src_python{print(1. 2)} today. Next sentence.",
+            "See x_src_python{print(1. 2)} today. Next sentence.",
+        ] {
+            let (_, placeholders) = protect_inline_tokens(text);
+            assert!(
+                !placeholders.iter().any(|p| p.contains(src) || p == src),
+                "src_ after word-underscore is a subscript, got {placeholders:?} for {text:?}"
+            );
+            let spans = atomic_inline_spans(text);
+            assert!(
+                !spans.iter().any(|&(s, e)| text[s..e].contains(src)),
+                "src_ after word-underscore must not be an atomic wrap span, got {:?} for {text:?}",
+                spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+            );
+            let parts = split(text);
+            assert!(
+                parts.iter().any(|p| p.contains("Next sentence.")),
+                "Next sentence. still splits, got {parts:?} for {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn inline_org_src_requires_word_boundary() {
+        // Word char before `s` is not `\<`. `case-fold-search` is nil.
+        for text in [
+            "asrc_python{print(1. 2)} today. Next sentence.",
+            "1src_python{print(1. 2)} today. Next sentence.",
+            "SRC_python{print(1. 2)} today. Next sentence.",
+        ] {
+            let (_, placeholders) = protect_inline_tokens(text);
+            assert!(
+                !placeholders
+                    .iter()
+                    .any(|p| p.contains("src_python{print(1. 2)}")
+                        || p.contains("SRC_python{print(1. 2)}")),
+                "src_ must not match after a word char or when folded, got {placeholders:?} for {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn inline_org_call_matches_after_leading_underscore() {
+        let call = "call_name(1. 2)";
+        for (text, first) in [
+            (
+                "See _call_name(1. 2) today. Next sentence.",
+                "See _call_name(1. 2) today.",
+            ),
+            (
+                "See foo-call_name(1. 2) today. Next sentence.",
+                "See foo-call_name(1. 2) today.",
+            ),
+        ] {
+            let (_, placeholders) = protect_inline_tokens(text);
+            assert!(
+                placeholders.iter().any(|p| p == call),
+                "call_ after leading _ or hyphen must be one token, got {placeholders:?} for {text:?}"
+            );
+            let spans = atomic_inline_spans(text);
+            assert!(
+                spans.iter().any(|&(s, e)| &text[s..e] == call),
+                "call_ after leading _ or hyphen must be an atomic wrap span, got {:?} for {text:?}",
+                spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+            );
+            assert_eq!(
+                split(text),
+                vec![first.to_string(), "Next sentence.".to_string()]
+            );
+        }
+    }
+
+    #[test]
+    fn inline_org_call_after_word_underscore_is_subscript() {
+        let call = "call_name(1. 2)";
+        for text in [
+            "See foo_call_name(1. 2) today. Next sentence.",
+            "See x_call_name(1. 2) today. Next sentence.",
+        ] {
+            let (_, placeholders) = protect_inline_tokens(text);
+            assert!(
+                !placeholders.iter().any(|p| p.contains(call) || p == call),
+                "call_ after word-underscore is a subscript, got {placeholders:?} for {text:?}"
+            );
+            let spans = atomic_inline_spans(text);
+            assert!(
+                !spans.iter().any(|&(s, e)| text[s..e].contains(call)),
+                "call_ after word-underscore must not be an atomic wrap span, got {:?} for {text:?}",
+                spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+            );
+            let parts = split(text);
+            assert!(
+                parts.iter().any(|p| p.contains("Next sentence.")),
+                "Next sentence. still splits, got {parts:?} for {text:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn inline_org_call_requires_word_boundary() {
+        for text in [
+            "acall_name(1. 2) today. Next sentence.",
+            "1call_name(1. 2) today. Next sentence.",
+        ] {
+            let (_, placeholders) = protect_inline_tokens(text);
+            assert!(
+                !placeholders.iter().any(|p| p.contains("call_name(1. 2)")),
+                "call_ must not match after a word char, got {placeholders:?} for {text:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/md_definition_lists.rs
+++ b/tests/md_definition_lists.rs
@@ -6,7 +6,7 @@
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::markdown::MarkdownParser;
 use snapper_fmt::parser::{FormatParser, Region};
-use snapper_fmt::{format_text, FormatConfig};
+use snapper_fmt::{FormatConfig, format_text};
 
 fn md_cfg() -> FormatConfig {
     FormatConfig {

--- a/tests/org_inline_src.rs
+++ b/tests/org_inline_src.rs
@@ -1,0 +1,179 @@
+//! GitHub #214 / snapper-pdtw: org-element inline src (`src_lang{...}`)
+//! and babel calls (`call_name(...)`) stay one inline token. Interior
+//! punctuation is not a sentence boundary. The use stays Prose.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "Use src_python{print(1. 2)} today. Next sentence.\n"
+}
+
+#[test]
+fn ticket_inline_src_use_stays_prose() {
+    let src = "src_python{print(1. 2)}";
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(src) && s.contains("Next sentence.")
+        )),
+        "inline src must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_src_span_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("src_python{print(1. 2)}"),
+        "inline src must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("src_python{print(1.\n") && !out.contains("print(1.\n2)}"),
+        "must not split inside the inline src, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("today. Next sentence."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn ticket_inline_call_stays_one_span() {
+    let input = "Use call_name(1. 2) today. Next sentence.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("call_name(1. 2)"),
+        "inline babel call must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("call_name(1.\n") && !out.contains("1.\n2)"),
+        "must not split inside the inline call, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn inline_src_headers_stay_one_span() {
+    let input = "Use src_python[:exports code]{print(1. 2)} today. Next sentence.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("src_python[:exports code]{print(1. 2)}"),
+        "inline src with headers must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn inline_src_after_leading_underscore_stays_one_span() {
+    // `_src_` after space / `foo-src_` are objects. `asrc_python` is not.
+    let src = "src_python{print(1. 2)}";
+    for input in [
+        "See _src_python{print(1. 2)} today. Next sentence.\n",
+        "See foo-src_python{print(1. 2)} today. Next sentence.\n",
+    ] {
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains(src) && s.contains("Next sentence.")
+            )),
+            "src after leading _ or hyphen must stay Prose, got {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("src_python{print(1. 2)}"),
+            "src_ after leading _ or hyphen must stay one token, got:\n{out}"
+        );
+        assert!(
+            !out.contains("print(1.\n2)}") && !out.contains("src_python{print(1.\n"),
+            "must not split inside src_ after leading _ or hyphen, got:\n{out}"
+        );
+        assert!(
+            out.contains("today.\nNext sentence."),
+            "following sentence must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    let unmatched = format_text(
+        "asrc_python{print(1. 2)} today. Next sentence.\n",
+        &org_cfg(),
+    )
+    .unwrap();
+    assert!(
+        unmatched.contains("today.\nNext sentence."),
+        "asrc_ is not an object; Next sentence. still splits, got:\n{unmatched}"
+    );
+}
+
+#[test]
+fn inline_src_after_word_underscore_is_not_a_span() {
+    // Subscript `_src` leaves leftover braces as prose. Wrap may cut on `1.`.
+    let input = "See foo_src_python{print(1. 2)} today. Next sentence.\n";
+    let src = "src_python{print(1. 2)}";
+    let regions = OrgParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(src) && s.contains("Next sentence.")
+        )),
+        "foo_src leftover must stay Prose, got {regions:?}"
+    );
+    let wrap_cfg = FormatConfig {
+        format: Format::Org,
+        max_width: 20,
+        ..Default::default()
+    }
+    .without_safety_backstops();
+    let wrapped = format_text(input, &wrap_cfg).unwrap();
+    assert!(
+        !wrapped.lines().any(|l| l.contains(src)),
+        "foo_src leftover braces must not stay one token, got:\n{wrapped}"
+    );
+    assert!(
+        wrapped.contains("1.\n2"),
+        "interior period may wrap after word-underscore subscript, got:\n{wrapped}"
+    );
+    assert!(
+        wrapped.contains("Next sentence."),
+        "following sentence must still split, got:\n{wrapped}"
+    );
+    assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+}


### PR DESCRIPTION
vissue: snapper-pdtw (parent snapper-etv7). GitHub #214.

unanimous-green-96 4/4 GREEN (impl-A, impl-B, rev-1, rev-2) on f4a1817;
isolated onto origin/main 25a9ff3 as c3a8047.

org-element-inline-src-block-parser / inline-babel-call-parser.
`src_python{print(1. 2)}` and `call_name(1. 2)` stay one token;
`Next sentence.` still splits. After a word, `_src_` / `_call_` is a
subscript (`foo_src_python{...}` is not an object). `_src_` after
space or hyphen still matches.

#239 isolate left `emit_same_line_bracket_fragments` calling helpers
that are not on origin/main, and used `Line` / `in_verse_block`
without importing them. This isolate imports `Line`, drops the unused
sibling helper, and uses `innermost_container == VERSE` so the tree
compiles.

## Test plan
- rustc tests in tests/org_inline_src.rs
- terra: cargo test sentence::unicode parser::org reflow org_inline_src