### PR TITLE
fix(md): reject list setext underlines shallower than the item hang

### DIFF
--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -796,6 +796,31 @@ fn strip_quote_markers(line: &str, depth: usize) -> Option<&str> {
     Some(rest)
 }
 
+/// CommonMark 5.2 hang: marker width after quote markers (`- ` is 2,
+/// `1. ` is 3). A setext underline shallower than this hang is lazy
+/// paragraph text, not a closer (GitHub #261).
+fn list_opener_hang(line: &str) -> Option<usize> {
+    let depth = quote_marker_depth(line);
+    let body = strip_quote_markers(line, depth)?;
+    LIST_ITEM_RE
+        .captures(body)
+        .map(|c| c.get(1).unwrap().as_str().len())
+}
+
+/// List-item last title line plus underline at or past the item hang.
+/// Indent below hang is not a heading. Quote depth must match so a lazy
+/// unquoted underline after a quote stays CM 4.3 ex. 93.
+fn is_list_setext_pair(title: &str, underline: &str) -> bool {
+    let Some(hang) = list_opener_hang(title) else {
+        return false;
+    };
+    let depth = quote_marker_depth(title);
+    let Some(under_body) = strip_quote_markers(underline, depth) else {
+        return false;
+    };
+    is_setext_underline(under_body) && line_indent(under_body) >= hang
+}
+
 /// Closing fence: same marker char, length at least the opener, indent at
 /// most `max(3, opener_indent)`. CommonMark allows 0–3 spaces on a closer;
 /// list-nested openers keep their own indent so a matching 4-space closer
