### PR TITLE
fix(latex): treat fvextra VerbatimWrite as code

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut=, standard =alltt=, and spverbatim.sty =spverbatim=.
+Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, standard =alltt=, and spverbatim.sty =spverbatim=.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -99,7 +99,7 @@ These tokens within prose are not split across lines:
 :CUSTOM_ID: latex-code
 :END:
 - =\\begin{...}= / =\\end{...}= lines are structure
-- fancyvrb =Verbatim= / =Verbatim*= / =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =SaveVerbatim= / =VerbatimOut= are built-in code regions (same FV@Scan class)
+- fancyvrb =Verbatim= / =Verbatim*= / =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite= are built-in code regions (same FV@Scan class)
 - =alltt= (standard =alltt.sty=) is a built-in code region (raw line breaks)
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,7 +16,7 @@ pub struct FormatOverrides {
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
     /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut and
+    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// standard alltt, and spverbatim; entries are added to it.
     pub verbatim_envs: Vec<String>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub struct FormatConfig {
     /// Extra LaTeX environments treated as code (no reflow), added to
     /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/codeexample,
-    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut and
+    /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// standard alltt, and spverbatim. Empty keeps the built-in list.
     pub latex_verbatim_envs: Vec<String>,

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -130,7 +130,7 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
 /// `sageblock`) plus latex2e `verbatim*` / fancyvrb `Verbatim` /
 /// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
-/// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut`, moreverb
+/// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut` / `VerbatimWrite`, moreverb
 /// `boxedverbatim`, tcolorbox `tcblisting` / `codeexample`, standard
 /// `alltt` (alltt.sty: macros still apply, line breaks stay raw;
 /// GitHub #230), spverbatim.sty `spverbatim` (raw body; `\spverb` is
@@ -140,10 +140,12 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Verbatim, boxedverbatim, tcblisting, codeexample. fancyvrb
 /// `BVerbatim` / `LVerbatim` are the same raw class as `Verbatim`
 /// (GitHub #209). `SaveVerbatim` / `VerbatimOut` are the same
-/// `FV@Scan` class (GitHub #213). fancyvrb `Verbatim*` / `BVerbatim*`
-/// / `LVerbatim*` are the starred twins (same `\FV@Scan`; GitHub
-/// #244). listings.sty `\lstnewenvironment{lstlisting}` also defines
-/// `lstlisting*` (same raw body scan; GitHub #234).
+/// `FV@Scan` class (GitHub #213). fvextra `VerbatimWrite` is the same
+/// `FV@Scan` class as `VerbatimOut` (GitHub #247). fancyvrb
+/// `Verbatim*` / `BVerbatim*` / `LVerbatim*` are the starred twins
+/// (same `\FV@Scan`; GitHub #244). listings.sty
+/// `\lstnewenvironment{lstlisting}` also defines `lstlisting*` (same
+/// raw body scan; GitHub #234).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
@@ -160,6 +162,7 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "LVerbatim*"
             | "SaveVerbatim"
             | "VerbatimOut"
+            | "VerbatimWrite"
             | "alltt"
             | "boxedverbatim"
             | "tcblisting"
@@ -2698,6 +2701,70 @@ Some text.
             );
             assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
         }
