### PR TITLE
fix(rst): keep substitution references atomic

### DIFF
--- a/docs/orgmode/reference/abbreviations.org
+++ b/docs/orgmode/reference/abbreviations.org
@@ -127,6 +127,7 @@ Periods inside inline tokens never trigger sentence breaks, regardless of abbrev
 - Org macros: ={{{cite(Smith. 2020)}}}=, ={{{title}}}=
 - Org radio / angle targets: =<<<the Fourier. transform>>>=, =<<sec. intro>>=
 - Org inline footnotes: =[fn:: the Fourier. transform]=, =[fn:note: the Fourier. transform]=
+- RST substitution references: =|fig. 1|=, =|version|=, =|name|_=, =|name|__=
 - LaTeX math: =$x = 3.14$=
 - LaTeX commands: =\cite{smith.2024}=
 - Markdown links: =[Example Inc.](url)=, =[the Fourier. transform][wiki]=

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -191,6 +191,12 @@ These tokens within prose are not split across lines:
 - Paragraph text between structural elements
 - Indented bodies of container directives (admonitions, figure captions, topic, sidebar, container); hang spaces stay structure
 
+*** Inline tokens (kept atomic)
+:PROPERTIES:
+:CUSTOM_ID: rst-inline
+:END:
+- Substitution references: =|fig. 1|= / =|version|= / =|name|_= / =|name|__= (Docutils Inliner.substitution_ref). Interior punctuation is not a sentence or wrap boundary. The use stays Prose, not Structure (line-block is =|= plus space or EOL)
+
 *** Auto-detection
 :PROPERTIES:
 :CUSTOM_ID: rst-detection

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -195,7 +195,9 @@ These tokens within prose are not split across lines:
 :PROPERTIES:
 :CUSTOM_ID: rst-inline
 :END:
-- Substitution references: =|fig. 1|= / =|version|= / =|name|_= / =|name|__= (Docutils Inliner.substitution_ref). Interior punctuation is not a sentence or wrap boundary. The use stays Prose, not Structure (line-block is =|= plus space or EOL)
+- Substitution references: =|fig. 1|= / =|version|= / =|name|_= / =|name|__= (Docutils Inliner.substitution_ref).
+  Interior punctuation is not a sentence or wrap boundary.
+  The use stays Prose, not Structure (line-block is =|= plus space or EOL)
 
 *** Auto-detection
 :PROPERTIES:

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -1747,6 +1747,29 @@ mod tests {
     }
 
     #[test]
