### PR TITLE
fix(latex): tokenize fancyvrb Verb and Verb* like verb

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Drop a `.snapperrc.toml` in your project root:
     structure_envs = ["algorithm", "comment"]
     verbatim_commands = ["Verb"]
 
-Missing `[latex]` keys keep the built-in minted/lstlisting/verbatim/comment, equation/figure, and verb/lstinline lists.
+Missing `[latex]` keys keep the built-in minted/lstlisting/verbatim/comment, equation/figure, and verb/lstinline/spverb/Verb lists.
 `snapper` walks up from the current directory to find it.
 
 

--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -186,9 +186,9 @@ Adding =algorithm= stops reflow of that environment.
 
 String array of extra command names tokenized like the built-in verb command before sentence split.
 The next character after the name is the delimiter.
-Built-in names are =verb=, =lstinline=, =spverb=, =mintinline=, and =mint=; =lstinline= still accepts optional =[...]= and ={...}=.
+Built-in names are =verb=, =lstinline=, =spverb=, =mintinline=, =mint=, and fancyvrb =Verb= / =Verb*=; =lstinline= still accepts optional =[...]= and ={...}=.
 =mintinline= / =mint= take optional =[...]=, a ={lang}= argument, then a delimiter or ={...}= body.
-Adding =Verb= (fancyvrb) keeps that command's delimited body atomic and treats an inner =%= as content, not a comment.
+Adding another name keeps that command's delimited body atomic and treats an inner =%= as content, not a comment.
 
 * Code-block sections (=[code.<lang>]=)
 :PROPERTIES:

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -105,7 +105,7 @@ These tokens within prose are not split across lines:
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= / =lstlisting*= =language== option)
-- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= (and extra =[latex].verbatim_commands=, for example =\Verb=) stay atomic; inner =.!?%= do not split or comment
+- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment
 
 *** Prose regions (reflowed)
 :PROPERTIES:

--- a/readme_src.org
+++ b/readme_src.org
@@ -260,7 +260,7 @@ verbatim_envs = ["Verbatim"]
 structure_envs = ["algorithm", "comment"]
 verbatim_commands = ["Verb"]
 #+end_src
-Missing =[latex]= keys keep the built-in minted/lstlisting/verbatim/comment, equation/figure, and verb/lstinline lists.
+Missing =[latex]= keys keep the built-in minted/lstlisting/verbatim/comment, equation/figure, and verb/lstinline/spverb/Verb lists.
 ~snapper~ walks up from the current directory to find it.
 * Documentation
 :PROPERTIES:

--- a/src/check.rs
+++ b/src/check.rs
@@ -812,14 +812,39 @@ mod tests {
     }
 
     #[test]
