### PR TITLE
fix(latex): treat pythontex pyblock pyverbatim pyconsole as code

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, and spverbatim.sty =spverbatim=.
+Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pyblock= / =pyverbatim= / =pyconsole=.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -105,6 +105,7 @@ These tokens within prose are not split across lines:
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
 - tcolorbox listings =tcblisting*= is the starred twin of =tcblisting= (same raw listing body)
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
+- pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= are the same =VerbatimEnvironment= class as =pycode=
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= / =lstlisting*= =language== option)
 - Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,8 +18,9 @@ pub struct FormatOverrides {
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
-    /// moreverb boxedverbatim/verbatimtab, standard alltt, and
-    /// spverbatim; entries are added to it.
+    /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
+    /// and pythontex pycode/pyblock/pyverbatim/pyconsole; entries are
+    /// added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,8 +118,9 @@ pub struct FormatConfig {
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
-    /// moreverb boxedverbatim/verbatimtab, standard alltt, and
-    /// spverbatim. Empty keeps the built-in list.
+    /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
+    /// and pythontex pycode/pyblock/pyverbatim/pyconsole. Empty keeps
+    /// the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -128,7 +128,9 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// Beyond minted/lstlisting/verbatim: latexindent `fileContentsEnvironments`
 /// (`filecontents`, `filecontents*`) and tree-sitter-latex raw trivia envs
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
-/// `sageblock`) plus latex2e `verbatim*` / fancyvrb `Verbatim` /
+/// `sageblock`), pythontex.sty `pyblock` / `pyverbatim` / `pyconsole`
+/// (same `VerbatimEnvironment` class as `pycode`; GitHub #249),
+/// plus latex2e `verbatim*` / fancyvrb `Verbatim` /
 /// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
 /// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut` / `VerbatimWrite`,
 /// moreverb `boxedverbatim` / `verbatimtab`, tcolorbox `tcblisting` /
@@ -178,6 +180,9 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "asy"
             | "asydef"
             | "pycode"
+            | "pyblock"
+            | "pyverbatim"
+            | "pyconsole"
             | "luacode"
             | "luacode*"
             | "sagesilent"
@@ -2770,6 +2775,59 @@ Some text.
             "prose after VerbatimWrite must still split, got:\n{out}"
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #249): pythontex.sty `pyblock` /
+    /// `pyverbatim` / `pyconsole` are the same `VerbatimEnvironment`
+    /// class as `pycode`. Body stays Code; following prose still splits.
+    #[test]
+    fn pythontex_pyblock_pyverbatim_pyconsole_are_code_not_prose() {
+        use crate::format_text;
+
+        for name in ["pyblock", "pyverbatim", "pyconsole"] {
+            let input = format!(
+                concat!(
+                    "\\begin{{{name}}}\n",
+                    "First line. Second line.\n",
+                    "\\end{{{name}}}\n",
+                    "After the block. Next.\n",
+                ),
+                name = name
+            );
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Code { body, .. } if body.contains("First line. Second line.")
+                )),
+                "{name} body must be Code, got: {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+                "{name} body must not leak into Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&format!("\\begin{{{name}}}"))
+                    && out.contains(&format!("\\end{{{name}}}")),
+                "{name} begin/end must stay, got:\n{out}"
+            );
+            assert!(
+                out.contains("First line. Second line."),
+                "{name} body must stay one source line, got:\n{out}"
+            );
+            assert!(
+                !out.contains("First line.\nSecond line."),
+                "{name} must not reflow as prose, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the block.\nNext."),
+                "prose after {name} must still split, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+        }
     }
 
     /// Ticket fixture (GitHub #230): alltt.sty is a standard

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -9,6 +9,8 @@
 //! GitHub #245: minted.sty \\mintinline / \\mint take {lang} then a FancyVerb body.
 //! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
 //! GitHub #250: moreverb verbatimtab is the same raw class as boxedverbatim.
+//! GitHub #249: pythontex.sty pyblock / pyverbatim / pyconsole are the same
+//! VerbatimEnvironment class as pycode.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -605,6 +607,56 @@ fn spverbatim_and_spverb_fixture_is_code_and_does_not_reflow() {
         "prose after \\spverb must still split, got:\n{out}"
     );
     assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #249): pythontex.sty `pyblock` / `pyverbatim`
+/// / `pyconsole` bodies stay Code; following prose still splits.
+#[test]
+fn pythontex_pyblock_pyverbatim_pyconsole_fixture_is_code_and_does_not_reflow() {
+    for name in ["pyblock", "pyverbatim", "pyconsole"] {
+        let input = format!(
+            concat!(
+                "\\begin{{{name}}}\n",
+                "First line. Second line.\n",
+                "\\end{{{name}}}\n",
+                "After the block. Next.\n",
+            ),
+            name = name
+        );
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "{name} body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&format!("\\begin{{{name}}}"))
+                && out.contains(&format!("\\end{{{name}}}")),
+            "{name} begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "{name} body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after {name} must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
 }
 
 /// Ticket fixture (GitHub #245): `\mintinline{python}|a.b! c|` is one


### PR DESCRIPTION
vissue: snapper-h1g0 (parent snapper-etv7). GitHub #249.

unanimous-green-108 4/4 GREEN (impl-A, impl-B, rev-1, rev-2);
isolated onto origin/main c63d248 as 5685d10.

pythontex.sty `pyblock` / `pyverbatim` / `pyconsole` are the same
VerbatimEnvironment class as already-built-in `pycode`. Env body
stays Code; following prose still splits. Keeps pycode / verbatimtab.

## Test plan
- terra: cargo test latex_verbatim_envs -- pythontex