### PR TITLE
fix(org): keep timestamps atomic across interior punctuation

### DIFF
--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -34,6 +34,14 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             // [a-zA-Z][-a-zA-Z0-9_]*; args are non-greedy and may
             // span lines. Two-brace {{...}} is not a macro (GitHub #212).
             r"\{\{\{[a-zA-Z][-a-zA-Z0-9_]*(?:\((?:.|\n)*?\))?\}\}\}",
+            // org-element-timestamp-parser (org-ts-regexp / org-tsr-regexp).
+            // Diary <%%(...)> first (unique prefix). Ranges before singles
+            // so <ts>--<ts> stays one token. YYYY-MM-DD after [ or < so
+            // radio/macro/fn/cite/autolink are not stolen (GitHub #248).
+            r"<%%\([^>\n]+\)[^\n>]*>",
+            r"[<\[][0-9]{4}-[0-9]{2}-[0-9]{2} ?[^\]>\r\n]*?[>\]]--[<\[][0-9]{4}-[0-9]{2}-[0-9]{2} ?[^\]>\r\n]*?[>\]]",
+            r"<[0-9]{4}-[0-9]{2}-[0-9]{2} ?[^>\r\n]*?>",
+            r"\[[0-9]{4}-[0-9]{2}-[0-9]{2} ?[^\]\r\n]*?\]",
             r"\[[^\]]+\]\([^)]+\)",  // Markdown links: [text](url)
             r"!\[[^\]]*\]\([^)]+\)", // Markdown images: ![alt](url)
             // CommonMark 0.31.2 §6.3 full / collapsed reference links.
@@ -934,8 +942,10 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 /// Byte ranges of inline tokens that wrapping must not split (links, images,
 /// reference links `[text][ref]`, inline code, autolinks, math, Org `[[...]]`,
 /// Org `[cite...]`, Org `[fn::…]` / `[fn:LABEL:…]`, Org `<<<...>>>` /