-    fn configured_verb_inner_percent_is_fused_not_comment() {
+    fn fancyvrb_verb_inner_percent_is_fused_not_comment() {
         let input = "\\begin{document}\nCode \\Verb!%! here. Next sentence.\n\\end{document}\n";
+        let splitter = UnicodeSentenceSplitter::new();
+        let found = collect_diagnostics(
+            input,
+            Format::Latex,
+            &splitter,
+            DEFAULT_LONG_THRESHOLD,
+            None,
+        );
+        assert!(
+            found
+                .iter()
+                .any(|d| d.line == 2 && d.kind == DiagnosticKind::Fused),
+            "built-in Verb inner % is content; the line is fused, got {found:?}"
+        );
+        let payloads = source_line_payloads(input, Format::Latex, None);
+        assert_eq!(
+            payloads[1].as_deref().map(str::trim),
+            Some("Code \\Verb!%! here. Next sentence."),
+            "built-in Verb must keep inner % as prose, got {payloads:?}"
+        );
+    }
+
+    #[test]
+    fn configured_verb_inner_percent_is_fused_not_comment() {
+        let input = "\\begin{document}\nCode \\MyVerb!%! here. Next sentence.\n\\end{document}\n";
         let config = FormatConfig {
             format: Format::Latex,
-            latex_verbatim_commands: vec!["Verb".into()],
+            latex_verbatim_commands: vec!["MyVerb".into()],
             ..Default::default()
         };
-        let splitter = UnicodeSentenceSplitter::new().with_verbatim_commands(vec!["Verb".into()]);
+        let splitter = UnicodeSentenceSplitter::new().with_verbatim_commands(vec!["MyVerb".into()]);
         let found = collect_diagnostics(
             input,
             Format::Latex,
@@ -831,19 +856,19 @@ mod tests {
             found
                 .iter()
                 .any(|d| d.line == 2 && d.kind == DiagnosticKind::Fused),
-            "configured Verb inner % is content; the line is fused, got {found:?}"
+            "configured MyVerb inner % is content; the line is fused, got {found:?}"
         );
         let payloads = source_line_payloads(input, Format::Latex, Some(&config));
         assert_eq!(
             payloads[1].as_deref().map(str::trim),
-            Some("Code \\Verb!%! here. Next sentence."),
-            "extras must keep % inside Verb as prose, got {payloads:?}"
+            Some("Code \\MyVerb!%! here. Next sentence."),
+            "extras must keep % inside MyVerb as prose, got {payloads:?}"
         );
         let builtin = source_line_payloads(input, Format::Latex, None);
         assert_ne!(
             builtin[1].as_deref().map(str::trim),
-            Some("Code \\Verb!%! here. Next sentence."),
-            "built-in lists treat % as a comment, got {builtin:?}"
+            Some("Code \\MyVerb!%! here. Next sentence."),
+            "built-in lists treat unlisted MyVerb % as a comment, got {builtin:?}"
         );
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,7 +26,7 @@ pub struct FormatOverrides {
     pub structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
     /// Meaningful under `[latex]` only. Missing or empty keeps
-    /// verb/lstinline/spverb/mintinline/mint.
+    /// verb/lstinline/spverb/mintinline/mint/Verb.
     pub verbatim_commands: Vec<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,7 +124,7 @@ pub struct FormatConfig {
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.
     pub latex_structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
-    /// Empty keeps verb/lstinline/spverb/mintinline/mint.
+    /// Empty keeps verb/lstinline/spverb/mintinline/mint/Verb.
     pub latex_verbatim_commands: Vec<String>,
 }
 

--- a/src/oracle.rs
+++ b/src/oracle.rs
@@ -389,17 +389,28 @@ mod tests {
     }
 
     #[test]
-    fn configured_verb_percent_tree_matches_across_split() {
+    fn fancyvrb_verb_percent_tree_matches_across_split() {
         let original = "\\begin{document}\nCode \\Verb!%! here. Next sentence.\n\\end{document}\n";
         let output = "\\begin{document}\nCode \\Verb!%! here.\nNext sentence.\n\\end{document}\n";
+        assert!(
+            matches(Format::Latex, original, output),
+            "built-in Verb inner % must parse the same region tree as format_once"
+        );
+    }
+
+    #[test]
+    fn configured_verb_percent_tree_matches_across_split() {
+        let original =
+            "\\begin{document}\nCode \\MyVerb!%! here. Next sentence.\n\\end{document}\n";
+        let output = "\\begin{document}\nCode \\MyVerb!%! here.\nNext sentence.\n\\end{document}\n";
         let cfg = crate::FormatConfig {
             format: Format::Latex,
-            latex_verbatim_commands: vec!["Verb".into()],
+            latex_verbatim_commands: vec!["MyVerb".into()],
             ..Default::default()
         };
         assert!(
             !matches(Format::Latex, original, output),
-            "built-in lists treat inner % as a comment, so the trees diverge"
+            "built-in lists treat unlisted MyVerb inner % as a comment, so the trees diverge"
         );
         assert!(
             matches_ex(Format::Latex, original, output, false, Some(&cfg)),

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -278,7 +278,7 @@ impl LatexParser {
 
     /// Byte offset of the first `%` that is not escaped as `\%` and is not
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
-    /// configured verbatim commands.
+    /// `\Verb` / configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -650,7 +650,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 }
 
 /// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` /
-/// `\spverb` / `\mintinline` / `\mint` spans.
+/// `\spverb` / `\mintinline` / `\mint` / `\Verb` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -1916,6 +1916,78 @@ Some text.
     }
 
     #[test]
+    fn fancyvrb_verb_with_inner_punct_round_trips() {
+        use crate::format_text;
+
+        // GitHub #243 fixture: `\Verb|a.b! c|` is one token; Next sentence. splits.
+        let input = "\\begin{document}\nUse \\Verb|a.b! c| here. Next sentence.\n\\end{document}\n";
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\Verb|a.b! c|"),
+            "Verb must stay intact, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\Verb|a.\n") && !out.contains("\\Verb|a.b!\n"),
+            "inner .!? must not split Verb, got:\n{out}"
+        );
+        assert!(
+            out.contains("Use \\Verb|a.b! c| here.\nNext sentence."),
+            "prose after Verb must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn fancyvrb_verb_star_with_inner_punct_round_trips() {
+        use crate::format_text;
+
+        let input =
+            "\\begin{document}\nUse \\Verb*|a.b! c| here. Next sentence.\n\\end{document}\n";
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\Verb*|a.b! c|"),
+            "Verb* must stay intact, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\Verb*|a.\n") && !out.contains("\\Verb*|a.b!\n"),
+            "inner .!? must not split Verb*, got:\n{out}"
+        );
+        assert!(
+            out.contains("Use \\Verb*|a.b! c| here.\nNext sentence."),
+            "prose after Verb* must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn fancyvrb_verb_inner_percent_is_not_a_comment() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nCode \\Verb!%! here. Next sentence.\n\\end{document}\n";
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\Verb!%!"),
+            "Verb with inner % must stay intact, got:\n{out}"
+        );
+        assert!(
+            out.contains("here."),
+            "text after Verb must not be commented out, got:\n{out}"
+        );
+        assert!(
+            out.contains("Code \\Verb!%! here.\nNext sentence."),
+            "prose after Verb must still split, got:\n{out}"
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            !regions.iter().any(
+                |r| matches!(r, Region::Structure(s) if s.contains("%!") || s.trim() == "%!\n")
+            ),
+            "inner % of Verb must not be a comment, got: {regions:?}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    #[test]
     fn lstinline_inner_percent_is_not_a_comment() {
         use crate::format_text;
 
@@ -2962,31 +3034,32 @@ Some text.
     fn configured_verbatim_command_is_tokenized_like_verb() {
         use crate::format_text;
 
-        let input = "\\begin{document}\nUse \\Verb|a.b! c| here. Next sentence.\n\\end{document}\n";
+        let input =
+            "\\begin{document}\nUse \\MyVerb|a.b! c| here. Next sentence.\n\\end{document}\n";
         let default_out = format_text(input, &latex_cfg()).unwrap();
         assert!(
-            !default_out.contains("Use \\Verb|a.b! c| here.\nNext sentence."),
-            "unlisted Verb must not stay atomic like verb, got:\n{default_out}"
+            !default_out.contains("Use \\MyVerb|a.b! c| here.\nNext sentence."),
+            "unlisted MyVerb must not stay atomic like verb, got:\n{default_out}"
         );
 
         let cfg = crate::FormatConfig {
             format: crate::format::Format::Latex,
-            latex_verbatim_commands: vec!["Verb".into()],
+            latex_verbatim_commands: vec!["MyVerb".into()],
             ..Default::default()
         }
         .without_safety_backstops();
         let out = format_text(input, &cfg).unwrap();
         assert!(
-            out.contains(r"\Verb|a.b! c|"),
-            "configured Verb must stay intact, got:\n{out}"
+            out.contains(r"\MyVerb|a.b! c|"),
+            "configured MyVerb must stay intact, got:\n{out}"
         );
         assert!(
-            !out.contains("\\Verb|a.\n") && !out.contains("\\Verb|a.b!\n"),
-            "inner .!? must not split configured Verb, got:\n{out}"
+            !out.contains("\\MyVerb|a.\n") && !out.contains("\\MyVerb|a.b!\n"),
+            "inner .!? must not split configured MyVerb, got:\n{out}"
         );
         assert!(
-            out.contains("Use \\Verb|a.b! c| here.\nNext sentence."),
-            "configured Verb must tokenize like verb before split, got:\n{out}"
+            out.contains("Use \\MyVerb|a.b! c| here.\nNext sentence."),
+            "configured MyVerb must tokenize like verb before split, got:\n{out}"
         );
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -156,9 +156,9 @@ pub fn protect_inline_tokens_with(
 ) -> (String, Vec<String>) {
     let mut placeholders: Vec<String> = Vec::new();
     let after_verb = protect_latex_verbatim(text, &mut placeholders, extra_verbatim_commands);
-    // After `\verb|` so a configured delimiter is gone. Unlisted
-    // `\Verb|a.b! c|` keeps the letter prefix, so it is not a
-    // substitution_ref (Docutils start-string; GitHub #233).
+    // After `\verb|` / `\Verb|` so a configured delimiter is gone.
+    // A leftover letter prefix is not a substitution_ref start-string
+    // (Docutils; GitHub #233).
     let after_rst = protect_rst_substitution_refs(&after_verb, &mut placeholders);
     // org-element inline src / babel-call before paired `=`/`~` so a body
     // like `src_python{~x~}` stays one object, not an Org code span.
@@ -175,8 +175,8 @@ pub fn protect_inline_tokens_with(
 }
 
 /// `\verb|...|` / `\lstinline[...]!...!` / `\spverb|...|` /
-/// `\mintinline{lang}|...|` / `\mint{lang}{...}` so inner `.!?%` cannot
-/// split or comment.
+/// `\mintinline{lang}|...|` / `\mint{lang}{...}` / `\Verb|...|` so
+/// inner `.!?%` cannot split or comment.
 fn protect_latex_verbatim(
     text: &str,
     placeholders: &mut Vec<String>,
@@ -201,9 +201,10 @@ fn protect_latex_verbatim(
 }
 
 /// Byte end of a `\verb` / `\lstinline` / `\spverb` / `\mintinline` /
-/// `\mint` / extra-name span starting at `at`.
+/// `\mint` / `\Verb` / extra-name span starting at `at`.
 ///
-/// `\verb` / `\verb*` / `\spverb` / `\spverb*`: next character is the
+/// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
+/// character is the
 /// delimiter; content runs to the same character. `\lstinline` /
 /// `\lstinline*` may take optional `[...]` before a delimiter or a
 /// `{...}` brace body. `\mintinline` / `\mint` (and stars) take optional
@@ -243,6 +244,11 @@ pub(crate) fn latex_verb_span_end_with(
             return None;
         }
         (after_bs + "mint".len(), VerbKind::Mint)
+    } else if let Some(stripped) = tail.strip_prefix("Verb") {
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (after_bs + "Verb".len(), VerbKind::Delim)
     } else if let Some(stripped) = tail.strip_prefix("verb") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -331,6 +337,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "spverb"
             || name == "mintinline"
             || name == "mint"
+            || name == "Verb"
         {
             continue;
         }
@@ -1646,6 +1653,67 @@ mod tests {
     }
 
     #[test]
+    fn latex_fancyvrb_verb_inner_punct_stays_atomic() {
+        // GitHub #243: fancyvrb `\Verb` / `\Verb*` use the same
+        // delimiter-body scan as `\verb`.
+        let text = r"Use \Verb|a.b! c| here. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == r"\Verb|a.b! c|"),
+            "Verb span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\Verb|a.b! c|", 0, &[]),
+            Some(r"\Verb|a.b! c|".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"Use \Verb|a.b! c| here.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn latex_fancyvrb_verb_star_inner_punct_stays_atomic() {
+        let text = r"Use \Verb*|a.b! c| here. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == r"\Verb*|a.b! c|"),
+            "Verb* span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\Verb*|a.b! c|", 0, &[]),
+            Some(r"\Verb*|a.b! c|".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"Use \Verb*|a.b! c| here.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn latex_fancyvrb_verb_inner_percent_stays_atomic() {
+        let text = r"Code \Verb!%! here. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == r"\Verb!%!"),
+            "Verb span with inner % must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"Code \Verb!%! here.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn extra_verbatim_command_is_tokenized_like_verb() {
         let text = r"Use \MyVerb|a.b! c| here. Next.";
         let extras = ["MyVerb".to_string()];
@@ -1665,26 +1733,29 @@ mod tests {
 
     #[test]
     fn extra_verb_does_not_steal_verbatim() {
-        let extras = ["Verb".to_string()];
         assert_eq!(
-            latex_verb_span_end_with(r"\Verbatim|x.y|", 0, &extras),
+            latex_verb_span_end_with(r"\Verbatim|x.y|", 0, &[]),
             None,
             "Verb must not match as a prefix of Verbatim"
         );
         assert_eq!(
-            latex_verb_span_end_with(r"\Verb|x.y|", 0, &extras),
+            latex_verb_span_end_with(r"\Verb|x.y|", 0, &[]),
             Some(r"\Verb|x.y|".len())
         );
+        let extras = ["MyVerb".to_string()];
+        assert_eq!(
+            latex_verb_span_end_with(r"\MyVerbatim|x.y|", 0, &extras),
+            None,
+            "MyVerb must not match as a prefix of MyVerbatim"
+        );
         let text = r"Use \Verbatim|x.y| here. Next.";
-        let (_, placeholders) = protect_inline_tokens_with(text, &extras);
+        let (_, placeholders) = protect_inline_tokens(text);
         assert!(
             placeholders.iter().all(|p| p != r"\Verbatim|x.y|"),
             "Verbatim must not become a verb span, got {placeholders:?}"
         );
         assert_eq!(
-            UnicodeSentenceSplitter::new()
-                .with_verbatim_commands(extras.to_vec())
-                .split(text),
+            split(text),
             vec![r"Use \Verbatim|x.y| here.".to_string(), "Next.".to_string()]
         );
     }
@@ -2536,20 +2607,18 @@ mod tests {
     fn rst_line_block_and_open_bar_are_not_substitution_refs() {
         // Docutils line_block is `| ` (space after opener). Unclosed
         // `|fig. 1` is not substitution_ref. Leading/trailing space
-        // inside the bars is invalid. A letter prefix (`\Verb|`) is
-        // not a start-string.
+        // inside the bars is invalid. `\Verb|...|` is a fancyvrb verb
+        // token (GitHub #243), not a substitution_ref.
         for text in [
             "| This is a line. Another sentence.",
             "See |fig. 1 in the caption. Next sentence.",
             "See | fig. 1| in the caption. Next sentence.",
             "See |fig. 1 | in the caption. Next sentence.",
-            r"Use \Verb|a.b! c| here. Next sentence.",
         ] {
             let (_, placeholders) = protect_inline_tokens(text);
             assert!(
                 !placeholders.iter().any(|p| p.contains("fig. 1")
                     || p.contains("This is a line")
-                    || p.contains("a.b!")
                     || p.starts_with("| ")),
                 "invalid / line-block `|` must not be a token, got {placeholders:?} for {text:?}"
             );


### PR DESCRIPTION
vissue: snapper-jdvo (parent snapper-etv7). GitHub #243.

unanimous-green-103 4/4 GREEN after child snapper-pm6w (RST negative
test no longer forbids a built-in \\Verb placeholder). Isolated onto
origin/main 257a924 as 5f8e4a1.

fancyvrb `\\Verb` / `\\Verb*` share the delimiter-body scan of `\\verb`.
`\\Verb|a.b! c|` stays one token; `Next sentence.` still splits.
Keeps verb / lstinline / spverb / mintinline / mint.

## Test plan
- terra: cargo test sentence::unicode parser::latex
- dogfood: snapper --native --check on config.org and formats.org