+    fn substitution_ref_interior_punct_stays_prose() {
+        // snapper-15i9 / GitHub #233: Inliner leftover. `|fig. 1|` is
+        // still Prose (t0th); the period is not a region bound.
+        let input = "See |fig. 1| in the caption. Next sentence.\n";
+        let regions = RstParser.parse(input);
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("|fig. 1|")
+            )),
+            "|fig. 1| must stay Prose not Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("|fig. 1|") && s.contains("Next sentence.")
+            )),
+            "|fig. 1| and the next sentence must stay Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
     fn leftover_plus_fragment_stays_structure() {
         let input = "+===+===+\n";
         let regions = RstParser.parse(input);

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2416,6 +2416,20 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_rst_substitution_ref_atomic() {
+        let token = "|fig. 1|";
+        let sentence = "See |fig. 1| in the caption. Next sentence.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 16, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("fig.\n1") && !wrapped.contains("|fig.\n"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn max_width_keeps_math_atomic() {
         let token = "$E = m c^{2}$";
         let sentence = "The identity $E = m c^{2}$ holds in this frame.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -156,11 +156,15 @@ pub fn protect_inline_tokens_with(
 ) -> (String, Vec<String>) {
     let mut placeholders: Vec<String> = Vec::new();
     let after_verb = protect_latex_verbatim(text, &mut placeholders, extra_verbatim_commands);
+    // After `\verb|` so a configured delimiter is gone. Unlisted
+    // `\Verb|a.b! c|` keeps the letter prefix, so it is not a
+    // substitution_ref (Docutils start-string; GitHub #233).
+    let after_rst = protect_rst_substitution_refs(&after_verb, &mut placeholders);
     // org-element inline src / babel-call before paired `=`/`~` so a body
     // like `src_python{~x~}` stays one object, not an Org code span.
     // Footnote references run in the same walk so a nested `[[link]]`
     // closer does not end `[fn:: …]` early (GitHub #231).
-    let after_org = protect_org_inline_src_and_call(&after_verb, &mut placeholders);
+    let after_org = protect_org_inline_src_and_call(&after_rst, &mut placeholders);
     let after_spans = protect_paired_spans(&after_org, &mut placeholders);
     let protected = INLINE_TOKEN_RE.replace_all(&after_spans, |caps: &regex::Captures| {
         let idx = placeholders.len();
@@ -337,6 +341,75 @@ fn find_unescaped_brace_close(text: &str, mut i: usize) -> Option<usize> {
             return Some(i + 1);
         }
         i += 1;
+    }
+    None
+}
+
+/// Docutils Inliner.substitution_ref: `|text|` plus optional `_` / `__`.
+/// Text may not begin or end with whitespace (line_block is `| `).
+/// Start-string must be at BOS or after 7-bit non-alphanumeric, so
+/// `\Verb|a.b|` is not a substitution (GitHub #233).
+fn protect_rst_substitution_refs(text: &str, placeholders: &mut Vec<String>) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut i = 0;
+    while i < text.len() {
+        if let Some(end) = rst_substitution_ref_span_end(text, i) {
+            push_placeholder(&mut out, placeholders, &text[i..end]);
+            i = end;
+            continue;
+        }
+        let ch = text[i..].chars().next().expect("i is in range");
+        out.push(ch);
+        i += ch.len_utf8();
+    }
+    out
+}
+
+/// Byte end of a substitution_ref starting at `at`, or None.
+fn rst_substitution_ref_span_end(text: &str, at: usize) -> Option<usize> {
+    if !text.get(at..)?.starts_with('|') {
+        return None;
+    }
+    if at > 0 {
+        let prev = text[..at].chars().next_back()?;
+        // Docutils start-string: whitespace or 7-bit non-alphanumeric.
+        // A preceding `\` is an escape, not a start.
+        if prev == '\\' || !prev.is_ascii() || prev.is_ascii_alphanumeric() {
+            return None;
+        }
+    }
+    let mut chars = text[at + 1..].chars();
+    let first = chars.next()?;
+    if first == '|' || first == '\n' || first.is_whitespace() {
+        return None;
+    }
+    let mut last = first;
+    let mut consumed = first.len_utf8();
+    for ch in chars {
+        if ch == '\n' {
+            return None;
+        }
+        if ch == '|' {
+            if last.is_whitespace() {
+                return None;
+            }
+            let mut end = at + 1 + consumed + '|'.len_utf8();
+            let mut unders = 0;
+            for c in text[end..].chars() {
+                if unders < 2 && c == '_' {
+                    end += 1;
+                    unders += 1;
+                    continue;
+                }
+                if c.is_ascii_alphanumeric() {
+                    return None;
+                }
+                break;
+            }
+            return Some(end);
+        }
+        last = ch;
+        consumed += ch.len_utf8();
     }
     None
 }
@@ -804,7 +877,7 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 /// reference links `[text][ref]`, inline code, autolinks, math, Org `[[...]]`,
 /// Org `[cite...]`, Org `[fn::…]` / `[fn:LABEL:…]`, Org `<<<...>>>` /
 /// `<<...>>`, Org `{{{name}}}` / `{{{name(args)}}}`, Org `src_lang{...}` /
-/// `call_name(...)`, paired spans).
+/// `call_name(...)`, RST `|fig. 1|` / `|name|_` / `|name|__`, paired spans).
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.
@@ -814,6 +887,11 @@ pub fn atomic_inline_spans(text: &str) -> Vec<(usize, usize)> {
     let bytes = text.as_bytes();
     let mut i = 0;
     while i < text.len() {
+        if let Some(end) = rst_substitution_ref_span_end(text, i) {
+            spans.push((i, end));
+            i = end;
+            continue;
+        }
         if let Some(end) = org_inline_src_or_call_span_end(text, i) {
             spans.push((i, end));
             org_src_call_spans.push((i, end));
@@ -2203,6 +2281,102 @@ mod tests {
             split(link_text),
             vec![
                 "See [fn:: see [[https://ex.com][ex. site]]] in the notes.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_rst_substitution_ref_interior_punct_is_not_a_sentence_boundary() {
+        // GitHub #233 / snapper-15i9: Docutils Inliner.substitution_ref
+        // `|fig. 1|` stays one token so an interior period is not a
+        // sentence boundary. `Next sentence.` still splits.
+        let sub = "|fig. 1|";
+        let text = "See |fig. 1| in the caption. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == sub),
+            "substitution_ref must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == sub),
+            "substitution_ref must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See |fig. 1| in the caption.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn rst_substitution_ref_hyperlink_suffix_stays_one_token() {
+        for sub in ["|fig. 1|_", "|fig. 1|__"] {
+            let text = format!("See {sub} in the caption. Next sentence.");
+            let (_, placeholders) = protect_inline_tokens(&text);
+            assert!(
+                placeholders.iter().any(|p| p == sub),
+                "suffixed substitution_ref must be one token, got {placeholders:?} for {sub}"
+            );
+            assert_eq!(
+                split(&text),
+                vec![
+                    format!("See {sub} in the caption."),
+                    "Next sentence.".to_string()
+                ]
+            );
+        }
+    }
+
+    #[test]
+    fn rst_line_block_and_open_bar_are_not_substitution_refs() {
+        // Docutils line_block is `| ` (space after opener). Unclosed
+        // `|fig. 1` is not substitution_ref. Leading/trailing space
+        // inside the bars is invalid. A letter prefix (`\Verb|`) is
+        // not a start-string.
+        for text in [
+            "| This is a line. Another sentence.",
+            "See |fig. 1 in the caption. Next sentence.",
+            "See | fig. 1| in the caption. Next sentence.",
+            "See |fig. 1 | in the caption. Next sentence.",
+            r"Use \Verb|a.b! c| here. Next sentence.",
+        ] {
+            let (_, placeholders) = protect_inline_tokens(text);
+            assert!(
+                !placeholders.iter().any(|p| p.contains("fig. 1")
+                    || p.contains("This is a line")
+                    || p.contains("a.b!")
+                    || p.starts_with("| ")),
+                "invalid / line-block `|` must not be a token, got {placeholders:?} for {text:?}"
+            );
+        }
+        let parts = split("See |fig. 1 in the caption. Next sentence.");
+        assert_eq!(parts.last().map(String::as_str), Some("Next sentence."));
+        assert!(
+            parts.iter().any(|p| p.contains("fig.")),
+            "unclosed |fig. 1 must still expose the interior period, got {parts:?}"
+        );
+    }
+
+    #[test]
+    fn rst_version_substitution_ref_is_one_token_and_still_splits() {
+        // snapper-t0th: `|version|` stays Prose. The closer period is
+        // still a sentence end.
+        let sub = "|version|";
+        let text = "The current release is |version|. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == sub),
+            "|version| must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "The current release is |version|.".to_string(),
                 "Next sentence.".to_string()
             ]
         );

--- a/tests/rst_substitution_refs.rs
+++ b/tests/rst_substitution_refs.rs
@@ -1,6 +1,8 @@
-//! snapper-t0th: RST substitution references are not leftover table rows.
-//! Docutils Inliner substitution_ref is inline; line_block is only `|`
-//! plus space or EOL; grid_table_top is `+---+`. Leftover `|` stays Prose.
+//! snapper-t0th / snapper-15i9 / GitHub #233: RST substitution
+//! references are not leftover table rows, and interior punctuation
+//! is not a sentence boundary. Docutils Inliner substitution_ref is
+//! inline; line_block is only `|` plus space or EOL; grid_table_top
+//! is `+---+`. Leftover `|` stays Prose. `|fig. 1|` stays one token.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::rst::RstParser;
@@ -97,5 +99,67 @@ fn line_block_and_grid_table_still_hold() {
         format_text(grid, &rst_cfg()).unwrap(),
         grid,
         "grid table must stay identity"
+    );
+}
+
+/// Ticket fixture (Format::Rst / GitHub #233).
+fn interior_punct_fixture() -> &'static str {
+    "See |fig. 1| in the caption. Next sentence.\n"
+}
+
+#[test]
+fn interior_punct_use_stays_prose_not_structure() {
+    let regions = RstParser.parse(interior_punct_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains("|fig. 1|") && s.contains("Next sentence.")
+        )),
+        "|fig. 1| must stay Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("|fig. 1|") || s.contains("|version|")
+        )),
+        "|fig. 1| / |version| must not be Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn interior_punct_fixture_keeps_span_and_splits_next() {
+    let input = interior_punct_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert!(
+        out.contains("|fig. 1|"),
+        "substitution_ref must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("|fig.\n") && !out.contains("fig.\n1"),
+        "must not split inside |fig. 1|, got:\n{out}"
+    );
+    assert_eq!(
+        out,
+        concat!("See |fig. 1| in the caption.\n", "Next sentence.\n"),
+        "Next sentence. must still split; |fig. 1| stays one token, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &rst_cfg()).unwrap(),
+        out,
+        "split substitution-ref prose must be identity, got:\n{out}"
+    );
+
+    let guarded = FormatConfig {
+        format: Format::Rst,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
     );
 }


### PR DESCRIPTION
vissue: snapper-15i9 (parent snapper-etv7). GitHub #233.

unanimous-green-101 4/4 GREEN (impl-A, impl-B, rev-1, rev-2) on a392d4f;
isolated onto origin/main 94dcd00 as 8a2f8b2.

Docutils Inliner.substitution_ref. `|fig. 1|` stays one token;
`Next sentence.` still splits. Line-block `| ` and unlisted `\Verb|...|`
are not tokens. Use stays Prose.

## Test plan
- rustc tests in tests/rst_substitution_refs.rs
- terra: cargo test sentence::unicode parser::rst rst_substitution_refs