### PR TITLE
fix(latex): treat moreverb listing envs as code

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pycode*= / =pyblock= / =pyblock*= / =pyverbatim= / =pyverbatim*= / =pyconsole= / =pyconsole*= / =pygments=.
+Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab= / =listing= / =listingcont= / =listing*= / =listingcont*=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pycode*= / =pyblock= / =pyblock*= / =pyverbatim= / =pyverbatim*= / =pyconsole= / =pyconsole*= / =pygments=.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -101,6 +101,7 @@ These tokens within prose are not split across lines:
 - =\\begin{...}= / =\\end{...}= lines are structure
 - fancyvrb =Verbatim= / =Verbatim*= / =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite= are built-in code regions (same FV@Scan class)
 - moreverb =verbatimtab= is a built-in code region (tab-expanding verbatim; same raw class as =boxedverbatim=)
+- moreverb =listing= / =listingcont= / =listing*= / =listingcont*= are built-in code regions (=verbatim@start= raw body; starred twins do not expand tabs)
 - =alltt= (standard =alltt.sty=) is a built-in code region (raw line breaks)
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
 - minted.sty =minted*= is the starred twin of =minted= (same raw minted body)

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,8 @@ pub struct FormatOverrides {
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
-    /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
+    /// moreverb boxedverbatim/verbatimtab/listing/listingcont/listing*/listingcont*,
+    /// standard alltt, spverbatim,
     /// and pythontex pycode/pycode*/pyblock/pyblock*/pyverbatim/pyverbatim*/
     /// pyconsole/pyconsole*/pygments; entries are
     /// added to it.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,7 +118,8 @@ pub struct FormatConfig {
     /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
-    /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
+    /// moreverb boxedverbatim/verbatimtab/listing/listingcont/listing*/listingcont*,
+    /// standard alltt, spverbatim,
     /// and pythontex pycode/pycode*/pyblock/pyblock*/pyverbatim/pyverbatim*/
     /// pyconsole/pyconsole*/pygments. Empty keeps
     /// the built-in list.

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -137,7 +137,8 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// plus latex2e `verbatim*` / fancyvrb `Verbatim` /
 /// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
 /// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut` / `VerbatimWrite`,
-/// moreverb `boxedverbatim` / `verbatimtab`, tcolorbox `tcblisting` /
+/// moreverb `boxedverbatim` / `verbatimtab` / `listing` / `listingcont` /
+/// `listing*` / `listingcont*`, tcolorbox `tcblisting` /
 /// `tcblisting*` / `codeexample`, standard `alltt` (alltt.sty: macros
 /// still apply, line breaks stay raw; GitHub #230), spverbatim.sty `spverbatim`
 /// (raw body; `\spverb` is the matching delimiter-body command,
@@ -154,8 +155,11 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// raw body scan; GitHub #234). tcolorbox listings library
 /// `tcblisting*` is the starred twin of `tcblisting` (same raw listing
 /// body; GitHub #246). moreverb `verbatimtab` is the same tab-expanding
-/// raw class as `boxedverbatim` (GitHub #250). minted.sty `minted*` is
-/// the starred twin of `minted` (same FV@Scan / minted body; GitHub #273).
+/// raw class as `boxedverbatim` (GitHub #250). moreverb `listing` /
+/// `listingcont` / `listing*` / `listingcont*` are `verbatim@start` raw
+/// bodies (starred twins do not expand tabs; GitHub #279). minted.sty
+/// `minted*` is the starred twin of `minted` (same FV@Scan / minted
+/// body; GitHub #273).
 fn is_builtin_code_env(name: &str) -> bool {
     matches!(
         name,
@@ -177,6 +181,10 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "alltt"
             | "boxedverbatim"
             | "verbatimtab"
+            | "listing"
+            | "listingcont"
+            | "listing*"
+            | "listingcont*"
             | "tcblisting"
             | "tcblisting*"
             | "codeexample"
@@ -3465,6 +3473,141 @@ Some text.
             "prose after verbatimtab must still split, got:\n{out}"
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #279): moreverb `listing` is a
+    /// `verbatim@start` raw body. Required `{1}` stays on the begin
+    /// header. Body stays Code; following prose still splits.
+    #[test]
+    fn moreverb_listing_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{listing}{1}\n",
+            "First line. Second line.\n",
+            "\\end{listing}\n",
+            "After the block. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        let code = regions.iter().find_map(|r| match r {
+            Region::Code {
+                header,
+                body,
+                footer,
+                ..
+            } => Some((header.as_str(), body.as_str(), footer.as_str())),
+            _ => None,
+        });
+        let Some((header, body, footer)) = code else {
+            panic!("listing must be Code, got: {regions:?}");
+        };
+        assert!(
+            header.contains(r"\begin{listing}{1}"),
+            "required start-line arg must stay on the begin header, got header={header:?}"
+        );
+        assert!(
+            body.contains("First line. Second line."),
+            "listing body must keep both sentences, got body={body:?}"
+        );
+        assert!(
+            footer.contains(r"\end{listing}"),
+            "listing footer must stay, got footer={footer:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("First line") || p.contains("{1}")
+            )),
+            "listing start-line/body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\begin{listing}{1}") && out.contains(r"\end{listing}"),
+            "listing begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "listing body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "listing must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after listing must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #279): moreverb `listingcont` / `listing*`
+    /// / `listingcont*` are the same `verbatim@start` raw class as
+    /// `listing`. `listing*` keeps the start-line arg on begin.
+    #[test]
+    fn moreverb_listing_twins_are_code_not_prose() {
+        use crate::format_text;
+
+        let cases = [
+            ("listingcont", ""),
+            ("listing*", "{1}"),
+            ("listingcont*", ""),
+        ];
+        for (name, arg) in cases {
+            let begin = format!("\\begin{{{name}}}{arg}");
+            let input = format!(
+                "{begin}\nFirst line. Second line.\n\\end{{{name}}}\nAfter the block. Next.\n"
+            );
+            let regions = LatexParser::default().parse(&input);
+            let code = regions.iter().find_map(|r| match r {
+                Region::Code {
+                    header,
+                    body,
+                    footer,
+                    ..
+                } => Some((header.as_str(), body.as_str(), footer.as_str())),
+                _ => None,
+            });
+            let Some((header, body, footer)) = code else {
+                panic!("{name} must be Code, got: {regions:?}");
+            };
+            assert!(
+                header.contains(&begin),
+                "{name} begin must stay on the header, got header={header:?}"
+            );
+            assert!(
+                body.contains("First line. Second line."),
+                "{name} body must keep both sentences, got body={body:?}"
+            );
+            assert!(
+                footer.contains(&format!("\\end{{{name}}}")),
+                "{name} footer must stay, got footer={footer:?}"
+            );
+            assert!(
+                !regions.iter().any(|r| matches!(
+                    r,
+                    Region::Prose(p) if p.contains("First line") || p.contains("{1}")
+                )),
+                "{name} body/arg must not leak into Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&begin) && out.contains(&format!("\\end{{{name}}}")),
+                "{name} begin/end must stay, got:\n{out}"
+            );
+            assert!(
+                out.contains("First line. Second line."),
+                "{name} body must stay one source line, got:\n{out}"
+            );
+            assert!(
+                !out.contains("First line.\nSecond line."),
+                "{name} must not reflow as prose, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the block.\nNext."),
+                "prose after {name} must still split, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+        }
     }
 
     /// Ticket fixture (GitHub #246): tcolorbox listings `tcblisting*`

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -11,6 +11,8 @@
 //! GitHub #275: fancyvrb \\SaveVerb{name}|body| is the same delimiter body as \\Verb.
 //! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
 //! GitHub #250: moreverb verbatimtab is the same raw class as boxedverbatim.
+//! GitHub #279: moreverb listing / listingcont / listing* / listingcont*
+//! are verbatim@start raw bodies (starred twins do not expand tabs).
 //! GitHub #249: pythontex.sty pyblock / pyverbatim / pyconsole are the same
 //! VerbatimEnvironment class as pycode.
 //! GitHub #276: pythontex.sty pycode* / pyblock* / pyverbatim* / pyconsole*
@@ -134,6 +136,135 @@ fn verbatimtab_fixture_is_code_and_does_not_reflow() {
         "prose after verbatimtab must still split, got:\n{out}"
     );
     assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #279): moreverb `listing` required `{1}`
+/// stays on begin; body stays Code; following prose still splits.
+#[test]
+fn listing_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{listing}{1}\n",
+        "First line. Second line.\n",
+        "\\end{listing}\n",
+        "After the block. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    let code = regions.iter().find_map(|r| match r {
+        Region::Code {
+            header,
+            body,
+            footer,
+            ..
+        } => Some((header.as_str(), body.as_str(), footer.as_str())),
+        _ => None,
+    });
+    let Some((header, body, footer)) = code else {
+        panic!("listing must be Code, got: {regions:?}");
+    };
+    assert!(
+        header.contains("\\begin{listing}{1}"),
+        "required start-line arg must stay on the begin header, got header={header:?}"
+    );
+    assert!(
+        body.contains("First line. Second line."),
+        "listing body must be Code, got body={body:?}"
+    );
+    assert!(
+        footer.contains("\\end{listing}"),
+        "listing footer must stay, got footer={footer:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("First line") || p.contains("{1}")
+        )),
+        "listing start-line/body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\begin{listing}{1}") && out.contains("\\end{listing}"),
+        "listing begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "listing body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "listing must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after listing must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #279): moreverb `listingcont` / `listing*` /
+/// `listingcont*` stay Code; `listing*` keeps `{1}` on begin; following
+/// prose still splits.
+#[test]
+fn listing_twins_fixture_is_code_and_does_not_reflow() {
+    let cases = [
+        ("listingcont", ""),
+        ("listing*", "{1}"),
+        ("listingcont*", ""),
+    ];
+    for (name, arg) in cases {
+        let begin = format!("\\begin{{{name}}}{arg}");
+        let input =
+            format!("{begin}\nFirst line. Second line.\n\\end{{{name}}}\nAfter the block. Next.\n");
+        let regions = LatexParser::default().parse(&input);
+        let code = regions.iter().find_map(|r| match r {
+            Region::Code {
+                header,
+                body,
+                footer,
+                ..
+            } => Some((header.as_str(), body.as_str(), footer.as_str())),
+            _ => None,
+        });
+        let Some((header, body, footer)) = code else {
+            panic!("{name} must be Code, got: {regions:?}");
+        };
+        assert!(
+            header.contains(&begin),
+            "{name} begin must stay on the header, got header={header:?}"
+        );
+        assert!(
+            body.contains("First line. Second line."),
+            "{name} body must be Code, got body={body:?}"
+        );
+        assert!(
+            footer.contains(&format!("\\end{{{name}}}")),
+            "{name} footer must stay, got footer={footer:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("First line") || p.contains("{1}")
+            )),
+            "{name} body/arg must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&begin) && out.contains(&format!("\\end{{{name}}}")),
+            "{name} begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "{name} body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after {name} must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
 }
 
 /// Ticket fixture (GitHub #246): tcolorbox listings `tcblisting*`


### PR DESCRIPTION
vissue: snapper-9wd8 (parent snapper-etv7). GitHub #279.

unanimous-green-124 drawer 4/4 accept; isolated onto origin/main c3cbf9f.

moreverb.sty `listing` / `listingcont` / `listing*` / `listingcont*` are
`verbatim@start` raw bodies. Body stays Code; following `After the block.`
/ `Next.` still splits. Landed `verbatimtab` / `boxedverbatim` / `minted*`
/ `pycode*` unchanged.

## Test plan
- terra: rustfmt --check; moreverb_listing lib tests + listing fixtures