### PR TITLE
fix(latex): treat moreverb verbatimtab as code

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, standard =alltt=, and spverbatim.sty =spverbatim=.
+Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, and spverbatim.sty =spverbatim=.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -100,6 +100,7 @@ These tokens within prose are not split across lines:
 :END:
 - =\\begin{...}= / =\\end{...}= lines are structure
 - fancyvrb =Verbatim= / =Verbatim*= / =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite= are built-in code regions (same FV@Scan class)
+- moreverb =verbatimtab= is a built-in code region (tab-expanding verbatim; same raw class as =boxedverbatim=)
 - =alltt= (standard =alltt.sty=) is a built-in code region (raw line breaks)
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
 - tcolorbox listings =tcblisting*= is the starred twin of =tcblisting= (same raw listing body)

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,8 @@ pub struct FormatOverrides {
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
-    /// standard alltt, and spverbatim; entries are added to it.
+    /// moreverb boxedverbatim/verbatimtab, standard alltt, and
+    /// spverbatim; entries are added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,8 @@ pub struct FormatConfig {
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
-    /// standard alltt, and spverbatim. Empty keeps the built-in list.
+    /// moreverb boxedverbatim/verbatimtab, standard alltt, and
+    /// spverbatim. Empty keeps the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -131,9 +131,9 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// `sageblock`) plus latex2e `verbatim*` / fancyvrb `Verbatim` /
 /// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
 /// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut` / `VerbatimWrite`,
-/// moreverb `boxedverbatim`, tcolorbox `tcblisting` / `tcblisting*` /
-/// `codeexample`, standard `alltt` (alltt.sty: macros still apply,
-/// line breaks stay raw; GitHub #230), spverbatim.sty `spverbatim`
+/// moreverb `boxedverbatim` / `verbatimtab`, tcolorbox `tcblisting` /
+/// `tcblisting*` / `codeexample`, standard `alltt` (alltt.sty: macros
+/// still apply, line breaks stay raw; GitHub #230), spverbatim.sty `spverbatim`
 /// (raw body; `\spverb` is the matching delimiter-body command,
 /// GitHub #235), and the `comment` package env (tree-sitter
 /// `comment_environment`: raw through matching `\end{comment}`).
@@ -147,7 +147,8 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// `\lstnewenvironment{lstlisting}` also defines `lstlisting*` (same
 /// raw body scan; GitHub #234). tcolorbox listings library
 /// `tcblisting*` is the starred twin of `tcblisting` (same raw listing
-/// body; GitHub #246).
+/// body; GitHub #246). moreverb `verbatimtab` is the same tab-expanding
+/// raw class as `boxedverbatim` (GitHub #250).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
@@ -167,6 +168,7 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "VerbatimWrite"
             | "alltt"
             | "boxedverbatim"
+            | "verbatimtab"
             | "tcblisting"
             | "tcblisting*"
             | "codeexample"
@@ -3057,6 +3059,53 @@ Some text.
             );
             assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
         }
+    }
+
+    /// Ticket fixture (GitHub #250): moreverb `verbatimtab` is the same
+    /// raw class as `boxedverbatim`. Body stays Code; following prose
+    /// still splits.
+    #[test]
+    fn moreverb_verbatimtab_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{verbatimtab}\n",
+            "First line. Second line.\n",
+            "\\end{verbatimtab}\n",
+            "After the block. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "verbatimtab body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "verbatimtab body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\begin{verbatimtab}") && out.contains("\\end{verbatimtab}"),
+            "verbatimtab begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "verbatimtab body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "verbatimtab must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after verbatimtab must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
 
     /// Ticket fixture (GitHub #246): tcolorbox listings `tcblisting*`

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -8,6 +8,7 @@
 //! GitHub #244: fancyvrb Verbatim* / BVerbatim* / LVerbatim* are the same FV@Scan class.
 //! GitHub #245: minted.sty \\mintinline / \\mint take {lang} then a FancyVerb body.
 //! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
+//! GitHub #250: moreverb verbatimtab is the same raw class as boxedverbatim.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -82,6 +83,50 @@ fn boxedverbatim_tcblisting_codeexample_do_not_reflow() {
             "{name} must not reflow as prose, got:\n{out}"
         );
     }
+}
+
+/// Ticket fixture (GitHub #250): moreverb `verbatimtab` bodies stay
+/// Code; following prose still splits.
+#[test]
+fn verbatimtab_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{verbatimtab}\n",
+        "First line. Second line.\n",
+        "\\end{verbatimtab}\n",
+        "After the block. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Code { body, .. } if body.contains("First line. Second line.")
+        )),
+        "verbatimtab body must be Code, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "verbatimtab body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\begin{verbatimtab}") && out.contains("\\end{verbatimtab}"),
+        "verbatimtab begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "verbatimtab body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "verbatimtab must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after verbatimtab must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 }
 
 /// Ticket fixture (GitHub #246): tcolorbox listings `tcblisting*`


### PR DESCRIPTION
vissue: snapper-efoh (parent snapper-etv7). GitHub #250.

unanimous-green-109 4/4 GREEN (impl-A, impl-B, rev-1, rev-2);
isolated onto origin/main 690024f as ba40ae0.

moreverb `verbatimtab` is the same tab-expanding raw class as
`boxedverbatim`. Env body stays Code; following prose still splits.
Keeps boxedverbatim / alltt / VerbatimWrite.

## Test plan
- terra: cargo test latex_verbatim_envs -- verbatimtab