### PR TITLE
fix(md): treat ordered start != 1 as setext title text

### DIFF
--- a/src/parser/markdown.rs
+++ b/src/parser/markdown.rs
@@ -814,9 +814,22 @@ fn strip_quote_markers(line: &str, depth: usize) -> Option<&str> {
 fn list_opener_hang(line: &str) -> Option<usize> {
     let depth = quote_marker_depth(line);
     let body = strip_quote_markers(line, depth)?;
-    LIST_ITEM_RE
-        .captures(body)
-        .map(|c| c.get(1).unwrap().as_str().len())
+    let caps = LIST_ITEM_RE.captures(body)?;
+    let marker = caps.get(1).unwrap().as_str();
+    let token = marker.trim();
+    if !token.starts_with(['-', '*', '+']) {
+        let digits = token.trim_end_matches(['.', ')']);
+        if digits.parse::<u32>().ok()? != 1 {
+            // Start != 1 cannot interrupt a paragraph (CM 5.2 ex. 301-302).
+            return None;
+        }
+    }
+    Some(marker.len())
+}
+
+/// Bullet, or ordered start 1, can interrupt an open paragraph.
+fn list_interrupts_paragraph(line: &str) -> bool {
+    list_opener_hang(line).is_some()
 }
 
 /// List-item last title line plus underline at or past the item hang.
@@ -1032,7 +1045,7 @@ fn is_setext_title_line(line: &str) -> bool {
     if TABLE_ROW_RE.is_match(line) {
         return false;
     }
-    if LIST_ITEM_RE.is_match(line) || quote_marker_depth(line) > 0 {
+    if list_interrupts_paragraph(line) || quote_marker_depth(line) > 0 {
         return false;
     }
     if is_thematic_break(line) {
@@ -1880,38 +1893,44 @@ impl FormatParser for MarkdownParser {
 
             // List item: emit marker as Structure, start accumulating text as prose.
             // Continuation lines are appended until a block boundary.
+            // Start != 1 does not interrupt an open paragraph (CM 5.2).
             if let Some(caps) = LIST_ITEM_RE.captures(line_text) {
-                close_list_item(
-                    &mut in_list_item,
-                    &mut list_hang,
-                    &mut current_prose,
-                    &mut prose_span,
-                    &mut list_term,
-                    input,
-                    &mut regions,
-                );
-                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-                let marker = caps.get(1).unwrap().as_str();
-                let marker_span = ByteSpan::new(line.start, line.start + marker.len());
-                regions.push(SpannedRegion::structure(input, marker_span));
-                in_list_item = true;
-                list_hang = Some(marker.len());
-                list_after_blank = false;
-                append_piece(
-                    &mut ProseAcc {
-                        text: &mut current_prose,
-                        span: &mut prose_span,
-                        term: &mut list_term,
-                    },
-                    line,
-                    marker.len(),
-                    false,
-                    false,
-                    input,
-                    &mut regions,
-                );
-                i += 1;
-                continue;
+                let open_para = !current_prose.is_empty() && !in_list_item;
+                if open_para && !list_interrupts_paragraph(line_text) {
+                    // Fall through: `2. Bar` stays title/prose text.
+                } else {
+                    close_list_item(
+                        &mut in_list_item,
+                        &mut list_hang,
+                        &mut current_prose,
+                        &mut prose_span,
+                        &mut list_term,
+                        input,
+                        &mut regions,
+                    );
+                    flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                    let marker = caps.get(1).unwrap().as_str();
+                    let marker_span = ByteSpan::new(line.start, line.start + marker.len());
+                    regions.push(SpannedRegion::structure(input, marker_span));
+                    in_list_item = true;
+                    list_hang = Some(marker.len());
+                    list_after_blank = false;
+                    append_piece(
+                        &mut ProseAcc {
+                            text: &mut current_prose,
+                            span: &mut prose_span,
+                            term: &mut list_term,
+                        },
+                        line,
+                        marker.len(),
+                        false,
+                        false,
+                        input,
+                        &mut regions,
+                    );
+                    i += 1;
+                    continue;
+                }
             }
 
             // pulldown ENABLE_DEFINITION_LIST: a `: ` marker on the next
@@ -2899,6 +2918,13 @@ mod tests {
         assert_eq!(list_opener_hang("- Foo"), Some(2));
         assert_eq!(list_opener_hang("> - Foo"), Some(2));
         assert_eq!(list_opener_hang("Foo"), None);
+        assert_eq!(list_opener_hang("2. Foo"), None);
+        assert_eq!(list_opener_hang("0. Foo"), None);
+        assert_eq!(list_opener_hang("10. Foo"), None);
+        assert_eq!(list_opener_hang("2) Foo"), None);
+        assert!(list_interrupts_paragraph("1. Foo"));
+        assert!(list_interrupts_paragraph("- Foo"));
+        assert!(!list_interrupts_paragraph("2. Foo"));
     }
 
     #[test]

--- a/tests/md_multiline_setext.rs
+++ b/tests/md_multiline_setext.rs
@@ -693,3 +693,100 @@ fn list_underline_indent_below_hang_is_not_setext() {
         "hang-2 ======= must stay a heading, got: {hung_regions:?}"
     );
 }
+
+/// snapper-ia7w / GitHub #258: only ordered start 1 interrupts a
+/// paragraph (CM 5.2). `2.` / `0.` / `10.` / `2)` stay title text.
+#[test]
+fn ordered_start_not_one_setext_is_structure() {
+    for marker in ["2.", "0.", "10.", "2)"] {
+        let input = format!(
+            concat!(
+                "Foo is the first title line. Still title.\n",
+                "{marker} Bar is the second title line.\n",
+                "=======\n",
+                "\n",
+                "Body after setext. Second body.\n",
+            ),
+            marker = marker
+        );
+        let regions = MarkdownParser.parse(&input);
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains("Still title")
+                        || p.contains("Foo is the first")
+                        || p.contains("Bar is the second")
+            )),
+            "{marker:?} start != 1 must stay setext title, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("Foo is the first title line.")
+            )),
+            "{marker:?} Foo must be Structure, got: {regions:?}"
+        );
+        let out = format_text(&input, &md_cfg()).unwrap();
+        assert!(
+            !out.contains("first title line.\n"),
+            "{marker:?} must not sentence-split the setext, got:\n{out}"
+        );
+        assert!(
+            out.contains("Body after setext.\nSecond body."),
+            "{marker:?} body Prose must still split, got:\n{out}"
+        );
+    }
+}
+
+/// Quoted start != 1 plus matching-depth underline.
+#[test]
+fn quoted_ordered_start_not_one_setext_is_structure() {
+    let input = concat!(
+        "> Foo is the first title line. Still title.\n",
+        "> 2. Bar is the second title line.\n",
+        "> =======\n",
+        "\n",
+        "Body after setext. Second body.\n",
+    );
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p)
+                if p.contains("Still title")
+                    || p.contains("Foo is the first")
+                    || p.contains("Bar is the second")
+        )),
+        "quoted 2. must stay quote setext, got: {regions:?}"
+    );
+    let out = format_text(input, &md_cfg()).unwrap();
+    assert!(
+        !out.contains("first title line.\n"),
+        "quoted 2. must not sentence-split the setext, got:\n{out}"
+    );
+    assert!(
+        out.contains("Body after setext.\nSecond body."),
+        "quoted body Prose must still split, got:\n{out}"
+    );
+}
+
+/// `1.` after an open paragraph still interrupts.
+#[test]
+fn ordered_start_one_still_interrupts() {
+    let input = concat!(
+        "Foo is the first title line. Still title.\n",
+        "1. Bar is the second title line.\n",
+        "=======\n",
+        "\n",
+        "Body after setext. Second body.\n",
+    );
+    let regions = MarkdownParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("Still title") || p.contains("Foo is the first")
+        )),
+        "1. must interrupt so Foo stays Prose, got: {regions:?}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-ia7w (parent snapper-4wxk). GitHub #258.

unanimous-green-111 drawer 4/4 accept after 3 rounds; isolated onto
origin/main 9776487 (apply was stacked leftover setext).

CommonMark 5.2 ex. 301-302: start != 1 does not interrupt a paragraph.
`Foo` / `2. Bar` / `=======` is one heading. `1.` and bullets still
interrupt. Quoted `> 2. Bar` / `> =======` is the same. Keeps #261 hang.

## Test plan
- terra: --test md_multiline_setext 16/16
  --lib list_opener_hang