### PR TITLE
chore(conda): refresh source sha256 for v0.11.2 archive

### DIFF
--- a/conda/recipe.yaml
+++ b/conda/recipe.yaml
@@ -11,7 +11,7 @@ package:
 
 source:
   url: https://github.com/TurtleTech-ehf/snapper/archive/refs/tags/v${{ version }}.tar.gz
-  sha256: 8b2e3f3b08c94473382491f642a2bf8ddfe98414e4eb74e217df97901d5d0c47
+  sha256: 3b6fa02fd70e3d25b77b0f40c324cd0d3312a315b56d2371b655569d6ef61467
 
 build:
   number: 0


### PR DESCRIPTION
Refresh `conda/recipe.yaml` sha256 from the published v0.11.2 tag tarball.

`scripts/check_release_ready.sh --post-tag` passes on this tree.
