### PR TITLE
fix(latex): treat pythontex sympy envs as verbatim

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pycode*= / =pyblock= / =pyblock*= / =pyverbatim= / =pyverbatim*= / =pyconsole= / =pyconsole*= / =pygments=.
+Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pycode*= / =pyblock= / =pyblock*= / =pyverbatim= / =pyverbatim*= / =pyconsole= / =pyconsole*= / =pygments= / =sympycode= / =sympyblock= / =sympyverbatim= / =sympyconsole= and starred twins.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -106,7 +106,7 @@ These tokens within prose are not split across lines:
 - minted.sty =minted*= is the starred twin of =minted= (same raw minted body)
 - tcolorbox listings =tcblisting*= is the starred twin of =tcblisting= (same raw listing body)
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
-- pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pycode*= / =pyblock*= / =pyverbatim*= / =pyconsole*= / =pygments= are the same =VerbatimEnvironment= class as =pycode=
+- pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pycode*= / =pyblock*= / =pyverbatim*= / =pyconsole*= / =pygments= / =sympycode= / =sympyblock= / =sympyverbatim= / =sympyconsole= and starred twins are the same =VerbatimEnvironment= class as =pycode=
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= / =minted*= language arg, =lstlisting= / =lstlisting*= =language== option)
 - Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,8 @@ pub struct FormatOverrides {
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
     /// and pythontex pycode/pycode*/pyblock/pyblock*/pyverbatim/pyverbatim*/
-    /// pyconsole/pyconsole*/pygments; entries are
+    /// pyconsole/pyconsole*/pygments plus sympycode/sympyblock/sympyverbatim/
+    /// sympyconsole and starred twins; entries are
     /// added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,7 +120,8 @@ pub struct FormatConfig {
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
     /// and pythontex pycode/pycode*/pyblock/pyblock*/pyverbatim/pyverbatim*/
-    /// pyconsole/pyconsole*/pygments. Empty keeps
+    /// pyconsole/pyconsole*/pygments plus sympycode/sympyblock/sympyverbatim/
+    /// sympyconsole and starred twins. Empty keeps
     /// the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -132,8 +132,9 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
 /// `sageblock`), pythontex.sty `pyblock` / `pyverbatim` / `pyconsole`
 /// / `pycode*` / `pyblock*` / `pyverbatim*` / `pyconsole*` / `pygments`
-/// (same `VerbatimEnvironment` class as `pycode`; GitHub #249 / #274
-/// / #276),
+/// / `sympycode` / `sympyblock` / `sympyverbatim` / `sympyconsole` and
+/// starred twins (same `VerbatimEnvironment` class as `pycode`;
+/// GitHub #249 / #274 / #276 / #277),
 /// plus latex2e `verbatim*` / fancyvrb `Verbatim` /
 /// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
 /// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut` / `VerbatimWrite`,
@@ -194,6 +195,14 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "pyconsole"
             | "pyconsole*"
             | "pygments"
+            | "sympycode"
+            | "sympycode*"
+            | "sympyblock"
+            | "sympyblock*"
+            | "sympyverbatim"
+            | "sympyverbatim*"
+            | "sympyconsole"
+            | "sympyconsole*"
             | "luacode"
             | "luacode*"
             | "sagesilent"
@@ -3008,6 +3017,69 @@ Some text.
             "prose after pygments must still split, got:\n{out}"
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #277): pythontex.sty `sympycode` /
+    /// `sympyblock` / `sympyverbatim` / `sympyconsole` and starred
+    /// twins are the same `VerbatimEnvironment` class as `pycode`.
+    /// Body stays Code; following prose still splits.
+    #[test]
+    fn pythontex_sympy_family_is_code_not_prose() {
+        use crate::format_text;
+
+        for name in [
+            "sympycode",
+            "sympycode*",
+            "sympyblock",
+            "sympyblock*",
+            "sympyverbatim",
+            "sympyverbatim*",
+            "sympyconsole",
+            "sympyconsole*",
+        ] {
+            let input = format!(
+                concat!(
+                    "\\begin{{{name}}}\n",
+                    "First line. Second line.\n",
+                    "\\end{{{name}}}\n",
+                    "After the block. Next.\n",
+                ),
+                name = name
+            );
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Code { body, .. } if body.contains("First line. Second line.")
+                )),
+                "{name} body must be Code, got: {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+                "{name} body must not leak into Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&format!("\\begin{{{name}}}"))
+                    && out.contains(&format!("\\end{{{name}}}")),
+                "{name} begin/end must stay, got:\n{out}"
+            );
+            assert!(
+                out.contains("First line. Second line."),
+                "{name} body must stay one source line, got:\n{out}"
+            );
+            assert!(
+                !out.contains("First line.\nSecond line."),
+                "{name} must not reflow as prose, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the block.\nNext."),
+                "prose after {name} must still split, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+        }
     }
 
     /// Ticket fixture (GitHub #230): alltt.sty is a standard

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -16,6 +16,8 @@
 //! GitHub #276: pythontex.sty pycode* / pyblock* / pyverbatim* / pyconsole*
 //! are the starred twins (same VerbatimEnvironment class).
 //! GitHub #274: pythontex.sty pygments is the same VerbatimEnvironment class.
+//! GitHub #277: pythontex.sty sympycode / sympyblock / sympyverbatim /
+//! sympyconsole and starred twins are the same VerbatimEnvironment class.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -841,6 +843,66 @@ fn pythontex_pygments_fixture_is_code_and_does_not_reflow() {
         "prose after pygments must still split, got:\n{out}"
     );
     assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #277): pythontex.sty `sympycode` / `sympyblock`
+/// / `sympyverbatim` / `sympyconsole` and starred twins stay Code;
+/// following prose still splits.
+#[test]
+fn pythontex_sympy_family_fixture_is_code_and_does_not_reflow() {
+    for name in [
+        "sympycode",
+        "sympycode*",
+        "sympyblock",
+        "sympyblock*",
+        "sympyverbatim",
+        "sympyverbatim*",
+        "sympyconsole",
+        "sympyconsole*",
+    ] {
+        let input = format!(
+            concat!(
+                "\\begin{{{name}}}\n",
+                "First line. Second line.\n",
+                "\\end{{{name}}}\n",
+                "After the block. Next.\n",
+            ),
+            name = name
+        );
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "{name} body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&format!("\\begin{{{name}}}"))
+                && out.contains(&format!("\\end{{{name}}}")),
+            "{name} begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "{name} body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after {name} must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
 }
 
 /// Ticket fixture (GitHub #245): `\mintinline{python}|a.b! c|` is one


### PR DESCRIPTION
vissue: snapper-ch9m (parent snapper-etv7). GitHub #277.

unanimous-green-123 drawer 4/4 accept; isolated onto origin/main c3cbf9f.

pythontex.sty sympy family (`sympycode` / `sympyblock` / `sympyverbatim` /
`sympyconsole` and starred twins) is the same `VerbatimEnvironment` class
as `pycode`. Body stays Code; following `After the block.` / `Next.` still
splits. Landed `pycode*` / `pygments` / `minted*` unchanged.

## Test plan
- terra: rustfmt --check; sympy family + pythontex_starred + pygments