### PR TITLE
fix(md): count nested quote markers after 0-3 spaces

### DIFF
--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -770,28 +770,46 @@ fn is_gfm_alert_marker(text: &str) -> bool {
     )
 }
 
+/// After `>`, the optional following space may be a tab (CM 2.2 / 5.1).
+fn quote_after_gt(after: &str) -> &str {
+    after
+        .strip_prefix(' ')
+        .or_else(|| after.strip_prefix('\t'))
+        .unwrap_or(after)
+}
+
 /// Count CommonMark blockquote markers at the start of `line`.
-/// Each marker is `>` plus an optional space. Leading whitespace is skipped.
+/// Each marker is `>` plus an optional space or tab. A marker may be
+/// indented 0–3 spaces ([`html_block_rest`]); four spaces or a tab is
+/// not a first `>` opener. After one marker the remainder is a new
+/// block and may start another `>` indented 0–3 spaces, so `>  >` /
+/// `>   >` / `>\t>` are depth 2 (GitHub #259).
 fn quote_marker_depth(line: &str) -> usize {
-    let mut rest = line.trim_start();
+    let mut rest = line;
     let mut depth = 0;
-    while let Some(after) = rest.strip_prefix('>') {
+    loop {
+        rest = html_block_rest(rest);
+        let Some(after) = rest.strip_prefix('>') else {
+            break;
+        };
         depth += 1;
-        rest = after.strip_prefix(' ').unwrap_or(after);
+        rest = quote_after_gt(after);
     }
     depth
 }
 
-/// Strip exactly `depth` blockquote markers (`>` plus optional space).
-/// Leading whitespace is skipped once, matching [`quote_marker_depth`].
+/// Strip exactly `depth` blockquote markers (`>` plus optional space
+/// or tab). Indent before each marker matches [`quote_marker_depth`]:
+/// 0–3 spaces only.
 fn strip_quote_markers(line: &str, depth: usize) -> Option<&str> {
     if depth == 0 {
         return Some(line);
     }
-    let mut rest = line.trim_start();
+    let mut rest = line;
     for _ in 0..depth {
+        rest = html_block_rest(rest);
         rest = rest.strip_prefix('>')?;
-        rest = rest.strip_prefix(' ').unwrap_or(rest);
+        rest = quote_after_gt(rest);
     }
     Some(rest)
 }
@@ -819,6 +837,23 @@ fn is_list_setext_pair(title: &str, underline: &str) -> bool {
         return false;
     };
     is_setext_underline(under_body) && line_indent(under_body) >= hang
+}
+
+/// Quoted title plus matching-depth underline after stripping markers.
+/// `is_setext_title_line` rejects `QUOTE_RE`, so `>  > Bar` / `>  > ===`
+/// would otherwise never pair (GitHub #259).
+fn is_quoted_setext_pair(title: &str, underline: &str) -> bool {
+    let depth = quote_marker_depth(title);
+    if depth == 0 {
+        return false;
+    }
+    let Some(title_body) = strip_quote_markers(title, depth) else {
+        return false;
+    };
+    let Some(under_body) = strip_quote_markers(underline, depth) else {
+        return false;
+    };
+    is_setext_title_line(title_body) && is_setext_underline(under_body)
 }
 
 /// Closing fence: same marker char, length at least the opener, indent at
@@ -1424,17 +1459,24 @@ impl FormatParser for MarkdownParser {
             // comments and indented code are already emitted.
             if i + 1 < total
                 && ((is_setext_title_line(line_text) && is_setext_underline(lines[i + 1].text))
-                    || is_list_setext_pair(line_text, lines[i + 1].text))
+                    || is_list_setext_pair(line_text, lines[i + 1].text)
+                    || is_quoted_setext_pair(line_text, lines[i + 1].text))
             {
                 // List/quote items reuse `in_list_item`; do not walk back
                 // into the marker line. A list opener as the last title
                 // line interrupts (CM 5.2): only that line is the heading.
-                // A lazy `---` after `> Foo` is a break (CM ex. 93), not a
-                // heading of the quote. Empty `current_prose` means the last
-                // flush already closed the paragraph (HTML comment, …).
+                // A deeper nested quote (`>  >` after `>`) interrupts the
+                // outer quote paragraph (GitHub #259). A lazy `---` after
+                // `> Foo` is a break (CM ex. 93), not a heading of the quote.
+                // Empty `current_prose` means the last flush already closed
+                // the paragraph (HTML comment, …).
+                let nested_quote = is_quoted_setext_pair(line_text, lines[i + 1].text)
+                    && i > 0
+                    && quote_marker_depth(line_text) > quote_marker_depth(lines[i - 1].text);
                 let start = if in_list_item
                     || current_prose.is_empty()
                     || is_list_setext_pair(line_text, lines[i + 1].text)
+                    || nested_quote
                 {
                     i
                 } else {
@@ -2760,6 +2802,32 @@ mod tests {
             ),
             "quoted hang 2 plus two-space-in-quote is at hang"
         );
+    }
+
+    #[test]
+    fn quote_marker_depth_allows_up_to_three_spaces_between_markers() {
+        assert_eq!(quote_marker_depth(">> Bar"), 2);
+        assert_eq!(quote_marker_depth("> > Bar"), 2);
+        assert_eq!(quote_marker_depth(">  > Bar"), 2);
+        assert_eq!(quote_marker_depth(">   > Bar"), 2);
+        assert_eq!(quote_marker_depth(">    > Bar"), 2);
+        assert_eq!(quote_marker_depth(">     > Bar"), 1);
+        assert_eq!(quote_marker_depth(">\t> Bar"), 2);
+        assert_eq!(quote_marker_depth("    > ======="), 0);
+        assert_eq!(quote_marker_depth("\t> ======="), 0);
+        assert_eq!(quote_marker_depth("   > ======="), 1);
+        assert_eq!(strip_quote_markers(">  > =======", 2), Some("======="));
+        assert_eq!(strip_quote_markers(">   > =======", 2), Some("======="));
+        assert_eq!(strip_quote_markers(">\t> =======", 2), Some("======="));
+        assert_eq!(strip_quote_markers(">     > Bar", 1), Some("    > Bar"));
+        assert!(is_quoted_setext_pair(
+            ">  > Bar is the second title line.",
+            ">  > ======="
+        ));
+        assert!(!is_quoted_setext_pair(
+            "> Foo is the first title line. Still title.",
+            ">  > ======="
+        ));
     }
 
     #[test]

