### PR TITLE
fix(latex): treat pythontex starred py envs as verbatim

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pyblock= / =pyverbatim= / =pyconsole= / =pygments=.
+Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pycode*= / =pyblock= / =pyblock*= / =pyverbatim= / =pyverbatim*= / =pyconsole= / =pyconsole*= / =pygments=.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -106,7 +106,7 @@ These tokens within prose are not split across lines:
 - minted.sty =minted*= is the starred twin of =minted= (same raw minted body)
 - tcolorbox listings =tcblisting*= is the starred twin of =tcblisting= (same raw listing body)
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
-- pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pygments= are the same =VerbatimEnvironment= class as =pycode=
+- pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pycode*= / =pyblock*= / =pyverbatim*= / =pyconsole*= / =pygments= are the same =VerbatimEnvironment= class as =pycode=
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= / =minted*= language arg, =lstlisting= / =lstlisting*= =language== option)
 - Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment

--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,8 @@ pub struct FormatOverrides {
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
-    /// and pythontex pycode/pyblock/pyverbatim/pyconsole/pygments; entries are
+    /// and pythontex pycode/pycode*/pyblock/pyblock*/pyverbatim/pyverbatim*/
+    /// pyconsole/pyconsole*/pygments; entries are
     /// added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,8 @@ pub struct FormatConfig {
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
-    /// and pythontex pycode/pyblock/pyverbatim/pyconsole/pygments. Empty keeps
+    /// and pythontex pycode/pycode*/pyblock/pyblock*/pyverbatim/pyverbatim*/
+    /// pyconsole/pyconsole*/pygments. Empty keeps
     /// the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -131,8 +131,9 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// (`filecontents`, `filecontents*`) and tree-sitter-latex raw trivia envs
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
 /// `sageblock`), pythontex.sty `pyblock` / `pyverbatim` / `pyconsole`
-/// / `pygments` (same `VerbatimEnvironment` class as `pycode`;
-/// GitHub #249 / #274),
+/// / `pycode*` / `pyblock*` / `pyverbatim*` / `pyconsole*` / `pygments`
+/// (same `VerbatimEnvironment` class as `pycode`; GitHub #249 / #274
+/// / #276),
 /// plus latex2e `verbatim*` / fancyvrb `Verbatim` /
 /// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
 /// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut` / `VerbatimWrite`,
@@ -185,9 +186,13 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "asy"
             | "asydef"
             | "pycode"
+            | "pycode*"
             | "pyblock"
+            | "pyblock*"
             | "pyverbatim"
+            | "pyverbatim*"
             | "pyconsole"
+            | "pyconsole*"
             | "pygments"
             | "luacode"
             | "luacode*"
@@ -2840,6 +2845,60 @@ Some text.
         use crate::format_text;
 
         for name in ["pyblock", "pyverbatim", "pyconsole"] {
+            let input = format!(
+                concat!(
+                    "\\begin{{{name}}}\n",
+                    "First line. Second line.\n",
+                    "\\end{{{name}}}\n",
+                    "After the block. Next.\n",
+                ),
+                name = name
+            );
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Code { body, .. } if body.contains("First line. Second line.")
+                )),
+                "{name} body must be Code, got: {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+                "{name} body must not leak into Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&format!("\\begin{{{name}}}"))
+                    && out.contains(&format!("\\end{{{name}}}")),
+                "{name} begin/end must stay, got:\n{out}"
+            );
+            assert!(
+                out.contains("First line. Second line."),
+                "{name} body must stay one source line, got:\n{out}"
+            );
+            assert!(
+                !out.contains("First line.\nSecond line."),
+                "{name} must not reflow as prose, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the block.\nNext."),
+                "prose after {name} must still split, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+        }
+    }
+
+    /// Ticket fixture (GitHub #276): pythontex.sty `pycode*` /
+    /// `pyblock*` / `pyverbatim*` / `pyconsole*` are the same
+    /// `VerbatimEnvironment` class as the unstarred twins. Body stays
+    /// Code; following prose still splits.
+    #[test]
+    fn pythontex_starred_py_envs_are_code_not_prose() {
+        use crate::format_text;
+
+        for name in ["pycode*", "pyblock*", "pyverbatim*", "pyconsole*"] {
             let input = format!(
                 concat!(
                     "\\begin{{{name}}}\n",

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -13,6 +13,8 @@
 //! GitHub #250: moreverb verbatimtab is the same raw class as boxedverbatim.
 //! GitHub #249: pythontex.sty pyblock / pyverbatim / pyconsole are the same
 //! VerbatimEnvironment class as pycode.
+//! GitHub #276: pythontex.sty pycode* / pyblock* / pyverbatim* / pyconsole*
+//! are the starred twins (same VerbatimEnvironment class).
 //! GitHub #274: pythontex.sty pygments is the same VerbatimEnvironment class.
 
 use snapper_fmt::format::Format;
@@ -682,6 +684,57 @@ fn spverbatim_and_spverb_fixture_is_code_and_does_not_reflow() {
 #[test]
 fn pythontex_pyblock_pyverbatim_pyconsole_fixture_is_code_and_does_not_reflow() {
     for name in ["pyblock", "pyverbatim", "pyconsole"] {
+        let input = format!(
+            concat!(
+                "\\begin{{{name}}}\n",
+                "First line. Second line.\n",
+                "\\end{{{name}}}\n",
+                "After the block. Next.\n",
+            ),
+            name = name
+        );
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "{name} body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&format!("\\begin{{{name}}}"))
+                && out.contains(&format!("\\end{{{name}}}")),
+            "{name} begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "{name} body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after {name} must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+}
+
+/// Ticket fixture (GitHub #276): pythontex.sty `pycode*` / `pyblock*`
+/// / `pyverbatim*` / `pyconsole*` bodies stay Code; following prose
+/// still splits.
+#[test]
+fn pythontex_starred_py_envs_fixture_is_code_and_does_not_reflow() {
+    for name in ["pycode*", "pyblock*", "pyverbatim*", "pyconsole*"] {
         let input = format!(
             concat!(
                 "\\begin{{{name}}}\n",


### PR DESCRIPTION
vissue: snapper-2cfw (parent snapper-etv7). GitHub #276.

unanimous-green-122 drawer 4/4 accept; isolated onto origin/main a176286.

pythontex.sty `pycode*` / `pyblock*` / `pyverbatim*` / `pyconsole*` are
the same `VerbatimEnvironment` class as the unstarred twins. Body stays
Code; following `After the block.` / `Next.` still splits. Landed
`pygments`, `minted*`, and unstarred py* unchanged.

## Test plan
- terra: rustfmt --check; pythontex starred + unstarred + pygments lib
  and latex_verbatim_envs