### PR TITLE
fix(org): treat table-rule lines as structure

### DIFF
--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -89,6 +89,34 @@ pub(crate) fn org_line_break_at(line: &str) -> Option<usize> {
     }
 }
 
+/// org-element-paragraph-separate table-rule (Emacs 30.2 / GitHub #310):
+/// `[ \t]*\+\(?:-+\+\)+[ \t]*$`. `+` then one or more groups of hyphens
+/// plus `+` (`+---+`, `+-----+`). Pipe rows (`|...`) and `-----` rules
+/// are separate.
+pub(crate) fn org_table_rule_line(line: &str) -> bool {
+    let t = line.trim_matches([' ', '\t']);
+    let bytes = t.as_bytes();
+    if bytes.len() < 3 || bytes[0] != b'+' {
+        return false;
+    }
+    let mut i = 1;
+    let mut groups = 0usize;
+    while i < bytes.len() {
+        if bytes[i] != b'-' {
+            return false;
+        }
+        while i < bytes.len() && bytes[i] == b'-' {
+            i += 1;
+        }
+        if i >= bytes.len() || bytes[i] != b'+' {
+            return false;
+        }
+        i += 1;
+        groups += 1;
+    }
+    groups >= 1
+}
+
 /// True when `s` is a spliced org line-break Structure (`\\` plus optional
 /// `[ \t]*` and the line terminator).
 pub(crate) fn is_org_line_break_structure(s: &str) -> bool {
@@ -207,6 +235,11 @@ impl OrgParser {
     fn is_horizontal_rule(line: &str) -> bool {
         let t = line.trim();
         t.len() >= 5 && t.bytes().all(|b| b == b'-')
+    }
+
+    /// org-element-paragraph-separate table-rule (Emacs 30.2 / GitHub #310).
+    fn is_table_rule(line: &str) -> bool {
+        org_table_rule_line(line)
     }
 
     /// org-element planning (`DEADLINE:`/`SCHEDULED:`/`CLOSED:`) or clock (`CLOCK:`).
@@ -855,8 +888,8 @@ impl FormatParser for OrgParser {
                 continue;
             }
 
-            // Table row
-            if Self::is_table_row(line_text) {
+            // Table row (`| ...`) or table-rule (`+---+`).
+            if Self::is_table_row(line_text) || Self::is_table_rule(line_text) {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 regions.push(SpannedRegion::structure(input, line.span()));
                 continue;
@@ -2145,6 +2178,71 @@ mod tests {
         assert!(
             out.contains("Start of next.\nMore."),
             "prose after the rule must reflow independently, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn table_rule_is_structure_boundary() {
+        use crate::format_text;
+
+        let input = "+-----+\nFirst line. Second line.\n+-----+\nAfter the block. Next.\n";
+        let regions = OrgParser.parse(input);
+        assert_eq!(
+            regions
+                .iter()
+                .filter(|r| matches!(r, Region::Structure(s) if s.trim() == "+-----+"))
+                .count(),
+            2,
+            "each +---+ line must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("+-----+"))),
+            "+---+ must not join surrounding prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("First line.") && p.contains("Second line.")
+            )),
+            "prose between table-rules must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("+-----+\nFirst line.\nSecond line.\n+-----+\nAfter the block.\nNext."),
+            "table-rule stays unjoined; flanking prose still splits, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn table_rule_does_not_steal_pipe_rows_or_horizontal_rules() {
+        use crate::format_text;
+
+        let input =
+            "| Name | Age |\n|------+-----|\n| Alice | 30 |\n-----\nAfter the rule. Next.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("|------+-----|")
+            )),
+            "pipe table rule-row must stay a table row, got: {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.trim() == "-----")),
+            "----- must stay a horizontal rule, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains(
+                "| Name | Age |\n|------+-----|\n| Alice | 30 |\n-----\nAfter the rule.\nNext."
+            ),
+            "pipe tables and ----- stay unchanged; following prose splits, got:\n{out}"
         );
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -669,6 +669,9 @@ fn org_opens_block(line: &str) -> bool {
     if t.starts_with('|') {
         return true;
     }
+    if crate::parser::org::org_table_rule_line(t) {
+        return true;
+    }
     if t.starts_with('#') {
         return true;
     }
@@ -2906,6 +2909,20 @@ They are endowed with reason and conscience and should act towards one another i
         assert!(
             result.contains("apples |"),
             "Org skip-cut keeps the pipe:\n{result}"
+        );
+    }
+
+    #[test]
+    fn wrap_created_org_table_rule_is_not_a_block() {
+        let result = wrap_fmt(
+            "The options are apples +-----+",
+            23,
+            crate::format::Format::Org,
+        );
+        assert_no_col0_block(&result, &["+-----+"]);
+        assert!(
+            result.contains("apples +-----+"),
+            "Org skip-cut keeps the table-rule token:\n{result}"
         );
     }
 

--- a/tests/org_table_rule.rs
+++ b/tests/org_table_rule.rs
@@ -1,0 +1,128 @@
+//! GitHub #310 / snapper-oac5: Org table-rule lines stay unjoined.
+//! Emacs 30.2 `org-element-paragraph-separate` matches `+` followed by
+//! one or more `-+` groups (`+---+`). That line ends a paragraph.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Org).
+fn table_rule_fixture() -> &'static str {
+    concat!(
+        "+-----+\n",
+        "First line. Second line.\n",
+        "+-----+\n",
+        "After the block. Next.\n",
+    )
+}
+
+#[test]
+fn table_rule_lines_are_structure() {
+    let regions = OrgParser.parse(table_rule_fixture());
+    assert_eq!(
+        regions
+            .iter()
+            .filter(|r| matches!(r, Region::Structure(s) if s.trim() == "+-----+"))
+            .count(),
+        2,
+        "each +---+ line must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("+-----+"))),
+        "table-rule must not join following prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_rules_and_splits_flanking_prose() {
+    let input = table_rule_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "+-----+\n",
+            "First line.\n",
+            "Second line.\n",
+            "+-----+\n",
+            "After the block.\n",
+            "Next.\n",
+        ),
+        "each +---+ stays unjoined; First line. / Second line. and After the block. / Next. still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    assert!(
+        snapper_fmt::oracle::matches(Format::Org, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn pipe_org_tables_and_horizontal_rules_unchanged() {
+    let input = concat!(
+        "| Name | Age |\n",
+        "|------+-----|\n",
+        "| Alice | 30 |\n",
+        "-----\n",
+        "After the rule. Next.\n",
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "| Name | Age |\n",
+            "|------+-----|\n",
+            "| Alice | 30 |\n",
+            "-----\n",
+            "After the rule.\n",
+            "Next.\n",
+        ),
+        "pipe tables and ----- stay; following prose still splits, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn indented_and_multi_cell_table_rules_are_structure() {
+    let input = concat!(
+        "  +---+---+\n",
+        "Between. More.\n",
+        "+-+\n",
+        "After. Next.\n",
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "  +---+---+\n",
+            "Between.\n",
+            "More.\n",
+            "+-+\n",
+            "After.\n",
+            "Next.\n",
+        ),
+        "indented / short table-rules stay unjoined, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn incomplete_plus_dash_line_is_still_prose() {
+    let input = "+-----\nFirst line. Second line.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out, "+----- First line.\nSecond line.\n",
+        "+----- without a closing + stays Prose and joins the next line, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #310.

Emacs 30.2 `org-element.el`: `org-element-paragraph-separate` includes `+` followed by one or more `-+` groups (`+---+`). That line ends a paragraph. A full table.el table is a later check; a lone rule is still not joined into the next paragraph.

Cherry-picked 5835e66 onto origin/main 3c25ffa (auto-merged with diary-sexp). Terra: `org_table_rule` 5/5, `org_diary_sexp` 4/4, lib table_rule+diary_sexp 7/7, dogfood `--native --check` exit 0.

Pipe org tables and `-----` horizontal rules unchanged.