### PR TITLE
fix(latex): treat tcolorbox tcblisting-star as code

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut=, standard =alltt=, and spverbatim.sty =spverbatim=.
+Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut=, standard =alltt=, and spverbatim.sty =spverbatim=.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -102,6 +102,7 @@ These tokens within prose are not split across lines:
 - fancyvrb =Verbatim= / =Verbatim*= / =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =SaveVerbatim= / =VerbatimOut= are built-in code regions (same FV@Scan class)
 - =alltt= (standard =alltt.sty=) is a built-in code region (raw line breaks)
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
+- tcolorbox listings =tcblisting*= is the starred twin of =tcblisting= (same raw listing body)
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= / =lstlisting*= =language== option)

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,7 @@ pub struct FormatOverrides {
     /// Extra LaTeX environments treated as code (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
     /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
-    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
+    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// standard alltt, and spverbatim; entries are added to it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,7 @@ pub struct FormatConfig {
     pub render_backstop: bool,
     /// Extra LaTeX environments treated as code (no reflow), added to
     /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
-    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
+    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// standard alltt, and spverbatim. Empty keeps the built-in list.

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -131,19 +131,21 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// `sageblock`) plus latex2e `verbatim*` / fancyvrb `Verbatim` /
 /// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
 /// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut`, moreverb
-/// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, standard
-/// `alltt` (alltt.sty: macros still apply, line breaks stay raw;
-/// GitHub #230), spverbatim.sty `spverbatim` (raw body; `\spverb` is
-/// the matching delimiter-body command, GitHub #235), and the
-/// `comment` package env (tree-sitter `comment_environment`: raw
-/// through matching `\end{comment}`). Overleaf `verbatimEnvNames` is
-/// Verbatim, boxedverbatim, tcblisting, codeexample. fancyvrb
-/// `BVerbatim` / `LVerbatim` are the same raw class as `Verbatim`
-/// (GitHub #209). `SaveVerbatim` / `VerbatimOut` are the same
-/// `FV@Scan` class (GitHub #213). fancyvrb `Verbatim*` / `BVerbatim*`
-/// / `LVerbatim*` are the starred twins (same `\FV@Scan`; GitHub
-/// #244). listings.sty `\lstnewenvironment{lstlisting}` also defines
-/// `lstlisting*` (same raw body scan; GitHub #234).
+/// `boxedverbatim`, tcolorbox `tcblisting` / `tcblisting*` /
+/// `codeexample`, standard `alltt` (alltt.sty: macros still apply,
+/// line breaks stay raw; GitHub #230), spverbatim.sty `spverbatim`
+/// (raw body; `\spverb` is the matching delimiter-body command,
+/// GitHub #235), and the `comment` package env (tree-sitter
+/// `comment_environment`: raw through matching `\end{comment}`).
+/// Overleaf `verbatimEnvNames` is Verbatim, boxedverbatim, tcblisting,
+/// codeexample. fancyvrb `BVerbatim` / `LVerbatim` are the same raw
+/// class as `Verbatim` (GitHub #209). `SaveVerbatim` / `VerbatimOut`
+/// are the same `FV@Scan` class (GitHub #213). fancyvrb `Verbatim*` /
+/// `BVerbatim*` / `LVerbatim*` are the starred twins (same `\FV@Scan`;
+/// GitHub #244). listings.sty `\lstnewenvironment{lstlisting}` also
+/// defines `lstlisting*` (same raw body scan; GitHub #234). tcolorbox
+/// listings library `tcblisting*` is the starred twin of `tcblisting`
+/// (same raw listing body; GitHub #246).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
@@ -163,6 +165,7 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "alltt"
             | "boxedverbatim"
             | "tcblisting"
+            | "tcblisting*"
             | "codeexample"
             | "spverbatim"
             | "filecontents"
@@ -2987,6 +2990,72 @@ Some text.
             );
             assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
         }
