### PR TITLE
fix(latex): treat pythontex pygments env as verbatim

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pyblock= / =pyverbatim= / =pyconsole=.
+Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pyblock= / =pyverbatim= / =pyconsole= / =pygments=.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -105,7 +105,7 @@ These tokens within prose are not split across lines:
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
 - tcolorbox listings =tcblisting*= is the starred twin of =tcblisting= (same raw listing body)
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
-- pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= are the same =VerbatimEnvironment= class as =pycode=
+- pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pygments= are the same =VerbatimEnvironment= class as =pycode=
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= / =lstlisting*= =language== option)
 - Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,7 @@ pub struct FormatOverrides {
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
-    /// and pythontex pycode/pyblock/pyverbatim/pyconsole; entries are
+    /// and pythontex pycode/pyblock/pyverbatim/pyconsole/pygments; entries are
     /// added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@ pub struct FormatConfig {
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
-    /// and pythontex pycode/pyblock/pyverbatim/pyconsole. Empty keeps
+    /// and pythontex pycode/pyblock/pyverbatim/pyconsole/pygments. Empty keeps
     /// the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -129,7 +129,8 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// (`filecontents`, `filecontents*`) and tree-sitter-latex raw trivia envs
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
 /// `sageblock`), pythontex.sty `pyblock` / `pyverbatim` / `pyconsole`
-/// (same `VerbatimEnvironment` class as `pycode`; GitHub #249),
+/// / `pygments` (same `VerbatimEnvironment` class as `pycode`;
+/// GitHub #249 / #274),
 /// plus latex2e `verbatim*` / fancyvrb `Verbatim` /
 /// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
 /// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut` / `VerbatimWrite`,
@@ -183,6 +184,7 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "pyblock"
             | "pyverbatim"
             | "pyconsole"
+            | "pygments"
             | "luacode"
             | "luacode*"
             | "sagesilent"
@@ -2828,6 +2830,72 @@ Some text.
             );
             assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
         }
+    }
+
+    /// Ticket fixture (GitHub #274): pythontex.sty `pygments` is the
+    /// same `VerbatimEnvironment` class as `pycode`. Required `{lang}`
+    /// stays on the begin header; body stays Code; following prose
+    /// still splits.
+    #[test]
+    fn pythontex_pygments_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{pygments}{python}\n",
+            "First line. Second line.\n",
+            "\\end{pygments}\n",
+            "After the block. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        let code = regions.iter().find_map(|r| match r {
+            Region::Code {
+                header,
+                body,
+                footer,
+                ..
+            } => Some((header.as_str(), body.as_str(), footer.as_str())),
+            _ => None,
+        });
+        let Some((header, body, footer)) = code else {
+            panic!("pygments must be Code, got: {regions:?}");
+        };
+        assert!(
+            header.contains(r"\begin{pygments}{python}"),
+            "required lexer arg must stay on the begin header, got header={header:?}"
+        );
+        assert!(
+            body.contains("First line. Second line."),
+            "pygments body must keep both sentences, got body={body:?}"
+        );
+        assert!(
+            footer.contains(r"\end{pygments}"),
+            "pygments footer must stay, got footer={footer:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("First line") || p.contains("{python}")
+            )),
+            "pygments lexer/body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\begin{pygments}{python}") && out.contains(r"\end{pygments}"),
+            "pygments begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "pygments body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "pygments must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after pygments must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
 
     /// Ticket fixture (GitHub #230): alltt.sty is a standard

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -11,6 +11,7 @@
 //! GitHub #250: moreverb verbatimtab is the same raw class as boxedverbatim.
 //! GitHub #249: pythontex.sty pyblock / pyverbatim / pyconsole are the same
 //! VerbatimEnvironment class as pycode.
+//! GitHub #274: pythontex.sty pygments is the same VerbatimEnvironment class.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -657,6 +658,69 @@ fn pythontex_pyblock_pyverbatim_pyconsole_fixture_is_code_and_does_not_reflow() 
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
+}
+
+/// Ticket fixture (GitHub #274): pythontex.sty `pygments` required
+/// `{lang}` stays on the begin header; body stays Code; following
+/// prose still splits.
+#[test]
+fn pythontex_pygments_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{pygments}{python}\n",
+        "First line. Second line.\n",
+        "\\end{pygments}\n",
+        "After the block. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    let code = regions.iter().find_map(|r| match r {
+        Region::Code {
+            header,
+            body,
+            footer,
+            ..
+        } => Some((header.as_str(), body.as_str(), footer.as_str())),
+        _ => None,
+    });
+    let Some((header, body, footer)) = code else {
+        panic!("pygments must be Code, got: {regions:?}");
+    };
+    assert!(
+        header.contains(r"\begin{pygments}{python}"),
+        "required lexer arg must stay on the begin header, got header={header:?}"
+    );
+    assert!(
+        body.contains("First line. Second line."),
+        "pygments body must keep both sentences, got body={body:?}"
+    );
+    assert!(
+        footer.contains(r"\end{pygments}"),
+        "pygments footer must stay, got footer={footer:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("First line") || p.contains("{python}")
+        )),
+        "pygments lexer/body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains(r"\begin{pygments}{python}") && out.contains(r"\end{pygments}"),
+        "pygments begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "pygments body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "pygments must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after pygments must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 }
 
 /// Ticket fixture (GitHub #245): `\mintinline{python}|a.b! c|` is one


### PR DESCRIPTION
vissue: snapper-b5w0 (parent snapper-etv7). GitHub #274.

unanimous-green-119 drawer 4/4 accept; isolated onto origin/main 151623f.

pythontex.sty `pygments` is the same `VerbatimEnvironment` class as
`pycode`. Required `{lang}` stays on the begin header; body stays Code.
Following `After the block.` / `Next.` still splits.
`pycode` / `pyblock` / `pyverbatim` / `pyconsole` unchanged.

## Test plan
- terra: rustfmt --check; `pythontex_pygments_is_code_not_prose`
  and `pythontex_pygments_fixture_is_code_and_does_not_reflow`
  plus `pythontex_pyblock_pyverbatim_pyconsole_are_code_not_prose`