### PR TITLE
fix(latex): treat tcolorbox verbatim write envs as code

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -165,7 +165,7 @@ There is no regex =other:= key (latexindent's pattern-based extra matching is no
 :END:
 
 String array of environment names treated like =minted= / =lstlisting= / =verbatim= / =comment= (=Region::Code=, no reflow).
-Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab= / =listing= / =listingcont= / =listing*= / =listingcont*=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pycode*= / =pyblock= / =pyblock*= / =pyverbatim= / =pyverbatim*= / =pyconsole= / =pyconsole*= / =pygments= / =sympycode= / =sympyblock= / =sympyverbatim= / =sympyconsole= and starred twins.
+Built-in: =minted= / =minted*=, =lstlisting= / =lstlisting*=, =verbatim=, =comment=, Overleaf =Verbatim= / =boxedverbatim= / =tcblisting= / =tcblisting*= / =codeexample= / =tcbverbatimwrite= / =tcbwritetemp=, fancyvrb =BVerbatim= / =BVerbatim*= / =LVerbatim= / =LVerbatim*= / =Verbatim*= / =SaveVerbatim= / =VerbatimOut= / fvextra =VerbatimWrite=, moreverb =verbatimtab= / =listing= / =listingcont= / =listing*= / =listingcont*=, standard =alltt=, spverbatim.sty =spverbatim=, and pythontex.sty =pycode= / =pycode*= / =pyblock= / =pyblock*= / =pyverbatim= / =pyverbatim*= / =pyconsole= / =pyconsole*= / =pygments= / =sympycode= / =sympyblock= / =sympyverbatim= / =sympyconsole= and starred twins.
 
 Adding an unlisted name stops reflow of that environment.
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -106,6 +106,7 @@ These tokens within prose are not split across lines:
 - listings.sty =lstlisting*= is the same raw body scan as =lstlisting=
 - minted.sty =minted*= is the starred twin of =minted= (same raw minted body)
 - tcolorbox listings =tcblisting*= is the starred twin of =tcblisting= (same raw listing body)
+- tcolorbox =tcbverbatimwrite= / =tcbwritetemp= write the env body raw to a file (same class as =VerbatimOut=)
 - spverbatim.sty =spverbatim= is a built-in code region (raw line breaks)
 - pythontex.sty =pyblock= / =pyverbatim= / =pyconsole= / =pycode*= / =pyblock*= / =pyverbatim*= / =pyconsole*= / =pygments= / =sympycode= / =sympyblock= / =sympyverbatim= / =sympyconsole= and starred twins are the same =VerbatimEnvironment= class as =pycode=
 - Extra names from =[latex].verbatim_envs= are code regions too

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,8 @@ pub struct FormatOverrides {
     /// Extra LaTeX environments treated as code (no reflow).
     /// Meaningful under `[latex]` only. Missing or empty keeps the built-in
     /// minted/minted*/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
-    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
+    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample/
+    /// tcbverbatimwrite/tcbwritetemp,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab/listing/listingcont/listing*/listingcont*,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,8 @@ pub struct FormatConfig {
     pub render_backstop: bool,
     /// Extra LaTeX environments treated as code (no reflow), added to
     /// minted/minted*/lstlisting/lstlisting*/verbatim/comment, filecontents, tree-sitter
-    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample,
+    /// trivia, Overleaf Verbatim/boxedverbatim/tcblisting/tcblisting*/codeexample/
+    /// tcbverbatimwrite/tcbwritetemp,
     /// fancyvrb BVerbatim/LVerbatim/SaveVerbatim/VerbatimOut/VerbatimWrite and
     /// Verbatim*/BVerbatim*/LVerbatim*,
     /// moreverb boxedverbatim/verbatimtab/listing/listingcont/listing*/listingcont*,

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -140,7 +140,8 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// `LVerbatim*` / `SaveVerbatim` / `VerbatimOut` / `VerbatimWrite`,
 /// moreverb `boxedverbatim` / `verbatimtab` / `listing` / `listingcont` /
 /// `listing*` / `listingcont*`, tcolorbox `tcblisting` /
-/// `tcblisting*` / `codeexample`, standard `alltt` (alltt.sty: macros
+/// `tcblisting*` / `codeexample` / `tcbverbatimwrite` / `tcbwritetemp`,
+/// standard `alltt` (alltt.sty: macros
 /// still apply, line breaks stay raw; GitHub #230), spverbatim.sty `spverbatim`
 /// (raw body; `\spverb` is the matching delimiter-body command,
 /// GitHub #235), and the `comment` package env (tree-sitter
@@ -155,10 +156,13 @@ static LSTLISTING_LANG_RE: LazyLock<Regex> = LazyLock::new(|| {
 /// `\lstnewenvironment{lstlisting}` also defines `lstlisting*` (same
 /// raw body scan; GitHub #234). tcolorbox listings library
 /// `tcblisting*` is the starred twin of `tcblisting` (same raw listing
-/// body; GitHub #246). moreverb `verbatimtab` is the same tab-expanding
-/// raw class as `boxedverbatim` (GitHub #250). moreverb `listing` /
-/// `listingcont` / `listing*` / `listingcont*` are `verbatim@start` raw
-/// bodies (starred twins do not expand tabs; GitHub #279). minted.sty
+/// body; GitHub #246). tcolorbox `tcbverbatimwrite` / `tcbwritetemp`
+/// write the env body raw to a file (same verbatim grab as
+/// `VerbatimOut`; GitHub #280). moreverb `verbatimtab` is the same
+/// tab-expanding raw class as `boxedverbatim` (GitHub #250). moreverb
+/// `listing` / `listingcont` / `listing*` / `listingcont*` are
+/// `verbatim@start` raw bodies (starred twins do not expand tabs;
+/// GitHub #279). minted.sty
 /// `minted*` is the starred twin of `minted` (same FV@Scan / minted
 /// body; GitHub #273).
 fn is_builtin_code_env(name: &str) -> bool {
@@ -189,6 +193,8 @@ fn is_builtin_code_env(name: &str) -> bool {
             | "tcblisting"
             | "tcblisting*"
             | "codeexample"
+            | "tcbverbatimwrite"
+            | "tcbwritetemp"
             | "spverbatim"
             | "filecontents"
             | "filecontents*"
@@ -3744,6 +3750,119 @@ Some text.
         assert!(
             out.contains("After the block.\nNext."),
             "prose after tcblisting* must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #280): tcolorbox `tcbverbatimwrite` writes
+    /// the env body raw to a file (same verbatim grab as `VerbatimOut`).
+    /// Required `{file}` stays on the begin header; body stays Code;
+    /// following prose still splits.
+    #[test]
+    fn tcolorbox_tcbverbatimwrite_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{tcbverbatimwrite}{out.tex}\n",
+            "First line. Second line.\n",
+            "\\end{tcbverbatimwrite}\n",
+            "After the block. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        let code = regions.iter().find_map(|r| match r {
+            Region::Code {
+                header,
+                body,
+                footer,
+                ..
+            } => Some((header.as_str(), body.as_str(), footer.as_str())),
+            _ => None,
+        });
+        let Some((header, body, footer)) = code else {
+            panic!("tcbverbatimwrite must be Code, got: {regions:?}");
+        };
+        assert!(
+            header.contains(r"\begin{tcbverbatimwrite}{out.tex}"),
+            "required file arg must stay on the begin header, got header={header:?}"
+        );
+        assert!(
+            body.contains("First line. Second line."),
+            "tcbverbatimwrite body must keep both sentences, got body={body:?}"
+        );
+        assert!(
+            footer.contains(r"\end{tcbverbatimwrite}"),
+            "tcbverbatimwrite footer must stay, got footer={footer:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "tcbverbatimwrite body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\begin{tcbverbatimwrite}{out.tex}")
+                && out.contains(r"\end{tcbverbatimwrite}"),
+            "tcbverbatimwrite begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "tcbverbatimwrite body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "tcbverbatimwrite must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after tcbverbatimwrite must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #280): tcolorbox `tcbwritetemp` is the
+    /// no-arg twin that writes to `\jobname.tcbtemp`. Body stays Code;
+    /// following prose still splits.
+    #[test]
+    fn tcolorbox_tcbwritetemp_is_code_not_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "\\begin{tcbwritetemp}\n",
+            "First line. Second line.\n",
+            "\\end{tcbwritetemp}\n",
+            "After the block. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Code { body, .. } if body.contains("First line. Second line.")
+            )),
+            "tcbwritetemp body must be Code, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+            "tcbwritetemp body must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(r"\begin{tcbwritetemp}") && out.contains(r"\end{tcbwritetemp}"),
+            "tcbwritetemp begin/end must stay, got:\n{out}"
+        );
+        assert!(
+            out.contains("First line. Second line."),
+            "tcbwritetemp body must stay one source line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("First line.\nSecond line."),
+            "tcbwritetemp must not reflow as prose, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after tcbwritetemp must still split, got:\n{out}"
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
     }

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -10,6 +10,8 @@
 //! GitHub #273: minted.sty minted* is the starred twin of minted (same raw body).
 //! GitHub #275: fancyvrb \\SaveVerb{name}|body| is the same delimiter body as \\Verb.
 //! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
+//! GitHub #280: tcolorbox tcbverbatimwrite / tcbwritetemp write the env
+//! body raw to a file (same verbatim grab as VerbatimOut).
 //! GitHub #250: moreverb verbatimtab is the same raw class as boxedverbatim.
 //! GitHub #279: moreverb listing / listingcont / listing* / listingcont*
 //! are verbatim@start raw bodies (starred twins do not expand tabs).
@@ -327,6 +329,113 @@ fn tcblisting_star_fixture_is_code_and_does_not_reflow() {
     assert!(
         out.contains("After the block.\nNext."),
         "prose after tcblisting* must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #280): tcolorbox `tcbverbatimwrite` bodies
+/// stay Code; the required `{out.tex}` arg stays on begin; following
+/// prose still splits.
+#[test]
+fn tcbverbatimwrite_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{tcbverbatimwrite}{out.tex}\n",
+        "First line. Second line.\n",
+        "\\end{tcbverbatimwrite}\n",
+        "After the block. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    let code = regions.iter().find_map(|r| match r {
+        Region::Code {
+            header,
+            body,
+            footer,
+            ..
+        } => Some((header.as_str(), body.as_str(), footer.as_str())),
+        _ => None,
+    });
+    let Some((header, body, footer)) = code else {
+        panic!("tcbverbatimwrite must be Code, got: {regions:?}");
+    };
+    assert!(
+        header.contains("\\begin{tcbverbatimwrite}{out.tex}"),
+        "required file arg must stay on the begin header, got header={header:?}"
+    );
+    assert!(
+        body.contains("First line. Second line."),
+        "tcbverbatimwrite body must be Code, got body={body:?}"
+    );
+    assert!(
+        footer.contains("\\end{tcbverbatimwrite}"),
+        "tcbverbatimwrite footer must stay, got footer={footer:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "tcbverbatimwrite body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\begin{tcbverbatimwrite}{out.tex}")
+            && out.contains("\\end{tcbverbatimwrite}"),
+        "tcbverbatimwrite begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "tcbverbatimwrite body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "tcbverbatimwrite must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after tcbverbatimwrite must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #280): tcolorbox `tcbwritetemp` bodies stay
+/// Code; following prose still splits.
+#[test]
+fn tcbwritetemp_fixture_is_code_and_does_not_reflow() {
+    let input = concat!(
+        "\\begin{tcbwritetemp}\n",
+        "First line. Second line.\n",
+        "\\end{tcbwritetemp}\n",
+        "After the block. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Code { body, .. } if body.contains("First line. Second line.")
+        )),
+        "tcbwritetemp body must be Code, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line"))),
+        "tcbwritetemp body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\begin{tcbwritetemp}") && out.contains("\\end{tcbwritetemp}"),
+        "tcbwritetemp begin/end must stay, got:\n{out}"
+    );
+    assert!(
+        out.contains("First line. Second line."),
+        "tcbwritetemp body must stay one source line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("First line.\nSecond line."),
+        "tcbwritetemp must not reflow as prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the block.\nNext."),
+        "prose after tcbwritetemp must still split, got:\n{out}"
     );
     assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 }


### PR DESCRIPTION
vissue: snapper-82mi (parent snapper-etv7). GitHub #280.

unanimous-green-126 drawer 4/4 accept; isolated onto origin/main b04f2fe.

tcolorbox `tcbverbatimwrite` / `tcbwritetemp` write the env body raw
(same grab as `VerbatimOut`). Body stays Code; following `After the
block.` / `Next.` still splits. Landed `tcblisting`, listing, sympy
unchanged.

## Test plan
- terra: rustfmt --check; tcbverbatimwrite lib + fixture