### PR TITLE
fix(latex): treat fancyvrb Verbatim-star envs as code

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut=, standard =alltt=, and spverbatim.sty =spverbatim=.
+Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut=, standard =alltt=, and spverbatim.sty =spverbatim=.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -99,7 +99,7 @@ These tokens within prose are not split across lines:
 :CUSTOM_ID: latex-code
 :END:
 - =\\begin{...}= / =\\end{...}= lines are structure
-- fancyvrb =Verbatim= / =BVerbatim= / =LVerbatim= / =SaveVerbatim= / =VerbatimOut= are built-in code regions (same FV@Scan class)
+- fancyvrb =Verbatim= / =Verbatim*= / =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =SaveVerbatim= / =VerbatimOut= are built-in code regions (same FV@Scan class)
 - =alltt= (standard =alltt.sty=) is a built-in code region (raw line breaks)
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,8 @@ pub struct FormatOverrides {
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
     /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut,
+    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut and
+    /// Verbatim*/BVerbatim*/LVerbatim*,
     /// standard alltt, and spverbatim; entries are added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,8 @@ pub struct FormatConfig {
     /// Extra LaTeX environments treated as code (no reflow), added to
     /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut,
+    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut and
+    /// Verbatim*/BVerbatim*/LVerbatim*,
     /// standard alltt, and spverbatim. Empty keeps the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -128,8 +128,9 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Beyond minted/lstlisting/verbatim: latexindent `fileContentsEnvironments`
 /// (`filecontents`, `filecontents*`) and tree-sitter-latex raw trivia envs
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
-/// `sageblock`) plus fancyvrb `verbatim*` / `Verbatim` / `BVerbatim` /
-/// `LVerbatim` / `SaveVerbatim` / `VerbatimOut`, moreverb
+/// `sageblock`) plus latex2e `verbatim*` / fancyvrb `Verbatim` /
+/// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
+/// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut`, moreverb
 /// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, standard
 /// `alltt` (alltt.sty: macros still apply, line breaks stay raw;
 /// GitHub #230), spverbatim.sty `spverbatim` (raw body; `\spverb` is
@@ -139,9 +140,10 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Verbatim, boxedverbatim, tcblisting, codeexample. fancyvrb
 /// `BVerbatim` / `LVerbatim` are the same raw class as `Verbatim`
 /// (GitHub #209). `SaveVerbatim` / `VerbatimOut` are the same
-/// `FV@Scan` class (GitHub #213). listings.sty
-/// `\lstnewenvironment{lstlisting}` also defines `lstlisting*` (same
-/// raw body scan; GitHub #234).
+/// `FV@Scan` class (GitHub #213). fancyvrb `Verbatim*` / `BVerbatim*`
+/// / `LVerbatim*` are the starred twins (same `\FV@Scan`; GitHub
+/// #244). listings.sty `\lstnewenvironment{lstlisting}` also defines
+/// `lstlisting*` (same raw body scan; GitHub #234).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
@@ -151,8 +153,11 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "verbatim"
             | "verbatim*"
             | "Verbatim"
+            | "Verbatim*"
             | "BVerbatim"
+            | "BVerbatim*"
             | "LVerbatim"
+            | "LVerbatim*"
             | "SaveVerbatim"
             | "VerbatimOut"
             | "alltt"
@@ -2412,6 +2417,59 @@ Some text.
                 !two_out.contains("First line.\nSecond line."),
                 "{name} two-sentence body must not split, got:\n{two_out}"
             );
+        }
+    }
+
+    /// Ticket fixture (GitHub #244): fancyvrb `Verbatim*` / `BVerbatim*`
+    /// / `LVerbatim*` are the starred twins of the unstarred FV@Scan
+    /// names. Body stays Code; following prose still splits.
+    #[test]
+    fn fancyvrb_verbatim_star_envs_are_code_not_prose() {
+        use crate::format_text;
+
+        for name in ["Verbatim*", "BVerbatim*", "LVerbatim*"] {
+            let input = format!(
+                concat!(
+                    "\\begin{{{name}}}\n",
+                    "First line. Second line.\n",
+                    "\\end{{{name}}}\n",
+                    "After the block. Next.\n",
+                ),
+                name = name
+            );
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Code { body, .. } if body.contains("First line. Second line.")
+                )),
+                "{name} body must be Code, got: {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+                "{name} body must not leak into Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&format!("\\begin{{{name}}}"))
+                    && out.contains(&format!("\\end{{{name}}}")),
+                "{name} begin/end must stay, got:\n{out}"
+            );
+            assert!(
+                out.contains("First line. Second line."),
+                "{name} body must stay one source line, got:\n{out}"
+            );
+            assert!(
+                !out.contains("First line.\nSecond line."),
+                "{name} must not reflow as prose, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the block.\nNext."),
+                "prose after {name} must still split, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
         }
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -4,6 +4,7 @@
 //! GitHub #230: alltt.sty is a standard verbatim-like env (raw line breaks).
 //! GitHub #234: listings.sty lstlisting* is the same raw scan as lstlisting.
 //! GitHub #235: spverbatim.sty env and \\spverb are the same class as verb.
+//! GitHub #244: fancyvrb Verbatim* / BVerbatim* / LVerbatim* are the same FV@Scan class.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -143,6 +144,56 @@ fn bverbatim_lverbatim_fixture_is_code_and_does_not_reflow() {
             !two_out.contains("First line.\nSecond line."),
             "{name} two-sentence body must not split, got:\n{two_out}"
         );
+    }
+}
+
+/// Ticket fixture (GitHub #244): fancyvrb Verbatim* / BVerbatim* /
+/// LVerbatim* bodies stay Code; following prose still splits.
+#[test]
+fn verbatim_star_envs_fixture_is_code_and_does_not_reflow() {
+    for name in ["Verbatim*", "BVerbatim*", "LVerbatim*"] {
+        let input = format!(
+            concat!(
+                "\\begin{{{name}}}\n",
+                "First line. Second line.\n",
+                "\\end{{{name}}}\n",
+                "After the block. Next.\n",
+            ),
+            name = name
+        );
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "{name} body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&format!("\\begin{{{name}}}"))
+                && out.contains(&format!("\\end{{{name}}}")),
+            "{name} begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "{name} body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after {name} must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
 }
 


### PR DESCRIPTION
vissue: snapper-jhaz (parent snapper-etv7). GitHub #244.

unanimous-green-104 4/4 GREEN (impl-A, impl-B, rev-1, rev-2) on 6043837;
isolated onto origin/main d3eb647 as dea2103.

fancyvrb `Verbatim*` / `BVerbatim*` / `LVerbatim*` share `\FV@Scan`
with the unstarred names. Env body stays Code; following prose still
splits. Keeps alltt / lstlisting* / spverbatim.

## Test plan
- rustc tests in tests/latex_verbatim_envs.rs (`verbatim_star_envs_fixture_is_code_and_does_not_reflow`)
- terra: cargo test parser::latex latex_verbatim_envs