### PR TITLE
fix(latex): treat pythontex pylab envs as verbatim

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pycode*= / =pyblock= / =pyblock*= / =pyverbatim= / =pyverbatim*= / =pyconsole= / =pyconsole*= / =pygments= / =sympycode= / =sympyblock= / =sympyverbatim= / =sympyconsole= and starred twins.
+Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pycode*= / =pyblock= / =pyblock*= / =pyverbatim= / =pyverbatim*= / =pyconsole= / =pyconsole*= / =pygments= / =sympycode= / =sympyblock= / =sympyverbatim= / =sympyconsole= / =pylabcode= / =pylabblock= / =pylabverbatim= / =pylabconsole= and starred twins.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -106,7 +106,7 @@ These tokens within prose are not split across lines:
 - minted.sty =minted*= is the starred twin of =minted= (same raw minted body)
 - tcolorbox listings =tcblisting*= is the starred twin of =tcblisting= (same raw listing body)
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
-- pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pycode*= / =pyblock*= / =pyverbatim*= / =pyconsole*= / =pygments= / =sympycode= / =sympyblock= / =sympyverbatim= / =sympyconsole= and starred twins are the same =VerbatimEnvironment= class as =pycode=
+- pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pycode*= / =pyblock*= / =pyverbatim*= / =pyconsole*= / =pygments= / =sympycode= / =sympyblock= / =sympyverbatim= / =sympyconsole= / =pylabcode= / =pylabblock= / =pylabverbatim= / =pylabconsole= and starred twins are the same =VerbatimEnvironment= class as =pycode=
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= / =minted*= language arg, =lstlisting= / =lstlisting*= =language== option)
 - Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,8 +20,8 @@ pub struct FormatOverrides {
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
     /// and pythontex pycode/pycode*/pyblock/pyblock*/pyverbatim/pyverbatim*/
-    /// pyconsole/pyconsole*/pygments plus sympycode/sympyblock/sympyverbatim/
-    /// sympyconsole and starred twins; entries are
+    /// pyconsole/pyconsole*/pygments plus sympy and pylab families and
+    /// starred twins; entries are
     /// added to it.
     pub verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,8 @@ pub struct FormatConfig {
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab, standard alltt, spverbatim,
     /// and pythontex pycode/pycode*/pyblock/pyblock*/pyverbatim/pyverbatim*/
-    /// pyconsole/pyconsole*/pygments plus sympycode/sympyblock/sympyverbatim/
-    /// sympyconsole and starred twins. Empty keeps
+    /// pyconsole/pyconsole*/pygments plus sympy and pylab families and
+    /// starred twins. Empty keeps
     /// the built-in list.
     pub latex_verbatim_envs: Vec<String>,
     /// Extra LaTeX environments treated as structure (no reflow), added

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -132,9 +132,10 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// (`asy`, `asydef`, `pycode`, `luacode`, `luacode*`, `sagesilent`,
 /// `sageblock`), pythontex.sty `pyblock` / `pyverbatim` / `pyconsole`
 /// / `pycode*` / `pyblock*` / `pyverbatim*` / `pyconsole*` / `pygments`
-/// / `sympycode` / `sympyblock` / `sympyverbatim` / `sympyconsole` and
+/// / `sympycode` / `sympyblock` / `sympyverbatim` / `sympyconsole` /
+/// `pylabcode` / `pylabblock` / `pylabverbatim` / `pylabconsole` and
 /// starred twins (same `VerbatimEnvironment` class as `pycode`;
-/// GitHub #249 / #274 / #276 / #277),
+/// GitHub #249 / #274 / #276 / #277 / #278),
 /// plus latex2e `verbatim*` / fancyvrb `Verbatim` /
 /// `Verbatim*` / `BVerbatim` / `BVerbatim*` / `LVerbatim` /
 /// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut` / `VerbatimWrite`,
@@ -203,6 +204,14 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "sympyverbatim*"
             | "sympyconsole"
             | "sympyconsole*"
+            | "pylabcode"
+            | "pylabcode*"
+            | "pylabblock"
+            | "pylabblock*"
+            | "pylabverbatim"
+            | "pylabverbatim*"
+            | "pylabconsole"
+            | "pylabconsole*"
             | "luacode"
             | "luacode*"
             | "sagesilent"
@@ -3080,6 +3089,86 @@ Some text.
             );
             assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
         }