-/// `<<...>>`, Org `{{{name}}}` / `{{{name(args)}}}`, Org `src_lang{...}` /
-/// `call_name(...)`, RST `|fig. 1|` / `|name|_` / `|name|__`, paired spans).
+/// `<<...>>`, Org `{{{name}}}` / `{{{name(args)}}}`, Org timestamps
+/// (`<YYYY-MM-DD…>`, `[YYYY-MM-DD…]`, ranges `--`, diary `<%%(...)>`),
+/// Org `src_lang{...}` / `call_name(...)`, RST `|fig. 1|` / `|name|_` /
+/// `|name|__`, paired spans).
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.
@@ -2124,6 +2134,129 @@ mod tests {
         assert!(
             !placeholders.iter().any(|p| p.contains("{{{cite")),
             "unclosed macro must not swallow the sentence, got {placeholders:?}"
+        );
+    }
+
+    #[test]
+    fn inline_org_timestamp_range_is_one_token() {
+        // GitHub #248 / snapper-c0fn: org-element-timestamp-parser.
+        // Active range stays one token. `Next sentence.` still splits.
+        let ts = "<2024-01-01 Mon 10:00>--<2024-01-02 Tue 12:00>";
+        let text =
+            "Meet at <2024-01-01 Mon 10:00>--<2024-01-02 Tue 12:00> then leave. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == ts),
+            "timestamp range must be one token, got {placeholders:?}"
+        );
+        assert!(
+            !placeholders
+                .iter()
+                .any(|p| p == "<2024-01-01 Mon 10:00>" || p == "<2024-01-02 Tue 12:00>"),
+            "range must not fall back to two singles, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == ts),
+            "timestamp range must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "Meet at <2024-01-01 Mon 10:00>--<2024-01-02 Tue 12:00> then leave.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_timestamp_repeater_interior_punct_is_not_a_sentence_boundary() {
+        // `.+1w` is org repeater-type catch-up; the period is not a boundary.
+        let ts = "<2024-01-01 Mon .+1w>";
+        let text = "Meet at <2024-01-01 Mon .+1w> then leave. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == ts),
+            "active timestamp with repeater must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "Meet at <2024-01-01 Mon .+1w> then leave.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_inactive_timestamp_is_one_token() {
+        let ts = "[2024-01-01 Mon 10:00]";
+        let text = "Logged [2024-01-01 Mon 10:00] then leave. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == ts),
+            "inactive timestamp must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "Logged [2024-01-01 Mon 10:00] then leave.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_diary_sexp_is_one_token() {
+        let ts = "<%%(equal (calendar-day-of-week date) 1.)>";
+        let text = "Meet at <%%(equal (calendar-day-of-week date) 1.)> then leave. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == ts),
+            "diary sexp timestamp must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "Meet at <%%(equal (calendar-day-of-week date) 1.)> then leave.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_inactive_timestamp_range_is_one_token() {
+        let ts = "[2024-01-01 Mon 10:00]--[2024-01-02 Tue 12:00]";
+        let text =
+            "Logged [2024-01-01 Mon 10:00]--[2024-01-02 Tue 12:00] then leave. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == ts),
+            "inactive timestamp range must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "Logged [2024-01-01 Mon 10:00]--[2024-01-02 Tue 12:00] then leave.".to_string(),
+                "Next sentence.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn angle_autolink_is_not_an_org_timestamp() {
+        let text = "See <https://example.com> today. Next sentence.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == "<https://example.com>"),
+            "autolink must stay an autolink, got {placeholders:?}"
+        );
+        assert!(
+            !placeholders
+                .iter()
+                .any(|p| p.starts_with("<20") || p.contains("%%")),
+            "autolink must not match as a timestamp, got {placeholders:?}"
         );
     }
 

--- a/tests/org_timestamps.rs
+++ b/tests/org_timestamps.rs
@@ -1,0 +1,190 @@
+//! GitHub #248 / snapper-c0fn: org-element timestamps stay one inline
+//! token. Active `<...>`, inactive `[...]`, ranges `--`, and diary
+//! `<%%(...)>` are atomic. Interior punctuation is not a sentence
+//! boundary. The use stays Prose. Radio / macro / fn / src_ / call_
+//! stay their own tokens.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "Meet at <2024-01-01 Mon 10:00>--<2024-01-02 Tue 12:00> then leave. Next sentence.\n"
+}
+
+#[test]
+fn ticket_timestamp_use_stays_prose() {
+    let ts = "<2024-01-01 Mon 10:00>--<2024-01-02 Tue 12:00>";
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(ts) && s.contains("Next sentence.")
+        )),
+        "timestamp must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_timestamp_span_and_splits_next() {
+    let input = ticket_fixture();
+    let ts = "<2024-01-01 Mon 10:00>--<2024-01-02 Tue 12:00>";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains(ts),
+        "timestamp range must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("<2024-01-01 Mon 10:00>\n")
+            && !out.contains("10:00>--\n")
+            && !out.contains("\n--<2024-01-02"),
+        "must not split inside the timestamp range, got:\n{out}"
+    );
+    assert!(
+        out.contains("then leave.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("then leave. Next sentence."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn inactive_timestamp_stays_one_span() {
+    let input = "Logged [2024-01-01 Mon 10:00] then leave. Next sentence.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("[2024-01-01 Mon 10:00]"),
+        "inactive timestamp must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("then leave.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn diary_sexp_stays_one_span() {
+    let input = "Meet at <%%(equal (calendar-day-of-week date) 1.)> then leave. Next sentence.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("<%%(equal (calendar-day-of-week date) 1.)>"),
+        "diary sexp must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("date) 1.\n") && !out.contains("1.\n)>"),
+        "must not split inside the diary sexp, got:\n{out}"
+    );
+    assert!(
+        out.contains("then leave.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn repeater_interior_punct_stays_one_span() {
+    let input = "Meet at <2024-01-01 Mon .+1w> then leave. Next sentence.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("<2024-01-01 Mon .+1w>"),
+        "repeater timestamp must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("Mon .\n") && !out.contains("Mon.\n+1w"),
+        "must not split on the repeater period, got:\n{out}"
+    );
+    assert!(
+        out.contains("then leave.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn radio_macro_fn_src_call_stay_their_tokens_beside_timestamps() {
+    let input = concat!(
+        "See <<<the Fourier. transform>>> at <2024-01-01 Mon .+1w> ",
+        "and {{{cite(Smith. 2020)}}} plus [fn:: see fig. 1] ",
+        "via src_python{print(1. 2)} or call_name(1. 2) today. Next sentence.\n"
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("<<<the Fourier. transform>>>"),
+        "radio must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("<2024-01-01 Mon .+1w>"),
+        "timestamp must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("{{{cite(Smith. 2020)}}}"),
+        "macro must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("[fn:: see fig. 1]"),
+        "inline fn must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("src_python{print(1. 2)}"),
+        "inline src must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("call_name(1. 2)"),
+        "inline call must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn wrap_does_not_cut_timestamp_range() {
+    let input = ticket_fixture();
+    let wrap_cfg = FormatConfig {
+        format: Format::Org,
+        max_width: 28,
+        ..Default::default()
+    }
+    .without_safety_backstops();
+    let wrapped = format_text(input, &wrap_cfg).unwrap();
+    assert!(
+        wrapped
+            .lines()
+            .any(|l| l.contains("<2024-01-01 Mon 10:00>--<2024-01-02 Tue 12:00>")),
+        "wrap must not cut inside the timestamp range, got:\n{wrapped}"
+    );
+    assert!(
+        !wrapped.contains("10:00>--\n") && !wrapped.contains("Mon 10:00>\n--"),
+        "must not wrap on the range dashes, got:\n{wrapped}"
+    );
+    assert!(
+        wrapped.contains("Next sentence."),
+        "sentence after the timestamp must still reflow, got:\n{wrapped}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-c0fn (parent snapper-etv7). GitHub #248.

unanimous-green-110 drawer 4/4 accept (impl-A, impl-B, rev-1, rev-2);
ledger open_count=0. Isolated onto origin/main 14d78b4 as 552e800.

org-element-timestamp-parser (`org-ts-regexp` / `org-tsr-regexp`):
diary `<%%(...)>`, ranges `--`, active `<YYYY-MM-DD…>`, inactive
`[YYYY-MM-DD…]` stay one token. Interior punctuation is not a sentence
boundary. `Next sentence.` still splits. Keeps radio / macro / fn /
src_ / call_.

## Test plan
- terra: rustfmt --check; cargo test --offline --no-default-features
  --lib timestamp (5/5) diary (1/1) inline_org (27/27)
  --test org_timestamps (7/7)
  --test org_radio_targets org_macros org_inline_src org_inline_footnotes (15/15)