### PR TITLE
fix(latex): treat minted-star env as code

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pyblock= / =pyverbatim= / =pyconsole= / =pygments=.
+Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pyblock= / =pyverbatim= / =pyconsole= / =pygments=.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -103,11 +103,12 @@ These tokens within prose are not split across lines:
 - moreverb =verbatimtab= is a built-in code region (tab-expanding verbatim; same raw class as =boxedverbatim=)
 - =alltt= (standard =alltt.sty=) is a built-in code region (raw line breaks)
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
+- minted.sty =minted*= is the starred twin of =minted= (same raw minted body)
 - tcolorbox listings =tcblisting*= is the starred twin of =tcblisting= (same raw listing body)
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
 - pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pygments= are the same =VerbatimEnvironment= class as =pycode=
 - Extra names from =[latex].verbatim_envs= are code regions too
-- Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= language arg, =lstlisting= / =lstlisting*= =language== option)
+- Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= / =minted*= language arg, =lstlisting= / =lstlisting*= =language== option)
 - Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment
 
 *** Prose regions (reflowed)

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,7 @@ pub struct FormatOverrides {
     pub max_width: Option<usize>,
     /// Extra LaTeX environments treated as code (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
-    /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
+    /// minted/minted*/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! - **Org-mode**: drawers, tables, keywords preserved; `#+BEGIN_SRC` is
 //!   `Region::Code` (comment reflow via `[code.<lang>]`, optional formatters)
-//! - **LaTeX**: preamble and math preserved; `minted` / `lstlisting` / `lstlisting*` are code regions
+//! - **LaTeX**: preamble and math preserved; `minted` / `minted*` / `lstlisting` / `lstlisting*` are code regions
 //! - **Markdown**: front matter and headings preserved; fenced blocks are code regions
 //! - **RST**: directives and literals preserved; admonition/figure/topic/sidebar/container bodies reflow; `.. code-block::` is a code region
 //! - **Plaintext**: everything treated as prose
@@ -114,7 +114,7 @@ pub struct FormatConfig {
     /// and assert the oracle themselves.
     pub render_backstop: bool,
     /// Extra LaTeX environments treated as code (no reflow), added to
-    /// minted/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
+    /// minted/minted*/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -113,9 +113,11 @@ fn is_float_env(name: &str) -> bool {
     matches!(name, "figure" | "figure*" | "table" | "table*")
 }
 
-/// `\begin{minted}{LANG}` -- the language is the brace argument after the env.
+/// `\begin{minted}{LANG}` / `\begin{minted*}{LANG}` -- language is the brace
+/// argument after the env. minted.sty `minted*` is the starred twin (same
+/// FV@Scan / minted body; GitHub #273).
 static MINTED_LANG_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\\begin\{minted\}\s*(?:\[[^\]]*\])?\s*\{([^}]+)\}").unwrap());
+    LazyLock::new(|| Regex::new(r"\\begin\{minted\*?\}\s*(?:\[[^\]]*\])?\s*\{([^}]+)\}").unwrap());
 
 /// `\begin{lstlisting}[language=LANG, ...]` / `\begin{lstlisting*}[...]`.
 /// listings.sty `\lstnewenvironment{lstlisting}` defines both names.
@@ -151,11 +153,13 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// raw body scan; GitHub #234). tcolorbox listings library
 /// `tcblisting*` is the starred twin of `tcblisting` (same raw listing
 /// body; GitHub #246). moreverb `verbatimtab` is the same tab-expanding
-/// raw class as `boxedverbatim` (GitHub #250).
+/// raw class as `boxedverbatim` (GitHub #250). minted.sty `minted*` is
+/// the starred twin of `minted` (same FV@Scan / minted body; GitHub #273).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
         "minted"
+            | "minted*"
             | "lstlisting"
             | "lstlisting*"
             | "verbatim"
