### PR TITLE
fix(latex): treat spverbatim and spverb as verbatim

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut=, and =alltt=.
+Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut=, standard =alltt=, and spverbatim.sty =spverbatim=.
 
 Adding an unlisted name stops reflow of that environment.
 
@@ -186,7 +186,7 @@ Adding =algorithm= stops reflow of that environment.
 
 String array of extra command names tokenized like the built-in verb command before sentence split.
 The next character after the name is the delimiter.
-Built-in names are =verb= and =lstinline=; =lstinline= still accepts optional =[...]= and ={...}=.
+Built-in names are =verb=, =lstinline=, and =spverb=; =lstinline= still accepts optional =[...]= and ={...}=.
 Adding =Verb= (fancyvrb) keeps that command's delimited body atomic and treats an inner =%= as content, not a comment.
 
 * Code-block sections (=[code.<lang>]=)

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -102,9 +102,10 @@ These tokens within prose are not split across lines:
 - fancyvrb =Verbatim= / =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut= are built-in code regions (same FV@Scan class)
 - =alltt= (standard =alltt.sty=) is a built-in code region (raw line breaks)
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
+- spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= / =lstlisting*= =language== option)
-- Inline =\verb= / =\lstinline= (and extra =[latex].verbatim_commands=, for example =\Verb=) stay atomic; inner =.!?%= do not split or comment
+- Inline =\verb= / =\lstinline= / =\spverb= (and extra =[latex].verbatim_commands=, for example =\Verb=) stay atomic; inner =.!?%= do not split or comment
 
 *** Prose regions (reflowed)
 :PROPERTIES:

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,15 +16,15 @@ pub struct FormatOverrides {
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
     /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut, and
-    /// alltt; entries are added to it.
+    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut,
+    /// standard alltt, and spverbatim; entries are added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps
     /// `NON_PROSE_ENVS`; entries are added to that list.
     pub structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
-    /// Meaningful under `[latex]` only. Missing or empty keeps verb/lstinline.
+    /// Meaningful under `[latex]` only. Missing or empty keeps verb/lstinline/spverb.
     pub verbatim_commands: Vec<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,14 +116,14 @@ pub struct FormatConfig {
     /// Extra LaTeX environments treated as code (no reflow), added to
     /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut, and
-    /// alltt. Empty keeps the built-in list.
+    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut,
+    /// standard alltt, and spverbatim. Empty keeps the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.
     pub latex_structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
-    /// Empty keeps verb/lstinline.
+    /// Empty keeps verb/lstinline/spverb.
     pub latex_verbatim_commands: Vec<String>,
 }
 

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -130,14 +130,16 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
 /// `sageblock`) plus fancyvrb `verbatim*` / `Verbatim` / `BVerbatim` /
 /// `LVerbatim` / `SaveVerbatim` / `VerbatimOut`, moreverb
-/// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, the
-/// standard `alltt` package env (raw line breaks, some macros still
-/// expand; GitHub #230), and the `comment` package env (tree-sitter
-/// `comment_environment`: raw through matching `\end{comment}`).
-/// Overleaf `verbatimEnvNames` is Verbatim, boxedverbatim, tcblisting,
-/// codeexample. fancyvrb `BVerbatim` / `LVerbatim` are the same raw
-/// class as `Verbatim` (GitHub #209). `SaveVerbatim` / `VerbatimOut`
-/// are the same `FV@Scan` class (GitHub #213). listings.sty
+/// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, standard
+/// `alltt` (alltt.sty: macros still apply, line breaks stay raw;
+/// GitHub #230), spverbatim.sty `spverbatim` (raw body; `\spverb` is
+/// the matching delimiter-body command, GitHub #235), and the
+/// `comment` package env (tree-sitter `comment_environment`: raw
+/// through matching `\end{comment}`). Overleaf `verbatimEnvNames` is
+/// Verbatim, boxedverbatim, tcblisting, codeexample. fancyvrb
+/// `BVerbatim` / `LVerbatim` are the same raw class as `Verbatim`
+/// (GitHub #209). `SaveVerbatim` / `VerbatimOut` are the same
+/// `FV@Scan` class (GitHub #213). listings.sty
 /// `\lstnewenvironment{lstlisting}` also defines `lstlisting*` (same
 /// raw body scan; GitHub #234).
 fn is_builtin_code_env(name: &str) -> bool {
@@ -157,6 +159,7 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "boxedverbatim"
             | "tcblisting"
             | "codeexample"
+            | "spverbatim"
             | "filecontents"
             | "filecontents*"
             | "asy"
@@ -269,7 +272,7 @@ impl LatexParser {
     }
 
     /// Byte offset of the first `%` that is not escaped as `\%` and is not
-    /// inside `\verb` / `\lstinline` / configured verbatim commands.
+    /// inside `\verb` / `\lstinline` / `\spverb` / configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -640,7 +643,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
     None
 }
 
-/// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` spans.
+/// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` / `\spverb` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -2669,6 +2672,66 @@ Some text.
                 .any(|r| matches!(r, Region::Prose(p) if p.contains("After the block"))),
             "prose after lstlisting* % closer must resume, got: {raw_regions:?}"
         );