--- a/tests/md_multiline_setext.rs
+++ b/tests/md_multiline_setext.rs
@@ -377,3 +377,86 @@ fn quoted_list_underline_below_hang_is_not_setext() {
         "quoted list plus >   ======= must stay a heading, got: {at_hang_regions:?}"
     );
 }
+
+/// snapper-34pr / GitHub #259: `>  >` interrupts like `>>`. Foo stays
+/// Prose and still splits; Bar plus the underline are Structure. Same
+/// for three spaces and a tab. Five spaces after `>` is not a second
+/// marker.
+#[test]
+fn two_or_three_space_nested_quote_leaves_outer_quote_prose() {
+    for inner in [">  >", ">   >", ">\t>"] {
+        let input = format!(
+            concat!(
+                "> Foo is the first title line. Still title.\n",
+                "{inner} Bar is the second title line.\n",
+                "{inner} =======\n",
+                "\n",
+                "Body after setext. Second body.\n",
+            ),
+            inner = inner
+        );
+        let regions = MarkdownParser.parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("Still title") || p.contains("Foo is the first")
+            )),
+            "{inner:?} nested quote interrupts: Foo must stay Prose, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("Bar is the second")
+            )),
+            "{inner:?} inner setext title must not be Prose: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("Bar is the second title line.")
+            )),
+            "{inner:?} Bar plus underline must be Structure, got: {regions:?}"
+        );
+        let out = format_text(&input, &md_cfg()).unwrap();
+        assert!(
+            out.contains("first title line.\n"),
+            "{inner:?} Foo must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("Body after setext.\nSecond body."),
+            "{inner:?} body Prose must still split, got:\n{out}"
+        );
+    }
+
+    let five = concat!(
+        "> Foo is the first title line. Still title.\n",
+        ">     > Bar is the second title line.\n",
+        ">     > =======\n",
+        "\n",
+        "Body after setext. Second body.\n",
+    );
+    let five_regions = MarkdownParser.parse(five);
+    assert!(
+        five_regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("Still title") || p.contains("Foo is the first")
+        )),
+        "five spaces after > must stay quote Prose, got: {five_regions:?}"
+    );
+    assert!(
+        five_regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("Bar is the second")
+        )),
+        "five-space leftover > is not a nested opener, got: {five_regions:?}"
+    );
+    let five_out = format_text(five, &md_cfg()).unwrap();
+    assert!(
+        five_out.contains("first title line.\n"),
+        "five-space Foo must still split, got:\n{five_out}"
+    );
+    assert!(
+        five_out.contains("Body after setext.\nSecond body."),
+        "five-space body Prose must still split, got:\n{five_out}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-34pr (parent snapper-4wxk). GitHub #259.

unanimous-green-114 drawer 4/4 accept; isolated onto origin/main
3b19e2b (apply was stacked leftover setext).

CommonMark 5.1: after one `>` plus optional space/tab, the remainder
may start another marker indented 0-3 spaces. `>  >` / `>   >` / `>\t>`
interrupt the outer quote. Foo stays Prose and still splits; Bar plus
the underline are Structure. Five spaces after `>` is not a second
marker. Keeps #261 hang setext.

## Test plan
- terra: --test md_multiline_setext 10/10
  --lib quote_marker_depth list_setext_pair list_opener_hang multiline_setext