### PR TITLE
fix(md): reject list setext underlines shallower than the open item hang

### DIFF
--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -1494,7 +1494,41 @@ impl FormatParser for MarkdownParser {
                             lines[i + 1].text,
                             lines[i - 1].text,
                         )))
+                // Open list item: underline indent below hang is lazy
+                // paragraph text, not a closer (GitHub #260).
+                && !(in_list_item
+                    && list_hang.is_some_and(|hang| {
+                        is_setext_underline(lines[i + 1].text)
+                            && line_indent(lines[i + 1].text) < hang
+                    }))
             {
+                // Open list item plus at-hang underline: Foo is already
+                // marker Structure + prose. Promote that prose with the
+                // last title line (GitHub #260).
+                if in_list_item
+                    && list_hang.is_some_and(|hang| {
+                        is_setext_underline(lines[i + 1].text)
+                            && line_indent(lines[i + 1].text) >= hang
+                    })
+                {
+                    flush_prose_as_structure(
+                        &mut current_prose,
+                        &mut prose_span,
+                        input,
+                        &mut regions,
+                    );
+                    if let Some(span) = list_term.take() {
+                        if !span.is_empty() {
+                            regions.push(SpannedRegion::structure(input, span));
+                        }
+                    }
+                    in_list_item = false;
+                    list_hang = None;
+                    regions.push(SpannedRegion::structure(input, line.span()));
+                    regions.push(SpannedRegion::structure(input, lines[i + 1].span()));
+                    i += 2;
+                    continue;
+                }
                 // List/quote items reuse `in_list_item`; do not walk back
                 // into the marker line. A list opener as the last title
                 // line interrupts (CM 5.2): only that line is the heading.

--- a/tests/md_multiline_setext.rs
+++ b/tests/md_multiline_setext.rs
@@ -618,3 +618,78 @@ fn matching_two_space_nested_quote_setext_promotes_both_title_lines() {
         "one-line >  > setext must not leave Foo Prose, got: {one_regions:?}"
     );
 }
+
+/// snapper-grff / GitHub #260: underline indent 1..hang-1 is outside the
+/// list item. Setext cannot be a lazy continuation (CM 4.3). Hang of
+/// `- ` is 2, so ` =======` is not a closer. One-space `---` is a
+/// thematic break. Hung indent == hang stays a heading.
+#[test]
+fn list_underline_indent_below_hang_is_not_setext() {
+    let input = concat!(
+        "- Foo is the first title line. Still title.\n",
+        "  Bar is the second title line.\n",
+        " =======\n",
+        "\n",
+        "Body after setext. Second body.\n",
+    );
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("Still title") || p.contains("Foo is the first")
+        )),
+        "indent-1 ======= must not promote the list item, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("Foo is the first title line.")
+        )),
+        "Foo must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert!(
+        out.contains("first title line.\n"),
+        "Foo must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("Body after setext.\nSecond body."),
+        "body Prose must still split, got:\n{out}"
+    );
+
+    let dash = concat!(
+        "- Foo is the first title line. Still title.\n",
+        "  Bar is the second title line.\n",
+        " ---\n",
+        "\n",
+        "Body after setext. Second body.\n",
+    );
+    let dash_regions = MarkdownParser.parse(dash);
+    assert!(
+        dash_regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("Still title") || p.contains("Foo is the first")
+        )),
+        "Foo must stay Prose under space-dash, got: {dash_regions:?}"
+    );
+    assert!(
+        dash_regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.trim() == "---")),
+        "one-space --- after a list is a thematic break, got: {dash_regions:?}"
+    );
+
+    let hung = concat!(
+        "- Foo is the first title line. Still title.\n",
+        "  Bar is the second title line.\n",
+        "  =======\n",
+    );
+    let hung_regions = MarkdownParser.parse(hung);
+    assert!(
+        !hung_regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("Still title") || p.contains("Foo is the first")
+        )),
+        "hang-2 ======= must stay a heading, got: {hung_regions:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-grff (parent snapper-4wxk). GitHub #260.

unanimous-green-116 drawer 4/4 accept; isolated onto origin/main
3cbe6da after #268.

CommonMark 5.2: underline indent 1..hang-1 is outside the list item.
`- Foo` / hung `Bar` / ` =======` stays Prose and still splits.
One-space `---` is a thematic break. Hang-2 `  =======` stays a heading.

## Test plan
- terra: --test md_multiline_setext 12/12