+    }
+
+    /// Ticket fixture (GitHub #246): tcolorbox listings `tcblisting*`
+    /// is the starred twin of `tcblisting`. The required `{listing
+    /// only}` arg stays on the begin header. Body stays Code;
+    /// following prose still splits.
+    #[test]
+    fn tcolorbox_tcblisting_star_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{tcblisting*}{listing only}\n",
+            "First line. Second line.\n",
+            "\\end{tcblisting*}\n",
+            "After the block. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        let code = regions.iter().find_map(|r| match r {
+            Region::Code {
+                header,
+                body,
+                footer,
+                ..
+            } => Some((header.as_str(), body.as_str(), footer.as_str())),
+            _ => None,
+        });
+        let Some((header, body, footer)) = code else {
+            panic!("tcblisting* must be Code, got: {regions:?}");
+        };
+        assert!(
+            header.contains(r"\begin{tcblisting*}{listing only}"),
+            "required listing options must stay on the begin header, got header={header:?}"
+        );
+        assert!(
+            body.contains("First line. Second line."),
+            "tcblisting* body must keep both sentences, got body={body:?}"
+        );
+        assert!(
+            footer.contains(r"\end{tcblisting*}"),
+            "tcblisting* footer must stay, got footer={footer:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "tcblisting* body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\begin{tcblisting*}{listing only}")
+                && out.contains(r"\end{tcblisting*}"),
+            "tcblisting* begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "tcblisting* body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "tcblisting* must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after tcblisting* must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
 
     #[test]

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -6,6 +6,7 @@
 //! GitHub #235: spverbatim.sty env and \\spverb are the same class as verb.
 //! GitHub #244: fancyvrb Verbatim* / BVerbatim* / LVerbatim* are the same FV@Scan class.
 //! GitHub #245: minted.sty \\mintinline / \\mint take {lang} then a FancyVerb body.
+//! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -80,6 +81,68 @@ fn boxedverbatim_tcblisting_codeexample_do_not_reflow() {
             "{name} must not reflow as prose, got:\n{out}"
         );
     }
+}
+
+/// Ticket fixture (GitHub #246): tcolorbox listings `tcblisting*`
+/// body stays Code; `{listing only}` stays on begin; following prose
+/// still splits.
+#[test]
+fn tcblisting_star_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{tcblisting*}{listing only}\n",
+        "First line. Second line.\n",
+        "\\end{tcblisting*}\n",
+        "After the block. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    let code = regions.iter().find_map(|r| match r {
+        Region::Code {
+            header,
+            body,
+            footer,
+            ..
+        } => Some((header.as_str(), body.as_str(), footer.as_str())),
+        _ => None,
+    });
+    let Some((header, body, footer)) = code else {
+        panic!("tcblisting* must be Code, got: {regions:?}");
+    };
+    assert!(
+        header.contains("\\begin{tcblisting*}{listing only}"),
+        "required listing options must stay on the begin header, got header={header:?}"
+    );
+    assert!(
+        body.contains("First line. Second line."),
+        "tcblisting* body must be Code, got body={body:?}"
+    );
+    assert!(
+        footer.contains("\\end{tcblisting*}"),
+        "tcblisting* footer must stay, got footer={footer:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "tcblisting* body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\begin{tcblisting*}{listing only}") && out.contains("\\end{tcblisting*}"),
+        "tcblisting* begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "tcblisting* body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "tcblisting* must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after tcblisting* must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 }
 
 /// Ticket fixture (GitHub #209): fancyvrb BVerbatim and LVerbatim


### PR DESCRIPTION
vissue: snapper-z6rb (parent snapper-etv7). GitHub #246.

unanimous-green-106 4/4 GREEN (impl-A, impl-B, rev-1, rev-2);
isolated onto origin/main 744ec98 as 9de8d4f.

tcolorbox listings `tcblisting*` is the starred twin of `tcblisting`.
Env body stays Code; following prose still splits. Keeps
Verbatim* / lstlisting* / spverbatim / alltt.

## Test plan
- terra: cargo test latex_verbatim_envs parser::latex -- tcblisting