### PR TITLE
fix(sentence): peel shortest closer before quote-capital

### DIFF
--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -1328,12 +1328,29 @@ fn merge_quoted_punct_splits(segments: Vec<String>) -> Vec<String> {
 /// quotes (including dialogue single quotes with apostrophe heuristics),
 /// LaTeX ```` / `''` style quotes, and balanced `()` / `[]` / `{}`.
 /// Escaped `\"` / `\'` do not toggle quote state.
+///
+/// UAX SB11 breaks after ATerm+Sp *before* a closer, so `(. aA. )A` is
+/// `(. aA. ` + `)A`. Glue only the closer; a following capital is a new
+/// sentence (GitHub #266). The tight form `(. aA.)A` already splits.
 fn merge_splits_inside_delimiters(segments: Vec<String>) -> Vec<String> {
     let mut result: Vec<String> = Vec::with_capacity(segments.len());
     let mut state = DelimState::default();
 
     for segment in segments {
         if state.is_inside() {
+            if let Some((closers, rest)) = split_closers_then_new_sentence(&state, &segment) {
+                if let Some(last) = result.last_mut() {
+                    push_segment_preserving_space(last, closers);
+                } else {
+                    result.push(closers.to_string());
+                }
+                state.feed(closers);
+                if !rest.is_empty() {
+                    result.push(rest.to_string());
+                    state.feed(rest);
+                }
+                continue;
+            }
             if let Some(last) = result.last_mut() {
                 push_segment_preserving_space(last, &segment);
             } else {
@@ -1346,6 +1363,51 @@ fn merge_splits_inside_delimiters(segments: Vec<String>) -> Vec<String> {
     }
 
     result
+}
+
+/// Leading span closers that finish the open delimiter, then a new sentence.
+///
+/// Walk shortest closer prefix that leaves `state` outside. A greedy take
+/// of every `is_span_closer` char would feed `)"` and toggle the ASCII
+/// quote back open, so `(. aA. )"A` never peels (GitHub #266 leftover).
+fn split_closers_then_new_sentence<'a>(
+    state: &DelimState,
+    segment: &'a str,
+) -> Option<(&'a str, &'a str)> {
+    for (i, ch) in segment.char_indices() {
+        if !is_span_closer(ch) {
+            break;
+        }
+        let end = i + ch.len_utf8();
+        let mut probe = state.clone();
+        probe.feed(&segment[..end]);
+        if probe.is_inside() {
+            continue;
+        }
+        let rest = segment[end..].trim_start();
+        if starts_sentence_after_closers(rest) {
+            return Some((&segment[..end], rest));
+        }
+    }
+    None
+}
+
+fn is_span_closer(ch: char) -> bool {
+    matches!(
+        ch,
+        ')' | ']' | '}' | '"' | '\'' | '\u{201D}' | '\u{2019}' | '\u{00BB}'
+    )
+}
+
+fn starts_sentence_after_closers(rest: &str) -> bool {
+    let mut chars = rest.chars();
+    match chars.next() {
+        Some(c) if c.is_uppercase() => true,
+        Some('"' | '\'' | '\u{201C}' | '\u{2018}' | '\u{00AB}') => {
+            chars.next().is_some_and(|c| c.is_uppercase())
+        }
+        _ => false,
+    }
 }
 
 /// Tracks delimiter nesting for span-aware sentence merging and invariants.
@@ -3076,6 +3138,35 @@ mod tests {
         assert_eq!(
             split("See (Fig. 3 is wrong. Really.) Next."),
             vec!["See (Fig. 3 is wrong. Really.)", "Next."]
+        );
+    }
+
+    #[test]
+    fn paren_space_before_closer_then_capital_splits_like_tight_closer() {
+        // GitHub #266: UAX breaks `(. aA. )A` after the space. Glue only
+        // `)`, not `)A`. The tight form already splits after `)`.
+        assert_eq!(
+            split("(. aA. )A"),
+            vec!["(. aA.)".to_string(), "A".to_string()]
+        );
+        assert_eq!(
+            split("(. aA.)A"),
+            vec!["(. aA.)".to_string(), "A".to_string()]
+        );
+    }
+
+    #[test]
+    fn paren_space_before_closer_quote_then_capital_splits() {
+        // snapper-rgxt: UAX of `(. aA. )"A` is `(. aA. ` + `)"A`. Glue
+        // only `)`; quote+capital is the next sentence. Greedy `)"` would
+        // toggle DelimState back inside.
+        assert_eq!(
+            split(r#"(. aA. )"A"#),
+            vec![r#"(. aA.)"#.to_string(), r#""A"#.to_string()]
+        );
+        assert_eq!(
+            split(r#"(. aA. )'A"#),
+            vec![r#"(. aA.)"#.to_string(), r#"'A"#.to_string()]
         );
     }
 

--- a/tests/sentence_delim_props.rs
+++ b/tests/sentence_delim_props.rs
@@ -33,6 +33,36 @@ fn plaintext_period_before_backticks_quote_is_span_safe() {
     );
 }
 
+/// GitHub #266. `(. aA. )A` is not idempotent on origin/main: first
+/// pass collapses the space (`(. aA.)A\n`), second pass splits
+/// (`(. aA.)\nA\n`). format_text twice must be identity.
+#[test]
+fn plaintext_paren_space_before_closer_then_capital_is_idempotent() {
+    let input = "(. aA. )A";
+    let out = format_plain(input);
+    let again = format_plain(&out);
+    assert_eq!(out, "(. aA.)\nA\n");
+    assert_eq!(
+        again, out,
+        "idempotence\n in={input:?}\n out={out:?}\n again={again:?}"
+    );
+}
+
+/// snapper-rgxt / GitHub #266 leftover. `(. aA. )"A` is not
+/// idempotent on 32934c2: first pass `(. aA.)"A\n`, second
+/// `(. aA.)" A\n`. format_text twice must be identity.
+#[test]
+fn plaintext_paren_quote_after_closer_then_capital_is_idempotent() {
+    let input = r#"(. aA. )"A"#;
+    let out = format_plain(input);
+    let again = format_plain(&out);
+    assert_eq!(out, "(. aA.)\n\"A\n");
+    assert_eq!(
+        again, out,
+        "idempotence\n in={input:?}\n out={out:?}\n again={again:?}"
+    );
+}
+
 /// GitHub #96 / macos proptest seed: `!` inside `` `=!a` `` is not a
 /// sentence end. The iCloud keep-break must not split that span.
 #[test]


### PR DESCRIPTION
vissue: snapper-nxsd (parent snapper-32gc). GitHub #266.

unanimous-green-117 drawer 4/4 accept after 2 rounds; isolated onto
origin/main 30d3d1d.

Format::Plaintext of \`(. aA. )A\` is idempotent: first and second pass
\`(. aA.)\\nA\\n\`. Leftover \`(. aA. )\"A\` peels only \`)\`.
proptest_balanced_wrappers unchanged.

## Test plan
- terra: rustfmt --check; --test sentence_delim_props 10/10
  --lib paren_space 2/2