+    }
+
+    /// Ticket fixture (GitHub #278): pythontex.sty `pylabcode` /
+    /// `pylabblock` / `pylabverbatim` / `pylabconsole` and starred
+    /// twins are the same `VerbatimEnvironment` class as `pycode`.
+    /// Body stays Code; following prose still splits.
+    #[test]
+    fn pythontex_pylab_family_is_code_not_prose() {
+        use crate::format_text;
+
+        for name in [
+            "pylabcode",
+            "pylabcode*",
+            "pylabblock",
+            "pylabblock*",
+            "pylabverbatim",
+            "pylabverbatim*",
+            "pylabconsole",
+            "pylabconsole*",
+        ] {
+            let input = format!(
+                concat!(
+                    "\\begin{{{name}}}\n",
+                    "First line. Second line.\n",
+                    "\\end{{{name}}}\n",
+                    "After the block. Next.\n",
+                ),
+                name = name
+            );
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Code { body, .. } if body.contains("First line. Second line.")
+                )),
+                "{name} body must be Code, got: {regions:?}"
+            );
+            assert!(
+                !regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+                "{name} body must not leak into Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&format!("\\begin{{{name}}}"))
+                    && out.contains(&format!("\\end{{{name}}}")),
+                "{name} begin/end must stay, got:\n{out}"
+            );
+            assert!(
+                out.contains("First line. Second line."),
+                "{name} body must stay one source line, got:\n{out}"
+            );
+            assert!(
+                !out.contains("First line.\nSecond line."),
+                "{name} must not reflow as prose, got:\n{out}"
+            );
+            assert!(
+                out.contains("After the block.\nNext."),
+                "prose after {name} must still split, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+        }
+
+        let pycode = concat!(
+            "\\begin{pycode}\n",
+            "First line. Second line.\n",
+            "\\end{pycode}\n",
+            "After the block. Next.\n",
+        );
+        let pycode_out = format_text(pycode, &latex_cfg()).unwrap();
+        assert!(
+            pycode_out.contains("\\begin{pycode}\nFirst line. Second line.\n\\end{pycode}"),
+            "unstarred pycode family must stay a code env, got:\n{pycode_out}"
+        );
+        assert!(
+            pycode_out.contains("After the block.\nNext."),
+            "prose after unstarred pycode must still split, got:\n{pycode_out}"
+        );
+        assert_eq!(format_text(&pycode_out, &latex_cfg()).unwrap(), pycode_out);
     }
 
     /// Ticket fixture (GitHub #230): alltt.sty is a standard

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -18,6 +18,8 @@
 //! GitHub #274: pythontex.sty pygments is the same VerbatimEnvironment class.
 //! GitHub #277: pythontex.sty sympycode / sympyblock / sympyverbatim /
 //! sympyconsole and starred twins are the same VerbatimEnvironment class.
+//! GitHub #278: pythontex.sty pylabcode / pylabblock / pylabverbatim /
+//! pylabconsole and starred twins are the same VerbatimEnvironment class.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -903,6 +905,83 @@ fn pythontex_sympy_family_fixture_is_code_and_does_not_reflow() {
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }
+}
+
+/// Ticket fixture (GitHub #278): pythontex.sty `pylabcode` /
+/// `pylabblock` / `pylabverbatim` / `pylabconsole` and starred twins
+/// stay Code; following prose still splits.
+#[test]
+fn pythontex_pylab_family_fixture_is_code_and_does_not_reflow() {
+    for name in [
+        "pylabcode",
+        "pylabcode*",
+        "pylabblock",
+        "pylabblock*",
+        "pylabverbatim",
+        "pylabverbatim*",
+        "pylabconsole",
+        "pylabconsole*",
+    ] {
+        let input = format!(
+            concat!(
+                "\\begin{{{name}}}\n",
+                "First line. Second line.\n",
+                "\\end{{{name}}}\n",
+                "After the block. Next.\n",
+            ),
+            name = name
+        );
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "{name} body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "{name} body must not be Prose, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&format!("\\begin{{{name}}}"))
+                && out.contains(&format!("\\end{{{name}}}")),
+            "{name} begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "{name} body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "{name} must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after {name} must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    let pycode = concat!(
+        "\\begin{pycode}\n",
+        "First line. Second line.\n",
+        "\\end{pycode}\n",
+        "After the block. Next.\n",
+    );
+    let pycode_out = format_text(pycode, &latex_cfg()).unwrap();
+    assert!(
+        pycode_out.contains("\\begin{pycode}\nFirst line. Second line.\n\\end{pycode}"),
+        "unstarred pycode family must stay a code env, got:\n{pycode_out}"
+    );
+    assert!(
+        pycode_out.contains("After the block.\nNext."),
+        "prose after unstarred pycode must still split, got:\n{pycode_out}"
+    );
+    assert_eq!(format_text(&pycode_out, &latex_cfg()).unwrap(), pycode_out);
 }
 
 /// Ticket fixture (GitHub #245): `\mintinline{python}|a.b! c|` is one


### PR DESCRIPTION
vissue: snapper-1l3l (parent snapper-etv7). GitHub #278.

unanimous-green-125 drawer 4/4 accept; isolated onto origin/main b04f2fe
(after listing #288).

pythontex.sty pylab family (`pylabcode` / `pylabblock` / `pylabverbatim` /
`pylabconsole` and starred twins) is the same `VerbatimEnvironment` class
as `pycode`. Body stays Code; following prose still splits. Landed sympy,
listing, `pycode*`, `minted*` unchanged.

## Test plan
- terra: rustfmt --check; pylab family + sympy regression