+    }
+
+    /// Ticket fixture (GitHub #247): fvextra VerbatimWrite is the same
+    /// FV@Scan class as fancyvrb VerbatimOut. The required `{file}`
+    /// argument stays on the begin header.
+    #[test]
+    fn fancyvrb_verbatimwrite_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{VerbatimWrite}{out.tex}\n",
+            "First line. Second line.\n",
+            "\\end{VerbatimWrite}\n",
+            "After the block. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        let code = regions.iter().find_map(|r| match r {
+            Region::Code {
+                header,
+                body,
+                footer,
+                ..
+            } => Some((header.as_str(), body.as_str(), footer.as_str())),
+            _ => None,
+        });
+        let Some((header, body, footer)) = code else {
+            panic!("VerbatimWrite must be Code, got: {regions:?}");
+        };
+        assert!(
+            header.contains(r"\begin{VerbatimWrite}{out.tex}"),
+            "VerbatimWrite required arg must stay on the begin header, got header={header:?}"
+        );
+        assert!(
+            body.contains("First line. Second line."),
+            "VerbatimWrite body must keep both sentences, got body={body:?}"
+        );
+        assert!(
+            footer.contains(r"\end{VerbatimWrite}"),
+            "VerbatimWrite footer must be \\end{{VerbatimWrite}}, got footer={footer:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "VerbatimWrite body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\begin{VerbatimWrite}{out.tex}") && out.contains(r"\end{VerbatimWrite}"),
+            "VerbatimWrite begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "VerbatimWrite body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "VerbatimWrite must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after VerbatimWrite must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
 
     /// Ticket fixture (GitHub #230): alltt.sty is a standard

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -1,6 +1,7 @@
 //! snapper-3tj3 / GitHub #98: Overleaf verbatimEnvNames are Code, not prose.
 //! GitHub #209: fancyvrb BVerbatim / LVerbatim are the same.
 //! GitHub #213: fancyvrb SaveVerbatim / VerbatimOut are the same FV@Scan class.
+//! GitHub #247: fvextra VerbatimWrite is the same FV@Scan class as VerbatimOut.
 //! GitHub #230: alltt.sty is a standard verbatim-like env (raw line breaks).
 //! GitHub #234: listings.sty lstlisting* is the same raw scan as lstlisting.
 //! GitHub #235: spverbatim.sty env and \\spverb are the same class as verb.
@@ -264,6 +265,68 @@ fn saveverbatim_verbatimout_fixture_is_code_and_does_not_reflow() {
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
+}
+
+/// Ticket fixture (GitHub #247): fvextra VerbatimWrite bodies stay
+/// Code; the required `{out.tex}` arg stays on begin; following prose
+/// still splits.
+#[test]
+fn verbatimwrite_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{VerbatimWrite}{out.tex}\n",
+        "First line. Second line.\n",
+        "\\end{VerbatimWrite}\n",
+        "After the block. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    let code = regions.iter().find_map(|r| match r {
+        Region::Code {
+            header,
+            body,
+            footer,
+            ..
+        } => Some((header.as_str(), body.as_str(), footer.as_str())),
+        _ => None,
+    });
+    let Some((header, body, footer)) = code else {
+        panic!("VerbatimWrite must be Code, got: {regions:?}");
+    };
+    assert!(
+        header.contains(r"\begin{VerbatimWrite}{out.tex}"),
+        "VerbatimWrite required arg must stay on the begin header, got header={header:?}"
+    );
+    assert!(
+        body.contains("First line. Second line."),
+        "VerbatimWrite body must be Code, got body={body:?}"
+    );
+    assert!(
+        footer.contains(r"\end{VerbatimWrite}"),
+        "VerbatimWrite footer must stay, got footer={footer:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "VerbatimWrite body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains(r"\begin{VerbatimWrite}{out.tex}") && out.contains(r"\end{VerbatimWrite}"),
+        "VerbatimWrite begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "VerbatimWrite body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "VerbatimWrite must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after VerbatimWrite must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 }
 
 /// Ticket fixture (GitHub #230): alltt.sty bodies stay Code; following


### PR DESCRIPTION
vissue: snapper-aao4 (parent snapper-etv7). GitHub #247.

unanimous-green-107 4/4 GREEN (impl-A, impl-B, rev-1, rev-2);
isolated onto origin/main 744ec98 as 362bc0a.

fvextra `VerbatimWrite` is the same FV@Scan class as fancyvrb
`VerbatimOut`. Env body stays Code through the matching `\\end`.
The required `{file}` argument stays on the begin header.
Keeps Verbatim* / SaveVerbatim / VerbatimOut.

Independent of #254 (tcblisting*).

## Test plan
- terra: cargo test latex_verbatim_envs parser::latex -- VerbatimWrite