### PR TITLE
fix(org): treat mixed-case planning and clock as Structure

### DIFF
--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -243,13 +243,17 @@ impl OrgParser {
     }
 
     /// org-element planning (`DEADLINE:`/`SCHEDULED:`/`CLOSED:`) or clock (`CLOCK:`).
-    /// Leading space/tab is allowed; keywords are the default org strings.
+    /// Leading space/tab is allowed. `org-element--current-element` binds
+    /// `case-fold-search` t before `org-element-planning-line-re` and
+    /// `org-element-clock-line-re`, so prefixes compare ignore ASCII case.
     fn is_planning_or_clock(line: &str) -> bool {
         let t = line.trim_start_matches([' ', '\t']);
-        t.starts_with("DEADLINE:")
-            || t.starts_with("SCHEDULED:")
-            || t.starts_with("CLOSED:")
-            || t.starts_with("CLOCK:")
+        const KEYS: [&str; 4] = ["DEADLINE:", "SCHEDULED:", "CLOSED:", "CLOCK:"];
+        KEYS.iter().any(|k| {
+            t.as_bytes()
+                .get(..k.len())
+                .is_some_and(|head| head.eq_ignore_ascii_case(k.as_bytes()))
+        })
     }
 
     /// org-element-diary-sexp-parser / org-element-paragraph-separate:
@@ -2627,6 +2631,131 @@ mod tests {
         assert!(
             out.contains("Body starts here.\nSecond sentence."),
             "prose after planning must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    /// GitHub #319 / snapper-svbp: Emacs binds `case-fold-search` t, so
+    /// lowercase planning/clock stay Structure and do not join prose.
+    fn svbp_lowercase_deadline_fixture() -> &'static str {
+        "deadline: <2026-01-01 Wed>\nAfter planning. Next sentence.\n"
+    }
+
+    #[test]
+    fn lowercase_deadline_is_structure_not_joined_prose() {
+        use crate::format_text;
+
+        let input = svbp_lowercase_deadline_fixture();
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("deadline: <2026-01-01 Wed>")
+            )),
+            "deadline: must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("deadline:")
+            )),
+            "deadline: must not join the following paragraph, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After planning.") && p.contains("Next sentence.")
+            )),
+            "prose after deadline: must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("deadline: <2026-01-01 Wed>\nAfter planning."),
+            "deadline: must stay its own line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("deadline: <2026-01-01 Wed> After planning."),
+            "deadline: must not glue onto the next paragraph, got:\n{out}"
+        );
+        assert!(
+            out.contains("After planning.\nNext sentence."),
+            "prose after deadline: must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn lowercase_clock_is_structure_not_joined_prose() {
+        use crate::format_text;
+
+        let input = "clock: [2026-01-01 Thu 10:00]\nAfter planning. Next sentence.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("clock: [2026-01-01 Thu 10:00]")
+            )),
+            "clock: must be Structure, got: {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("clock:"))),
+            "clock: must not join the following paragraph, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("clock: [2026-01-01 Thu 10:00]\nAfter planning."),
+            "clock: must stay its own line, got:\n{out}"
+        );
+        assert!(
+            !out.contains("clock: [2026-01-01 Thu 10:00] After planning."),
+            "clock: must not glue onto the next paragraph, got:\n{out}"
+        );
+        assert!(
+            out.contains("After planning.\nNext sentence."),
+            "prose after clock: must still reflow, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    #[test]
+    fn mixed_case_planning_and_clock_are_structure() {
+        use crate::format_text;
+
+        let input = concat!(
+            "* TODO Task\n",
+            "Deadline: <2026-01-01 Wed>\n",
+            "Scheduled: <2026-01-02 Thu>\n",
+            "Closed: [2026-01-01 Wed 09:00]\n",
+            "Clock: [2026-01-01 Thu 10:00]\n",
+            "After planning. Next sentence.\n",
+        );
+        let regions = OrgParser.parse(input);
+        for token in ["Deadline:", "Scheduled:", "Closed:", "Clock:"] {
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Structure(s) if s.contains(token)
+                )),
+                "{token} must be Structure, got: {regions:?}"
+            );
+            assert!(
+                !regions.iter().any(|r| matches!(
+                    r,
+                    Region::Prose(p) if p.contains(token)
+                )),
+                "{token} must not join prose, got: {regions:?}"
+            );
+        }
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("Deadline: <2026-01-01 Wed>\nScheduled: <2026-01-02 Thu>\nClosed: [2026-01-01 Wed 09:00]\nClock: [2026-01-01 Thu 10:00]\nAfter planning."),
+            "mixed-case planning/clock must stay their own lines, got:\n{out}"
+        );
+        assert!(
+            out.contains("After planning.\nNext sentence."),
+            "prose after mixed-case planning must still reflow, got:\n{out}"
         );
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -695,12 +695,16 @@ fn org_opens_block(line: &str) -> bool {
 }
 
 /// org-element planning (`DEADLINE:`/`SCHEDULED:`/`CLOSED:`) or clock (`CLOCK:`).
