### PR TITLE
fix(latex): tokenize fancyvrb SaveVerb like Verb

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -186,8 +186,9 @@ Adding =algorithm= stops reflow of that environment.
 
 String array of extra command names tokenized like the built-in verb command before sentence split.
 The next character after the name is the delimiter.
-Built-in names are =verb=, =lstinline=, =spverb=, =mintinline=, =mint=, and fancyvrb =Verb= / =Verb*=; =lstinline= still accepts optional =[...]= and ={...}=.
+Built-in names are =verb=, =lstinline=, =spverb=, =mintinline=, =mint=, and fancyvrb =Verb= / =Verb*= / =SaveVerb=; =lstinline= still accepts optional =[...]= and ={...}=.
 =mintinline= / =mint= take optional =[...]=, a ={lang}= argument, then a delimiter or ={...}= body.
+=SaveVerb= takes optional =[...]=, a ={name}= argument, then the same delimiter body as =Verb=.
 Adding another name keeps that command's delimited body atomic and treats an inner =%= as content, not a comment.
 
 * Code-block sections (=[code.<lang>]=)

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -108,7 +108,7 @@ These tokens within prose are not split across lines:
 - pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pygments= are the same =VerbatimEnvironment= class as =pycode=
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= / =lstlisting*= =language== option)
-- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment
+- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment
 
 *** Prose regions (reflowed)
 :PROPERTIES:

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,7 +28,7 @@ pub struct FormatOverrides {
     pub structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
     /// Meaningful under `[latex]` only. Missing or empty keeps
-    /// verb/lstinline/spverb/mintinline/mint/Verb.
+    /// verb/lstinline/spverb/mintinline/mint/Verb/SaveVerb.
     pub verbatim_commands: Vec<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub struct FormatConfig {
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.
     pub latex_structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
-    /// Empty keeps verb/lstinline/spverb/mintinline/mint/Verb.
+    /// Empty keeps verb/lstinline/spverb/mintinline/mint/Verb/SaveVerb.
     pub latex_verbatim_commands: Vec<String>,
 }
 

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -293,7 +293,7 @@ impl LatexParser {
 
     /// Byte offset of the first `%` that is not escaped as `\%` and is not
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
-    /// `\Verb` / configured verbatim commands.
+    /// `\Verb` / `\SaveVerb` / configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -665,7 +665,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 }
 
 /// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` /
-/// `\spverb` / `\mintinline` / `\mint` / `\Verb` spans.
+/// `\spverb` / `\mintinline` / `\mint` / `\Verb` / `\SaveVerb` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -2127,6 +2127,55 @@ Some text.
                 |r| matches!(r, Region::Structure(s) if s.contains("%b|") || s.trim() == "%b|\n")
             ),
             "inner % of mintinline must not be a comment, got: {regions:?}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #275): fancyvrb `\SaveVerb{name}|body|` is
+    /// one token; following `After.` still splits.
+    #[test]
+    fn fancyvrb_saveverb_name_delim_round_trips() {
+        use crate::format_text;
+
+        let input =
+            "\\begin{document}\nUse \\SaveVerb{foo}|done. Next| here. After.\n\\end{document}\n";
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\SaveVerb{foo}|done. Next|"),
+            "SaveVerb name+delim must stay intact, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\SaveVerb{foo}|done.\n")
+                && !out.contains("\\SaveVerb{foo}|done. Next|\n"),
+            "inner . must not split SaveVerb, got:\n{out}"
+        );
+        assert!(
+            out.contains("Use \\SaveVerb{foo}|done. Next| here.\nAfter."),
+            "prose after SaveVerb must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn fancyvrb_saveverb_inner_percent_is_not_a_comment() {
+        use crate::format_text;
+
+        let input = "\\begin{document}\nCode \\SaveVerb{foo}|a%b| here. After.\n\\end{document}\n";
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\SaveVerb{foo}|a%b|"),
+            "SaveVerb with inner % must stay intact, got:\n{out}"
+        );
+        assert!(
+            out.contains("here."),
+            "text after SaveVerb must not be commented out, got:\n{out}"
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            !regions.iter().any(
+                |r| matches!(r, Region::Structure(s) if s.contains("%b|") || s.trim() == "%b|\n")
+            ),
+            "inner % of SaveVerb must not be a comment, got: {regions:?}"
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -183,8 +183,8 @@ pub fn protect_inline_tokens_with(
 }
 
 /// `\verb|...|` / `\lstinline[...]!...!` / `\spverb|...|` /
-/// `\mintinline{lang}|...|` / `\mint{lang}{...}` / `\Verb|...|` so
-/// inner `.!?%` cannot split or comment.
+/// `\mintinline{lang}|...|` / `\mint{lang}{...}` / `\Verb|...|` /
+/// `\SaveVerb{name}|...|` so inner `.!?%` cannot split or comment.
 fn protect_latex_verbatim(
     text: &str,
     placeholders: &mut Vec<String>,
@@ -209,7 +209,7 @@ fn protect_latex_verbatim(
 }
 
 /// Byte end of a `\verb` / `\lstinline` / `\spverb` / `\mintinline` /
-/// `\mint` / `\Verb` / extra-name span starting at `at`.
+/// `\mint` / `\Verb` / `\SaveVerb` / extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
 /// character is the
@@ -217,9 +217,11 @@ fn protect_latex_verbatim(
 /// `\lstinline*` may take optional `[...]` before a delimiter or a
 /// `{...}` brace body. `\mintinline` / `\mint` (and stars) take optional
 /// `[...]`, a required `{lang}`, then a delimiter or `{...}` body
-/// (minted.sty / FVExtraReadVArg; GitHub #245). Extra names are
-/// tokenized like `\verb`. With no closer, the span runs to end of line
-/// so an inner `%` is not a comment.
+/// (minted.sty / FVExtraReadVArg; GitHub #245). `\SaveVerb` / `\SaveVerb*`
+/// take optional `[...]`, a required `{name}`, then the same delimiter
+/// body as `\Verb` (fancyvrb FVExtraReadVArg; GitHub #275). Extra names
+/// are tokenized like `\verb`. With no closer, the span runs to end of
+/// line so an inner `%` is not a comment.
 pub(crate) fn latex_verb_span_end_with(
     text: &str,
     at: usize,
@@ -257,6 +259,11 @@ pub(crate) fn latex_verb_span_end_with(
             return None;
         }
         (after_bs + "Verb".len(), VerbKind::Delim)
+    } else if let Some(stripped) = tail.strip_prefix("SaveVerb") {
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (after_bs + "SaveVerb".len(), VerbKind::SaveVerb)
     } else if let Some(stripped) = tail.strip_prefix("verb") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -271,7 +278,10 @@ pub(crate) fn latex_verb_span_end_with(
         i += 1;
     }
 
-    if matches!(kind, VerbKind::Lstinline | VerbKind::Mint) {
+    if matches!(
+        kind,
+        VerbKind::Lstinline | VerbKind::Mint | VerbKind::SaveVerb
+    ) {
         i = skip_ascii_ws(text, i);
         if text.get(i..).is_some_and(|s| s.starts_with('[')) {
             match skip_bracket_group(text, i) {
@@ -288,6 +298,18 @@ pub(crate) fn latex_verb_span_end_with(
         i += 1;
         match find_unescaped_brace_close(text, i) {
             Some(end) => i = skip_ascii_ws(text, end),
+            None => return Some(line_end(text, i)),
+        }
+    }
+
+    // After `{name}`, the next character is the delimiter (Verb / FV@Scan).
+    if kind == VerbKind::SaveVerb {
+        if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
+            return None;
+        }
+        i += 1;
+        match find_unescaped_brace_close(text, i) {
+            Some(end) => i = end,
             None => return Some(line_end(text, i)),
         }
     }
@@ -325,6 +347,8 @@ enum VerbKind {
     Lstinline,
     /// `\mintinline` / `\mint`: optional `[...]`, `{lang}`, then body.
     Mint,
+    /// `\SaveVerb`: optional `[...]`, `{name}`, then delimiter body like `\Verb`.
+    SaveVerb,
 }
 
 fn line_end(text: &str, from: usize) -> usize {
@@ -346,6 +370,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "mintinline"
             || name == "mint"
             || name == "Verb"
+            || name == "SaveVerb"
         {
             continue;
         }
@@ -1984,6 +2009,76 @@ mod tests {
             vec![
                 r"See \mintinline[escapeinside=||]{python}|a.b%| please.".to_string(),
                 "Next.".to_string()
+            ]
+        );
+    }
+
+    /// Ticket fixture (GitHub #275): fancyvrb `\SaveVerb{name}|body|`
+    /// is one token; following `After.` still splits.
+    #[test]
+    fn latex_fancyvrb_saveverb_name_delim_stays_atomic() {
+        let text = r"Use \SaveVerb{foo}|done. Next| here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders
+                .iter()
+                .any(|p| p == r"\SaveVerb{foo}|done. Next|"),
+            "SaveVerb name+delim span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\SaveVerb{foo}|done. Next|", 0, &[]),
+            Some(r"\SaveVerb{foo}|done. Next|".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"Use \SaveVerb{foo}|done. Next| here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn latex_saveverb_does_not_steal_saveverbatim() {
+        assert_eq!(
+            latex_verb_span_end_with(r"\SaveVerbatim|x.y|", 0, &[]),
+            None,
+            "SaveVerb must not match as a prefix of SaveVerbatim"
+        );
+        let text = r"Use \SaveVerbatim|x.y| here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().all(|p| p != r"\SaveVerbatim|x.y|"),
+            "SaveVerbatim must not become a SaveVerb span, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"Use \SaveVerbatim|x.y| here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn latex_saveverb_star_and_optional_args_stay_atomic() {
+        assert_eq!(
+            latex_verb_span_end_with(r"\SaveVerb*{foo}|done. Next|", 0, &[]),
+            Some(r"\SaveVerb*{foo}|done. Next|".len())
+        );
+        let text = r"See \SaveVerb[aftersave=\relax]{foo}|a.b%| please. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders
+                .iter()
+                .any(|p| p == r"\SaveVerb[aftersave=\relax]{foo}|a.b%|"),
+            "SaveVerb optional args must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \SaveVerb[aftersave=\relax]{foo}|a.b%| please.".to_string(),
+                "After.".to_string()
             ]
         );
     }

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -7,6 +7,7 @@
 //! GitHub #235: spverbatim.sty env and \\spverb are the same class as verb.
 //! GitHub #244: fancyvrb Verbatim* / BVerbatim* / LVerbatim* are the same FV@Scan class.
 //! GitHub #245: minted.sty \\mintinline / \\mint take {lang} then a FancyVerb body.
+//! GitHub #275: fancyvrb \\SaveVerb{name}|body| is the same delimiter body as \\Verb.
 //! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
 //! GitHub #250: moreverb verbatimtab is the same raw class as boxedverbatim.
 //! GitHub #249: pythontex.sty pyblock / pyverbatim / pyconsole are the same
@@ -769,6 +770,33 @@ fn mintinline_and_mint_fixture_is_atomic_and_does_not_reflow() {
     assert!(
         mint_out.contains("Use \\mint{python}|a.b! c| here.\nNext sentence."),
         "prose after mint must still split, got:\n{mint_out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #275): `\SaveVerb{foo}|done. Next|` is one
+/// token; following `After.` still splits.
+#[test]
+fn saveverb_fixture_is_atomic_and_does_not_reflow() {
+    let input =
+        "\\begin{document}\nUse \\SaveVerb{foo}|done. Next| here. After.\n\\end{document}\n";
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        !regions.iter().any(|r| matches!(r, Region::Prose(p) if p.contains("|done. Next|") && !p.contains(r"\SaveVerb"))),
+        "SaveVerb leftover |body| must not be prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains(r"\SaveVerb{foo}|done. Next|"),
+        "\\SaveVerb{{foo}}|done. Next| must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\SaveVerb{foo}|done.\n") && !out.contains("\\SaveVerb{foo}|done. Next|\n"),
+        "inner . must not split SaveVerb, got:\n{out}"
+    );
+    assert!(
+        out.contains("Use \\SaveVerb{foo}|done. Next| here.\nAfter."),
+        "prose after SaveVerb must still split, got:\n{out}"
     );
     assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 }


### PR DESCRIPTION
vissue: snapper-4y0l (parent snapper-etv7). GitHub #275.

unanimous-green-120 drawer 4/4 accept; isolated onto origin/main e0489d5.

fancyvrb `\SaveVerb{name}|body|` is the same delimiter body as `\Verb`.
The span stays one token; following `After.` still splits.
`\SaveVerb` does not steal `\SaveVerbatim`. Walk order otherwise unchanged.

## Test plan
- terra: rustfmt --check; saveverb lib + latex_verbatim_envs;
  `pythontex_pygments_is_code_not_prose` still passes