@@ -1398,15 +1423,19 @@ impl FormatParser for MarkdownParser {
             // Start from current_prose, not a title-line walk-back: HTML
             // comments and indented code are already emitted.
             if i + 1 < total
-                && is_setext_title_line(line_text)
-                && is_setext_underline(lines[i + 1].text)
+                && ((is_setext_title_line(line_text) && is_setext_underline(lines[i + 1].text))
+                    || is_list_setext_pair(line_text, lines[i + 1].text))
             {
                 // List/quote items reuse `in_list_item`; do not walk back
-                // into the marker line. A lazy `---` after `> Foo` is a
-                // break (CM ex. 93), not a heading of the quote.
-                // Empty `current_prose` means the last flush already closed
-                // the paragraph (HTML comment, indented code, …).
-                let start = if in_list_item || current_prose.is_empty() {
+                // into the marker line. A list opener as the last title
+                // line interrupts (CM 5.2): only that line is the heading.
+                // A lazy `---` after `> Foo` is a break (CM ex. 93), not a
+                // heading of the quote. Empty `current_prose` means the last
+                // flush already closed the paragraph (HTML comment, …).
+                let start = if in_list_item
+                    || current_prose.is_empty()
+                    || is_list_setext_pair(line_text, lines[i + 1].text)
+                {
                     i
                 } else {
                     setext_heading_start(&lines, i, prose_span)
@@ -2693,6 +2722,44 @@ mod tests {
                 "level {hashes}"
             );
         }
+    }
+
+    #[test]
+    fn list_opener_hang_is_marker_width() {
+        assert_eq!(list_opener_hang("1. Foo"), Some(3));
+        assert_eq!(list_opener_hang("- Foo"), Some(2));
+        assert_eq!(list_opener_hang("> - Foo"), Some(2));
+        assert_eq!(list_opener_hang("Foo"), None);
+    }
+
+    #[test]
+    fn list_setext_pair_rejects_underline_below_hang() {
+        assert!(
+            !is_list_setext_pair("1. Foo is a list item. Still item.", "  ======="),
+            "hang 3 plus two-space underline is below hang"
+        );
+        assert!(
+            is_list_setext_pair("1. Foo is a list item. Still item.", "   ======="),
+            "hang 3 plus three-space underline is at hang"
+        );
+        assert!(
+            is_list_setext_pair("- Foo is a list item. Still item.", "  ======="),
+            "hang 2 plus two-space underline is at hang"
+        );
+        assert!(
+            !is_list_setext_pair(
+                "> - Foo is the first title line. Still title.",
+                ">  ======="
+            ),
+            "quoted hang 2 plus one-space-in-quote is below hang"
+        );
+        assert!(
+            is_list_setext_pair(
+                "> - Foo is the first title line. Still title.",
+                ">   ======="
+            ),
+            "quoted hang 2 plus two-space-in-quote is at hang"
+        );
     }
 
     #[test]

--- a/tests/md_multiline_setext.rs
+++ b/tests/md_multiline_setext.rs
@@ -251,3 +251,129 @@ fn setext_after_indented_code_emits_code_once() {
         "body Prose must still split, got:\n{out}"
     );
 }
+
+/// snapper-32gc / GitHub #261: CommonMark 5.2. Setext underline must sit
+/// at the list hang. Hang of `1. ` is 3; two spaces is below hang.
+#[test]
+fn ordered_list_underline_below_hang_is_not_setext() {
+    let input = concat!(
+        "1. Foo is a list item. Still item.\n",
+        "  =======\n",
+        "\n",
+        "Body after list. Second body.\n",
+    );
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("list item") && p.contains("Still item")
+        )),
+        "two-space ======= must not promote 1. Foo, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("Foo is a list item")
+        )),
+        "1. Foo must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert!(
+        out.contains("list item.\n   Still item."),
+        "Foo must still split at hang 3, got:\n{out}"
+    );
+    assert!(
+        !out.contains("list item. Still item."),
+        "fused Foo must not survive, got:\n{out}"
+    );
+    assert!(
+        out.contains("Body after list.\nSecond body."),
+        "body after the list must still split, got:\n{out}"
+    );
+}
+
+/// snapper-32gc: hang of `- ` is 2, so two-space `=======` stays a heading.
+#[test]
+fn bullet_list_underline_at_hang_is_setext() {
+    let input = concat!(
+        "- Foo is a list item. Still item.\n",
+        "  =======\n",
+        "\n",
+        "Body after list. Second body.\n",
+    );
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("list item") || p.contains("Still item")
+        )),
+        "two-space ======= is at hang 2 and must stay a heading, got: {regions:?}"
+    );
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert!(
+        !out.contains("list item.\n"),
+        "must not sentence-split a hang-2 list setext, got:\n{out}"
+    );
+    assert!(
+        out.contains("Body after list.\nSecond body."),
+        "body after the heading must still split, got:\n{out}"
+    );
+}
+
+/// snapper-32gc: after quote markers, one space is below hang 2; two
+/// spaces sit at hang. Multi-line quoted list is the same hole.
+#[test]
+fn quoted_list_underline_below_hang_is_not_setext() {
+    let below = concat!(
+        "> - Foo is the first title line. Still title.\n",
+        ">  =======\n",
+        "\n",
+        "Body after setext. Second body.\n",
+    );
+    let regions = MarkdownParser.parse(below);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("Still title") || p.contains("Foo is the first")
+        )),
+        "quoted list plus >  ======= must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(below, &md_cfg()).unwrap();
+    assert!(
+        out.contains("first title line.\n"),
+        "Foo must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("Body after setext.\nSecond body."),
+        "body Prose must still split, got:\n{out}"
+    );
+
+    let multi = concat!(
+        "> - Foo is the first title line. Still title.\n",
+        ">   Bar is the second title line.\n",
+        ">  =======\n",
+        "\n",
+        "Body after setext. Second body.\n",
+    );
+    let multi_regions = MarkdownParser.parse(multi);
+    assert!(
+        multi_regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("Still title") || p.contains("Foo is the first")
+        )),
+        "multi-line quoted list plus >  ======= must stay Prose, got: {multi_regions:?}"
+    );
+
+    let at_hang = concat!(
+        "> - Foo is the first title line. Still title.\n",
+        ">   =======\n",
+    );
+    let at_hang_regions = MarkdownParser.parse(at_hang);
+    assert!(
+        !at_hang_regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("Still title") || p.contains("Foo is the first")
+        )),
+        "quoted list plus >   ======= must stay a heading, got: {at_hang_regions:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-32gc (parent snapper-4wxk). GitHub #261.

unanimous-green-112 drawer 4/4 accept (impl-A, impl-B, rev-1, rev-2);
ledger open_count=0. Isolated onto origin/main 5acafcd as 17970c3
(apply tree was stacked leftover setext; reimplemented hang check on
the origin/main parser).

CommonMark 5.2: list-item last title line plus underline indent below
the item hang is lazy paragraph text. At-hang underlines stay headings.
`1. Foo` / two-space `=======` stays Prose and still splits. `- Foo` /
two-space `=======` (hang 2) and `> - Foo` / `>   =======` stay headings.

## Test plan
- terra: cargo test --offline --no-default-features
  --test md_multiline_setext (9/9)
  --lib list_opener_hang list_setext_pair multiline_setext setext_ (19/19)