+/// `org-element--current-element` binds `case-fold-search` t, so prefixes
+/// compare ignore ASCII case (GitHub #319).
 fn org_planning_or_clock(line: &str) -> bool {
     let t = line.trim_start_matches([' ', '\t']);
-    t.starts_with("DEADLINE:")
-        || t.starts_with("SCHEDULED:")
-        || t.starts_with("CLOSED:")
-        || t.starts_with("CLOCK:")
+    const KEYS: [&str; 4] = ["DEADLINE:", "SCHEDULED:", "CLOSED:", "CLOCK:"];
+    KEYS.iter().any(|k| {
+        t.as_bytes()
+            .get(..k.len())
+            .is_some_and(|head| head.eq_ignore_ascii_case(k.as_bytes()))
+    })
 }
 
 /// org-element drawer opener: `:NAME:` with NAME=`[A-Za-z_-]+`, not `:END:`.
@@ -2928,7 +2932,18 @@ They are endowed with reason and conscience and should act towards one another i
 
     #[test]
     fn wrap_created_org_planning_or_clock_is_not_a_block() {
-        for token in ["DEADLINE:", "SCHEDULED:", "CLOSED:", "CLOCK:"] {
+        for token in [
+            "DEADLINE:",
+            "SCHEDULED:",
+            "CLOSED:",
+            "CLOCK:",
+            "deadline:",
+            "scheduled:",
+            "closed:",
+            "clock:",
+            "Deadline:",
+            "Clock:",
+        ] {
             let result = wrap_fmt(
                 &format!("The options are apples {token} extra words here."),
                 23,

--- a/tests/org_planning_case.rs
+++ b/tests/org_planning_case.rs
@@ -1,0 +1,165 @@
+//! GitHub #319 / snapper-svbp: org-element planning and clock lines
+//! match ignore ASCII case. Emacs 30.2 binds `case-fold-search` t
+//! before `org-element-planning-line-re` and `org-element-clock-line-re`.
+//! Lowercase `deadline:` / `clock:` stay unjoined; following prose still
+//! splits. Uppercase `DEADLINE:` / `CLOCK:` and inline timestamps stay.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Org / GitHub #319).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "deadline: <2026-01-01 Wed>\n",
+        "After planning. Next sentence.\n",
+    )
+}
+
+#[test]
+fn lowercase_deadline_is_structure() {
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("deadline: <2026-01-01 Wed>")
+        )),
+        "deadline: must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("deadline:"))),
+        "deadline: must not be Prose, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After planning.") && p.contains("Next sentence.")
+        )),
+        "following prose must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_lowercase_deadline_unjoined_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "deadline: <2026-01-01 Wed>\n",
+            "After planning.\n",
+            "Next sentence.\n",
+        ),
+        "deadline: stays unjoined; After planning. / Next sentence. still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn lowercase_clock_stays_unjoined() {
+    let input = "clock: [2026-01-01 Thu 10:00]\nAfter planning. Next sentence.\n";
+    let regions = OrgParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("clock: [2026-01-01 Thu 10:00]")
+        )),
+        "clock: must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("clock:"))),
+        "clock: must not be Prose, got {regions:?}"
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "clock: [2026-01-01 Thu 10:00]\n",
+            "After planning.\n",
+            "Next sentence.\n",
+        ),
+        "clock: stays unjoined; After planning. / Next sentence. still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn lowercase_scheduled_and_closed_stay_unjoined() {
+    let input = concat!(
+        "scheduled: <2026-01-02 Thu>\n",
+        "closed: [2026-01-01 Wed 09:00]\n",
+        "After planning. Next sentence.\n",
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "scheduled: <2026-01-02 Thu>\n",
+            "closed: [2026-01-01 Wed 09:00]\n",
+            "After planning.\n",
+            "Next sentence.\n",
+        ),
+        "scheduled:/closed: stay unjoined, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn uppercase_deadline_clock_and_inline_timestamps_unchanged() {
+    let input = concat!(
+        "* TODO Task\n",
+        "DEADLINE: <2026-01-01 Wed>\n",
+        "CLOCK: [2026-01-01 Thu 10:00]--[2026-01-01 Thu 11:00] =>  1:00\n",
+        "Meet at <2026-01-01 Wed> then leave. Next sentence.\n",
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("* TODO Task\nDEADLINE: <2026-01-01 Wed>\nCLOCK:"),
+        "uppercase DEADLINE: must stay its own line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("DEADLINE: <2026-01-01 Wed> CLOCK:"),
+        "uppercase DEADLINE: must not glue onto CLOCK:, got:\n{out}"
+    );
+    assert!(
+        out.contains("CLOCK: [2026-01-01 Thu 10:00]--[2026-01-01 Thu 11:00] =>  1:00\nMeet at "),
+        "uppercase CLOCK: must stay its own line, got:\n{out}"
+    );
+    assert!(
+        !out.contains("=>  1:00 Meet at"),
+        "uppercase CLOCK: must not glue onto following prose, got:\n{out}"
+    );
+    assert!(
+        out.contains("<2026-01-01 Wed>"),
+        "inline timestamp must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("then leave.\nNext sentence."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
Closes #319.

Emacs 30.2 `org-element.el`: `org-element--current-element` binds `case-fold-search` t before `org-element-planning-line-re` and `org-element-clock-line-re`. `deadline:` / `clock:` (any ASCII case) are planning/clock elements, not paragraphs.

Cherry-picked 41f5068 onto origin/main 8bd3352. Terra: `org_planning_case` / `org_table_rule` / `org_diary_sexp` green, lib planning+diary+table_rule green, dogfood `--native --check` exit 0.

Uppercase `DEADLINE:` / `CLOCK:` and inline timestamps unchanged.