### PR TITLE
fix(org): keep two-sentence verse lines as one physical line

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -21,7 +21,7 @@ The classification depends on the format.
 - Non-source =#+BEGIN_*= ...
 =#+END_*= fences, and the bodies of literal blocks (example, export, comment)
 - Dynamic blocks (=#+BEGIN: NAME= ... =#+END:=), including the generated body
-- Quote, verse, center, and special-block (NOTE and other unknown NAME) open/close lines; verse inner lines stay unjoined
+- Quote, verse, center, and special-block (NOTE and other unknown NAME) open/close lines; verse inner lines stay unjoined, and a two-sentence verse line stays one physical line
 - Special-block interiors (NOTE, ABSTRACT, WARNING, ...) reflow as prose
 - =:PROPERTIES:= ...
 =:END:= drawers

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -553,6 +553,26 @@ impl OrgParser {
     }
 }
 
+/// True when `regions[idx]` sits inside an org-element verse-block.
+///
+/// Verse-line lineation is the object (Org manual: line breaks are
+/// preserved). The parser already flushes each verse line as its own
+/// Prose region; reflow must not insert new physical lines there.
+pub(crate) fn org_verse_inner_prose(idx: usize, regions: &[Region]) -> bool {
+    let mut stack: Vec<OpenGreater> = Vec::new();
+    for region in regions.iter().take(idx) {
+        let Region::Structure(s) = region else {
+            continue;
+        };
+        if let Some(name) = OrgParser::block_begin_name(s) {
+            OrgParser::push_greater(&mut stack, name);
+        } else if let Some(name) = OrgParser::block_end_name(s) {
+            OrgParser::pop_matching_greater(&mut stack, &name);
+        }
+    }
+    OrgParser::innermost_container(&stack) == Some("VERSE")
+}
+
 impl FormatParser for OrgParser {
     fn parse_full(&self, input: &str) -> Vec<SpannedRegion> {
         let mut regions: Vec<SpannedRegion> = Vec::new();
@@ -978,6 +998,8 @@ impl FormatParser for OrgParser {
 
             // Regular prose line -- accumulate. Verse keeps physical lines.
             // Org `\\` at EOL is a line-break object, not a join (GitHub #232).
+            let verse_line = Self::innermost_container(&block_stack) == Some("VERSE");
+            let before = regions.len();
             Self::push_prose_or_line_break(
                 input,
                 &line,
@@ -987,8 +1009,15 @@ impl FormatParser for OrgParser {
                 &mut regions,
                 true,
             );
-            if Self::innermost_container(&block_stack) == Some("VERSE") {
+            if verse_line {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                // org-element verse-line: lineation is the object (GitHub #281).
+                // Keep Region::Prose; splice must not invent physical lines.
+                for sr in &mut regions[before..] {
+                    if matches!(sr.region, Region::Prose(_)) {
+                        sr.line_preserving = true;
+                    }
+                }
             }
         }
 
@@ -1880,6 +1909,47 @@ mod tests {
         assert!(
             out.contains("#+END_VERSE\nAfter.\nNext."),
             "prose after verse must reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn verse_two_sentence_line_stays_one_physical_line() {
+        use crate::format_text;
+
+        let input =
+            "#+BEGIN_VERSE\nFirst line. Second line.\n#+END_VERSE\nAfter the block. Next.\n";
+        let spanned = OrgParser.parse_full(input);
+        let verse_prose = spanned.iter().any(|s| match &s.region {
+            Region::Prose(p)
+                if p.contains("First line.") && p.contains("Second line.") && s.line_preserving =>
+            {
+                true
+            }
+            _ => false,
+        });
+        assert!(
+            verse_prose,
+            "verse line must be line-preserving Prose, got: {spanned:?}"
+        );
+        assert!(
+            !spanned.iter().any(|s| {
+                matches!(&s.region, Region::Structure(t) if t.contains("First line."))
+            }),
+            "verse inner must not flip to Structure, got: {spanned:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("#+BEGIN_VERSE\nFirst line. Second line.\n#+END_VERSE"),
+            "verse line must stay one physical line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "must not invent a verse line break, got:\n{out}"
+        );
+        assert!(
+            out.contains("#+END_VERSE\nAfter the block.\nNext."),
+            "prose after verse must still split, got:\n{out}"
         );
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }

--- a/src/parser/span.rs
+++ b/src/parser/span.rs
@@ -84,6 +84,9 @@ pub struct CodeSpans {
 pub struct SpannedRegion {
     pub region: Region,
     pub origin: Option<RegionOrigin>,
+    /// When true, splice keeps the source physical line (Org verse-line).
+    /// The region stays [`Region::Prose`]; sentence breaks do not invent lines.
+    pub line_preserving: bool,
 }
 
 impl SpannedRegion {
@@ -91,6 +94,7 @@ impl SpannedRegion {
         Self {
             region,
             origin: None,
+            line_preserving: false,
         }
     }
 
@@ -98,6 +102,7 @@ impl SpannedRegion {
         Self {
             region: Region::Prose(text),
             origin: Some(RegionOrigin::Whole(span)),
+            line_preserving: false,
         }
     }
 
@@ -105,6 +110,7 @@ impl SpannedRegion {
         Self {
             region: Region::Structure(input[span.start..span.end].to_string()),
             origin: Some(RegionOrigin::Whole(span)),
+            line_preserving: false,
         }
     }
 
@@ -112,6 +118,7 @@ impl SpannedRegion {
         Self {
             region: Region::BlankLines(input[span.start..span.end].to_string()),
             origin: Some(RegionOrigin::Whole(span)),
+            line_preserving: false,
         }
     }
 
@@ -134,6 +141,7 @@ impl SpannedRegion {
                 body,
                 footer,
             }),
+            line_preserving: false,
         }
     }
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -100,6 +100,10 @@ fn splice(
             .ok_or_else(|| SpliceError(format!("region {idx} has no source origin")))?;
         match (&sr.region, origin) {
             (Region::Prose(text), RegionOrigin::Whole(span)) => {
+                if sr.line_preserving {
+                    // Org verse-line: keep the source physical line (GitHub #281).
+                    continue;
+                }
                 let replacement = reflow_prose(text, idx, &regions, splitter, config);
                 rewrites.push((span.start, span.end, replacement));
             }
@@ -227,6 +231,9 @@ fn reflow_prose(
     splitter: &dyn SentenceSplitter,
     config: &ReflowConfig,
 ) -> String {
+    if config.format == Format::Org && crate::parser::org::org_verse_inner_prose(idx, regions) {
+        return reflow_verse_line(text, idx, regions);
+    }
     let mut output = String::new();
     let hang = match idx.checked_sub(1).and_then(|i| regions.get(i)) {
         Some(Region::Structure(s)) => hanging_prefix(s),
@@ -294,6 +301,28 @@ fn reflow_prose(
         if !suppress {
             output.push('\n');
         }
+    }
+    output
+}
+
+/// Org verse-line: keep the source physical line. Sentence, clause, or
+/// wrap breaks would invent lineation the Org manual says to preserve.
+fn reflow_verse_line(text: &str, idx: usize, regions: &[Region]) -> String {
+    let mut output = text.trim_end_matches(['\n', '\r']).to_string();
+    if output.is_empty() && text.is_empty() {
+        return output;
+    }
+    let suppress = match regions.get(idx + 1) {
+        Some(Region::Structure(s)) if suppress_prose_trailing_newline(s) => true,
+        Some(Region::Structure(s))
+            if s.trim_start().starts_with('%') && text.ends_with([' ', '\t']) =>
+        {
+            true
+        }
+        _ => false,
+    };
+    if !suppress {
+        output.push('\n');
     }
     output
 }
@@ -1211,6 +1240,7 @@ mod tests {
         let spanned = vec![SpannedRegion {
             region: Region::Prose("Hi.".into()),
             origin: Some(RegionOrigin::Whole(ByteSpan::new(0, 99))),
+            line_preserving: false,
         }];
         let err = reflow_spanned(
             "Hi.",
@@ -1226,6 +1256,50 @@ mod tests {
     fn simple_reflow() {
         let result = reflow_text("Hello world. This is a test. Another sentence.");
         assert_eq!(result, "Hello world.\nThis is a test.\nAnother sentence.\n");
+    }
+
+    #[test]
+    fn org_verse_two_sentence_line_stays_one_physical_line() {
+        let regions = vec![
+            Region::Structure("#+BEGIN_VERSE\n".into()),
+            Region::Prose("First line. Second line.".into()),
+            Region::Structure("#+END_VERSE\n".into()),
+            Region::Prose("After the block. Next.".into()),
+        ];
+        let config = ReflowConfig {
+            format: Format::Org,
+            ..Default::default()
+        };
+        let result = reflow(&regions, &UnicodeSentenceSplitter::new(), &config);
+        assert_eq!(
+            result,
+            concat!(
+                "#+BEGIN_VERSE\n",
+                "First line. Second line.\n",
+                "#+END_VERSE\n",
+                "After the block.\n",
+                "Next.\n",
+            ),
+            "verse line stays one physical line; after-block still splits, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn org_quote_two_sentence_line_still_splits() {
+        let regions = vec![
+            Region::Structure("#+BEGIN_QUOTE\n".into()),
+            Region::Prose("Quoted one. Quoted two.".into()),
+            Region::Structure("#+END_QUOTE\n".into()),
+        ];
+        let config = ReflowConfig {
+            format: Format::Org,
+            ..Default::default()
+        };
+        let result = reflow(&regions, &UnicodeSentenceSplitter::new(), &config);
+        assert_eq!(
+            result, "#+BEGIN_QUOTE\nQuoted one.\nQuoted two.\n#+END_QUOTE\n",
+            "quote inner must still split, got:\n{result}"
+        );
     }
 
     #[test]

--- a/tests/org_verse.rs
+++ b/tests/org_verse.rs
@@ -1,0 +1,124 @@
+//! snapper-hw7m / GitHub #281: an org verse line with two sentences
+//! stays one physical line. org-element verse-line lineation is the
+//! object. Inner stays Prose, not Structure. After the block still
+//! splits. Quote / center / special-block reflow is unchanged.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Org).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "#+BEGIN_VERSE\n",
+        "First line. Second line.\n",
+        "#+END_VERSE\n",
+        "After the block. Next.\n",
+    )
+}
+
+#[test]
+fn verse_line_is_prose_not_structure() {
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains("#+BEGIN_VERSE"))),
+        "verse opener must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("First line.") && p.contains("Second line.")
+        )),
+        "verse line must be Prose, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains("First line."))),
+        "verse inner must not flip to Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_verse_line_and_splits_after() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "#+BEGIN_VERSE\n",
+            "First line. Second line.\n",
+            "#+END_VERSE\n",
+            "After the block.\n",
+            "Next.\n",
+        ),
+        "verse line stays one physical line; After the block. / Next. still splits, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "must not invent a verse line break, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    assert!(
+        snapper_fmt::oracle::matches(Format::Org, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn period_free_verse_lines_stay_unjoined() {
+    let input = concat!(
+        "#+BEGIN_VERSE\n",
+        "Great clouds overhead\n",
+        "Tiny black birds rise and fall\n",
+        "#+END_VERSE\n",
+        "After. Next.\n",
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("Great clouds overhead\nTiny black birds rise and fall"),
+        "period-free verse lines must stay separate, got:\n{out}"
+    );
+    assert!(
+        !out.contains("Great clouds overhead Tiny black birds"),
+        "verse must not join lines, got:\n{out}"
+    );
+    assert!(
+        out.contains("#+END_VERSE\nAfter.\nNext."),
+        "prose after verse must still split, got:\n{out}"
+    );
+}
+
+#[test]
+fn quote_center_special_block_still_split() {
+    let quote = "#+BEGIN_QUOTE\nQuoted one. Quoted two.\n#+END_QUOTE\n";
+    let center = "#+BEGIN_CENTER\nCentered one. Centered two.\n#+END_CENTER\n";
+    let note = "#+BEGIN_NOTE\nQuoted one. Quoted two.\n#+END_NOTE\n";
+    let q = format_text(quote, &org_cfg()).unwrap();
+    let c = format_text(center, &org_cfg()).unwrap();
+    let n = format_text(note, &org_cfg()).unwrap();
+    assert!(
+        q.contains("Quoted one.\nQuoted two."),
+        "quote inner must still split, got:\n{q}"
+    );
+    assert!(
+        c.contains("Centered one.\nCentered two."),
+        "center inner must still split, got:\n{c}"
+    );
+    assert!(
+        n.contains("Quoted one.\nQuoted two."),
+        "special-block inner must still split, got:\n{n}"
+    );
+}


### PR DESCRIPTION
vissue: snapper-hw7m (parent snapper-etv7). GitHub #281.

unanimous-green-121 drawer 4/4 accept; isolated onto origin/main 1ca7281.

org-element verse-line lineation is the object. A `#+BEGIN_VERSE` line
that already contains two sentences stays one physical line. Each verse
line remains Prose (not Structure). After the block. / Next. still
splits. Quote / center / special-block reflow unchanged.

## Test plan
- terra: rustfmt --check; verse lib tests + tests/org_verse.rs