@@ -770,7 +774,7 @@ impl<'a> ParseState<'a> {
     fn enter_code(&mut self, env_name: &str, line: Line<'_>, hit_start: usize) {
         self.flush();
         let header_src = &line.text[hit_start..];
-        self.code_lang = if env_name == "minted" {
+        self.code_lang = if env_name == "minted" || env_name == "minted*" {
             MINTED_LANG_RE
                 .captures(header_src)
                 .map(|c| c.get(1).unwrap().as_str().to_string())
@@ -3084,6 +3088,127 @@ Some text.
                 .iter()
                 .any(|r| matches!(r, Region::Prose(p) if p.contains("After the block"))),
             "prose after lstlisting* % closer must resume, got: {raw_regions:?}"
+        );
+    }
+
+    /// Ticket fixture (GitHub #273): minted.sty `minted*` is the starred
+    /// twin of `minted`. Body stays Code; following prose still splits.
+    /// Unstarred `minted` is unchanged.
+    #[test]
+    fn minted_star_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{minted*}\n",
+            "First line. Second line.\n",
+            "\\end{minted*}\n",
+            "After the block. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "minted* body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "minted* body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\begin{minted*}") && out.contains("\\end{minted*}"),
+            "minted* begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "minted* body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "minted* must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after minted* must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let lang = concat!(
+            "\\begin{minted*}{python}\n",
+            "print(1) # First. Second.\n",
+            "\\end{minted*}\n",
+            "After the block. Next.\n",
+        );
+        let lang_regions = LatexParser::default().parse(lang);
+        let lang_code = lang_regions.iter().find_map(|r| match r {
+            Region::Code {
+                lang, body, header, ..
+            } => Some((lang.as_deref(), body.as_str(), header.as_str())),
+            _ => None,
+        });
+        let Some((got_lang, body, header)) = lang_code else {
+            panic!("minted* with {{lang}} must be Code, got: {lang_regions:?}");
+        };
+        assert_eq!(
+            got_lang,
+            Some("python"),
+            "minted* language arg must parse like minted, got lang={got_lang:?}"
+        );
+        assert!(
+            header.contains(r"\begin{minted*}{python}"),
+            "required language arg must stay on the begin header, got header={header:?}"
+        );
+        assert!(
+            body.contains("print(1) # First. Second."),
+            "minted* language body must stay Code, got body={body:?}"
+        );
+        let lang_out = format_text(lang, &latex_cfg()).unwrap();
+        assert!(
+            lang_out.contains("print(1) # First. Second."),
+            "minted* language body must not reflow, got:\n{lang_out}"
+        );
+        assert!(
+            lang_out.contains("After the block.\nNext."),
+            "prose after minted* language must still split, got:\n{lang_out}"
+        );
+        assert_eq!(format_text(&lang_out, &latex_cfg()).unwrap(), lang_out);
+
+        let unstarred = concat!(
+            "\\begin{minted}{python}\n",
+            "print(1)\n",
+            "print(2)\n",
+            "\\end{minted}\n",
+            "After the block. Next.\n",
+        );
+        let unstarred_regions = LatexParser::default().parse(unstarred);
+        let unstarred_code = unstarred_regions.iter().find_map(|r| match r {
+            Region::Code { lang, body, .. } => Some((lang.as_deref(), body.as_str())),
+            _ => None,
+        });
+        let Some((got_lang, body)) = unstarred_code else {
+            panic!("unstarred minted must stay Code, got: {unstarred_regions:?}");
+        };
+        assert_eq!(got_lang, Some("python"));
+        assert!(
+            body.contains("print(1)") && body.contains("print(2)"),
+            "unstarred minted body must stay Code, got body={body:?}"
+        );
+        let unstarred_out = format_text(unstarred, &latex_cfg()).unwrap();
+        assert!(
+            unstarred_out.contains("\\begin{minted}{python}\nprint(1)\nprint(2)\n\\end{minted}"),
+            "unstarred minted must stay a code env, got:\n{unstarred_out}"
+        );
+        assert!(
+            unstarred_out.contains("After the block.\nNext."),
+            "prose after unstarred minted must still split, got:\n{unstarred_out}"
+        );
+        assert_eq!(
+            format_text(&unstarred_out, &latex_cfg()).unwrap(),
+            unstarred_out
         );
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -7,6 +7,7 @@
 //! GitHub #235: spverbatim.sty env and \\spverb are the same class as verb.
 //! GitHub #244: fancyvrb Verbatim* / BVerbatim* / LVerbatim* are the same FV@Scan class.
 //! GitHub #245: minted.sty \\mintinline / \\mint take {lang} then a FancyVerb body.
+//! GitHub #273: minted.sty minted* is the starred twin of minted (same raw body).
 //! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
 //! GitHub #250: moreverb verbatimtab is the same raw class as boxedverbatim.
 //! GitHub #249: pythontex.sty pyblock / pyverbatim / pyconsole are the same
@@ -550,6 +551,71 @@ fn lstlisting_star_fixture_is_code_and_does_not_reflow() {
         "prose after lstlisting* must still split, got:\n{out}"
     );
     assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #273): minted.sty `minted*` bodies stay
+/// Code; following prose still splits. Unstarred `minted` is unchanged.
+#[test]
+fn minted_star_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{minted*}\n",
+        "First line. Second line.\n",
+        "\\end{minted*}\n",
+        "After the block. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Code { body, .. } if body.contains("First line. Second line.")
+        )),
+        "minted* body must be Code, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "minted* body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\begin{minted*}") && out.contains("\\end{minted*}"),
+        "minted* begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "minted* body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "minted* must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after minted* must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let unstarred = concat!(
+        "\\begin{minted}{python}\n",
+        "print(1)\n",
+        "print(2)\n",
+        "\\end{minted}\n",
+        "After the block. Next.\n",
+    );
+    let unstarred_out = format_text(unstarred, &latex_cfg()).unwrap();
+    assert!(
+        unstarred_out.contains("\\begin{minted}{python}\nprint(1)\nprint(2)\n\\end{minted}"),
+        "unstarred minted must stay a code env, got:\n{unstarred_out}"
+    );
+    assert!(
+        unstarred_out.contains("After the block.\nNext."),
+        "prose after unstarred minted must still split, got:\n{unstarred_out}"
+    );
+    assert_eq!(
+        format_text(&unstarred_out, &latex_cfg()).unwrap(),
+        unstarred_out
+    );
 }
 
 /// Ticket fixture (GitHub #235): spverbatim.sty `spverbatim` body stays


### PR DESCRIPTION
vissue: snapper-08o0 (parent snapper-etv7). GitHub #273.

unanimous-green-118 drawer 4/4 accept; isolated onto origin/main e0489d5.

minted.sty `minted*` is the starred twin of `minted` (same raw body scan).
Body stays Code; `{lang}` still parsed; following `After the block.` /
`Next.` still splits. Unstarred `minted` and landed `pygments` unchanged.

## Test plan
- terra: rustfmt --check; `minted_star_is_code_not_prose` and
  `minted_star_fixture_is_code_and_does_not_reflow`;
  pygments + unstarred minted still pass