### PR TITLE
fix(org): treat column-0 diary-sexp as Structure

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -29,6 +29,7 @@ The classification depends on the format.
 - Standalone bracket-link lines (=[[file:plot.png]]=)
 - Table rows (lines starting with =|=)
 - Comment lines (starting with =#= but not =#+= )
+- Column-0 diary-sexp lines (=%%(...)=; org-element-diary-sexp-parser)
 - Full headline lines (stars, optional TODO keyword, and title text)
 - List item markers (=-=, =+=, =1.=); continuation sentences hang at the marker width
 - LaTeX environments (=\begin{equation}= ... =\end{equation}=, =\begin{align}=, etc.)

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -219,6 +219,14 @@ impl OrgParser {
             || t.starts_with("CLOCK:")
     }
 
+    /// org-element-diary-sexp-parser / org-element-paragraph-separate:
+    /// `%%(` at column 0 (group 11 of `org-element--current-element-re`;
+    /// `looking-at "\\(%%(.*\\)[ \t]*$"`). The whole line is `:value`.
+    /// Leading space is a paragraph. Inline timestamps are `<%%(...)>`.
+    fn is_diary_sexp(line: &str) -> bool {
+        line.starts_with("%%(")
+    }
+
     /// org-element-dynamic-block-open-re: `^[ \t]*#\+BEGIN:[ \t]+\S`
     /// (`case-fold-search t`). A name is required; bare `#+BEGIN:` is a keyword.
     fn is_dynamic_block_begin(line: &str) -> bool {
@@ -878,6 +886,14 @@ impl FormatParser for OrgParser {
 
             // Planning / clock stay Structure so they do not join the next paragraph.
             if Self::is_planning_or_clock(line_text) {
+                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+                regions.push(SpannedRegion::structure(input, line.span()));
+                continue;
+            }
+
+            // Column-0 diary-sexp is its own element, not a paragraph
+            // (org-element-diary-sexp-parser; GitHub #309).
+            if Self::is_diary_sexp(line_text) {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
@@ -2594,6 +2610,137 @@ mod tests {
         assert!(
             out.contains("Notes after clock.\nMore notes."),
             "notes after CLOCK: must reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (Format::Org / GitHub #309): column-0 diary-sexp
+    /// is a diary-sexp element, not a paragraph.
+    fn diary_sexp_fixture() -> &'static str {
+        concat!(
+            "%%(or (diary-date 9 11 2026) (eq 1. 2))\n",
+            "After the block. Next.\n",
+        )
+    }
+
+    #[test]
+    fn diary_sexp_line_is_structure_not_joined_prose() {
+        use crate::format_text;
+
+        let input = diary_sexp_fixture();
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s)
+                    if s.contains("%%(or (diary-date 9 11 2026) (eq 1. 2))")
+            )),
+            "column-0 diary-sexp must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("%%(")
+            )),
+            "diary-sexp must not join the following paragraph, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After the block.") && p.contains("Next.")
+            )),
+            "prose after diary-sexp must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("%%(or (diary-date 9 11 2026) (eq 1. 2))\nAfter the block."),
+            "diary-sexp must stay its own line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("%%(or (diary-date 9 11 2026) (eq 1. 2)) After the block."),
+            "diary-sexp must not glue onto the next paragraph, got:\n{out}"
+        );
+        assert!(
+            !out.contains("(eq 1.\n") && !out.contains("1.\n 2)"),
+            "must not split inside the diary-sexp, got:\n{out}"
+        );
+        assert!(
+            out.contains("After the block.\nNext."),
+            "prose after diary-sexp must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn diary_sexp_does_not_change_planning_clock_or_inline_timestamp() {
+        use crate::format_text;
+
+        let input = concat!(
+            "* TODO Task\n",
+            "DEADLINE: <2026-01-01 Wed>\n",
+            "%%(or (diary-date 9 11 2026) (eq 1. 2))\n",
+            "CLOCK: [2026-01-01 Thu 10:00]--[2026-01-01 Thu 11:00] =>  1:00\n",
+            "Meet at <%%(equal (calendar-day-of-week date) 1.)> then leave. Next sentence.\n",
+        );
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("DEADLINE: <2026-01-01 Wed>")
+            )),
+            "DEADLINE: must stay Structure, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("CLOCK:") && s.contains("=>  1:00")
+            )),
+            "CLOCK: must stay Structure, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("%%(or (diary-date 9 11 2026) (eq 1. 2))")
+            )),
+            "column-0 diary-sexp must stay Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains("DEADLINE:") || p.contains("CLOCK:") || p.contains("%%(or")
+            )),
+            "planning/clock/diary-sexp must not join prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p)
+                    if p.contains("<%%(equal (calendar-day-of-week date) 1.)>")
+                        && p.contains("Next sentence.")
+            )),
+            "inline <%%(...)> timestamp must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("* TODO Task\nDEADLINE: <2026-01-01 Wed>\n%%(or (diary-date 9 11 2026) (eq 1. 2))\nCLOCK:"),
+            "DEADLINE / diary-sexp / CLOCK must stay their own lines, got:\n{out}"
+        );
+        assert!(
+            !out.contains("DEADLINE: <2026-01-01 Wed> %%(") && !out.contains("1. 2)) CLOCK:"),
+            "planning/clock must not glue onto the diary-sexp, got:\n{out}"
+        );
+        assert!(
+            out.contains("<%%(equal (calendar-day-of-week date) 1.)>"),
+            "inline diary timestamp must stay one token, got:\n{out}"
+        );
+        assert!(
+            !out.contains("date) 1.\n") && !out.contains("1.\n)>"),
+            "must not split inside <%%(...)>, got:\n{out}"
+        );
+        assert!(
+            out.contains("then leave.\nNext sentence."),
+            "prose after inline timestamp must still reflow, got:\n{out}"
         );
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -661,6 +661,10 @@ fn md_opens_block(line: &str) -> bool {
 }
 
 fn org_opens_block(line: &str) -> bool {
+    // org-element-paragraph-separate: `%%(` is column-0 only.
+    if line.starts_with("%%(") {
+        return true;
+    }
     let t = line.trim_start();
     if t.starts_with('|') {
         return true;
@@ -2919,6 +2923,20 @@ They are endowed with reason and conscience and should act towards one another i
                 "{token} stays with the previous line:\n{result}"
             );
         }