+    }
+
+    /// Ticket fixture (GitHub #235): spverbatim.sty env body stays Code;
+    /// `\spverb|a.b%|` is one token; following `Next.` still splits.
+    #[test]
+    fn spverbatim_and_spverb_are_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{spverbatim}\n",
+            "First line. Second line.\n",
+            "\\end{spverbatim}\n",
+            "See \\spverb|a.b%| please. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "spverbatim body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "spverbatim body must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| {
+                matches!(r, Region::Structure(s) if s.contains("%|") || s.trim() == "%|\n")
+            }),
+            "inner % of \\spverb must not be a comment, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\begin{spverbatim}") && out.contains("\\end{spverbatim}"),
+            "spverbatim begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "spverbatim body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "spverbatim must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains(r"\spverb|a.b%|"),
+            "\\spverb|a.b%| must stay one token, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\spverb|a.\n") && !out.contains("\\spverb|a.b%\n"),
+            "inner .!?% must not split \\spverb, got:\n{out}"
+        );
+        assert!(
+            out.contains("See \\spverb|a.b%| please.\nNext."),
+            "prose after \\spverb must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
 
     #[test]

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -170,7 +170,7 @@ pub fn protect_inline_tokens_with(
     (protected.into_owned(), placeholders)
 }
 
-/// `\verb|...|` / `\lstinline[...]!...!` so inner `.!?%` cannot split or comment.
+/// `\verb|...|` / `\lstinline[...]!...!` / `\spverb|...|` so inner `.!?%` cannot split or comment.
 fn protect_latex_verbatim(
     text: &str,
     placeholders: &mut Vec<String>,
@@ -194,13 +194,13 @@ fn protect_latex_verbatim(
     out
 }
 
-/// Byte end of a `\verb` / `\lstinline` / extra-name span starting at `at`.
+/// Byte end of a `\verb` / `\lstinline` / `\spverb` / extra-name span starting at `at`.
 ///
-/// `\verb` / `\verb*`: next character is the delimiter; content runs to the
-/// same character. `\lstinline` / `\lstinline*` may take optional `[...]`
-/// before a delimiter or a `{...}` brace body. Extra names are tokenized
-/// like `\verb`. With no closer, the span runs to end of line so an inner
-/// `%` is not a comment.
+/// `\verb` / `\verb*` / `\spverb` / `\spverb*`: next character is the
+/// delimiter; content runs to the same character. `\lstinline` /
+/// `\lstinline*` may take optional `[...]` before a delimiter or a
+/// `{...}` brace body. Extra names are tokenized like `\verb`. With no
+/// closer, the span runs to end of line so an inner `%` is not a comment.
 pub(crate) fn latex_verb_span_end_with(
     text: &str,
     at: usize,
@@ -217,6 +217,11 @@ pub(crate) fn latex_verb_span_end_with(
             return None;
         }
         (after_bs + "lstinline".len(), true)
+    } else if let Some(stripped) = tail.strip_prefix("spverb") {
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (after_bs + "spverb".len(), false)
     } else if let Some(stripped) = tail.strip_prefix("verb") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -276,7 +281,7 @@ fn line_end(text: &str, from: usize) -> usize {
 fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&'a str> {
     let mut best: Option<&str> = None;
     for name in extras {
-        if name.is_empty() || name == "verb" || name == "lstinline" {
+        if name.is_empty() || name == "verb" || name == "lstinline" || name == "spverb" {
             continue;
         }
         let Some(stripped) = tail.strip_prefix(name.as_str()) else {
@@ -1487,6 +1492,32 @@ mod tests {
         assert_eq!(
             split(text),
             vec![r"Use \verb|a.b! c| here.".to_string(), "Next.".to_string()]
+        );
+    }
+
+    #[test]
+    fn latex_spverb_inner_percent_stays_atomic() {
+        let text = r"See \spverb|a.b%| please. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == r"\spverb|a.b%|"),
+            "spverb span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\spverb|a.b%|", 0, &[]),
+            Some(r"\spverb|a.b%|".len())
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\spverbatim|x.y|", 0, &[]),
+            None,
+            "spverb must not match as a prefix of spverbatim"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \spverb|a.b%| please.".to_string(),
+                "Next.".to_string()
+            ]
         );
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -3,6 +3,7 @@
 //! GitHub #213: fancyvrb SaveVerbatim / VerbatimOut are the same FV@Scan class.
 //! GitHub #230: alltt.sty is a standard verbatim-like env (raw line breaks).
 //! GitHub #234: listings.sty lstlisting* is the same raw scan as lstlisting.
+//! GitHub #235: spverbatim.sty env and \\spverb are the same class as verb.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -321,6 +322,64 @@ fn lstlisting_star_fixture_is_code_and_does_not_reflow() {
     assert!(
         out.contains("After the block.\nNext."),
         "prose after lstlisting* must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #235): spverbatim.sty `spverbatim` body stays
+/// Code; `\spverb|a.b%|` is one token; following `Next.` still splits.
+#[test]
+fn spverbatim_and_spverb_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{spverbatim}\n",
+        "First line. Second line.\n",
+        "\\end{spverbatim}\n",
+        "See \\spverb|a.b%| please. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Code { body, .. } if body.contains("First line. Second line.")
+        )),
+        "spverbatim body must be Code, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "spverbatim body must not be Prose, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| {
+            matches!(r, Region::Structure(s) if s.contains("%|") || s.trim() == "%|\n")
+        }),
+        "inner % of \\spverb must not be a comment, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\begin{spverbatim}") && out.contains("\\end{spverbatim}"),
+        "spverbatim begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "spverbatim body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "spverbatim must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains(r"\spverb|a.b%|"),
+        "\\spverb|a.b%| must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\spverb|a.\n") && !out.contains("\\spverb|a.b%\n"),
+        "inner .!?% must not split \\spverb, got:\n{out}"
+    );
+    assert!(
+        out.contains("See \\spverb|a.b%| please.\nNext."),
+        "prose after \\spverb must still split, got:\n{out}"
     );
     assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 }


### PR DESCRIPTION
vissue: snapper-6nzh (parent snapper-etv7). GitHub #235.

unanimous-green-102 4/4 GREEN (impl-A, impl-B, rev-1, rev-2) on a9ae8d0;
isolated onto origin/main 94dcd00 as 383ecca.

spverbatim.sty env is builtin Code; `\spverb` tokenizes like `\verb`.
Env body stays frozen; `\spverb|a.b%|` is one token; `Next.` still splits.

## Test plan
- rustc tests in tests/latex_verbatim_envs.rs
- terra: cargo test parser::latex sentence::unicode latex_verbatim_envs