+    }
+
+    #[test]
+    fn wrap_created_org_diary_sexp_is_not_a_block() {
+        let result = wrap_fmt(
+            "The options are apples %%(or extra words here.",
+            23,
+            crate::format::Format::Org,
+        );
+        assert_no_col0_block(&result, &["%%(", "%%(or"]);
+        assert!(
+            result.contains("apples %%("),
+            "%%( stays with the previous line:\n{result}"
+        );
     }
 
     #[test]

--- a/tests/org_diary_sexp.rs
+++ b/tests/org_diary_sexp.rs
@@ -1,0 +1,140 @@
+//! GitHub #309 / snapper-b3qs: a column-0 diary-sexp line is a
+//! diary-sexp element, not a paragraph. `%%(` at BOL stays unjoined;
+//! following prose still splits. CLOCK / DEADLINE / `<%%(...)>` stay.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Org / GitHub #309).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "%%(or (diary-date 9 11 2026) (eq 1. 2))\n",
+        "After the block. Next.\n",
+    )
+}
+
+#[test]
+fn diary_sexp_line_is_structure() {
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s)
+                if s.contains("%%(or (diary-date 9 11 2026) (eq 1. 2))")
+        )),
+        "column-0 diary-sexp must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("%%("))),
+        "diary-sexp must not be Prose, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After the block.") && p.contains("Next.")
+        )),
+        "following prose must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_diary_sexp_unjoined_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "%%(or (diary-date 9 11 2026) (eq 1. 2))\n",
+            "After the block.\n",
+            "Next.\n",
+        ),
+        "%%( line stays unjoined; After the block. / Next. still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("(eq 1.\n") && !out.contains("1.\n 2)"),
+        "must not split inside the diary-sexp, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn clock_deadline_and_inline_diary_timestamp_unchanged() {
+    let input = concat!(
+        "* TODO Task\n",
+        "DEADLINE: <2026-01-01 Wed>\n",
+        "CLOCK: [2026-01-01 Thu 10:00]--[2026-01-01 Thu 11:00] =>  1:00\n",
+        "Meet at <%%(equal (calendar-day-of-week date) 1.)> then leave. Next sentence.\n",
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("* TODO Task\nDEADLINE: <2026-01-01 Wed>\nCLOCK:"),
+        "DEADLINE: must stay its own line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("DEADLINE: <2026-01-01 Wed> CLOCK:"),
+        "DEADLINE: must not glue onto CLOCK:, got:\n{out}"
+    );
+    assert!(
+        out.contains("CLOCK: [2026-01-01 Thu 10:00]--[2026-01-01 Thu 11:00] =>  1:00\nMeet at "),
+        "CLOCK: must stay its own line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("=>  1:00 Meet at"),
+        "CLOCK: must not glue onto the following prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("<%%(equal (calendar-day-of-week date) 1.)>"),
+        "inline <%%(...)> timestamp must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("date) 1.\n") && !out.contains("1.\n)>"),
+        "must not split inside <%%(...)>, got:\n{out}"
+    );
+    assert!(
+        out.contains("then leave.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn indented_diary_sexp_is_not_the_element() {
+    let input = "  %%(or (diary-date 9 11 2026) (eq 1. 2))\nAfter the block. Next.\n";
+    let regions = OrgParser.parse(input);
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("%%(")
+        )),
+        "indented %%( is not org-element diary-sexp (column-0 only), got {regions:?}"
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("After the block.\nNext."),
+        "following prose must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
Closes #309.

Emacs 30.2 `org-element.el`: `org-element-paragraph-separate` matches `%%(` at BOL; group 11 dispatches `org-element-diary-sexp-parser`. The line is a `diary-sexp` element, not a paragraph, so it must not join the next sentence.

`CLOCK` / `DEADLINE` / `<%%(...)>` timestamp objects unchanged.