### PR TITLE
fix(org): treat Emacs word-char drawer names as structure

### DIFF
--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -148,6 +148,20 @@ struct OpenGreater {
     kind: GreaterKind,
 }
 
+/// org-element-drawer-re NAME: `(any ?- ?_ word)` — hyphen, underscore,
+/// or Unicode word characters (letters and digits). `:END:` is the closer.
+pub(crate) fn is_org_drawer_begin(line: &str) -> bool {
+    let trimmed = line.trim();
+    let Some(name) = trimmed.strip_prefix(':').and_then(|s| s.strip_suffix(':')) else {
+        return false;
+    };
+    !name.is_empty()
+        && !name.eq_ignore_ascii_case("END")
+        && name
+            .chars()
+            .all(|c| c == '-' || c == '_' || c.is_alphanumeric())
+}
+
 pub struct OrgParser;
 
 impl OrgParser {
@@ -207,17 +221,9 @@ impl OrgParser {
         Self::block_end_name(line).as_deref() == Some("SRC")
     }
 
-    /// org-element drawer: `:NAME:` with NAME = `[A-Za-z_-]+`. Not `:END:`.
+    /// org-element-drawer-re NAME: `(any ?- ?_ word)`. Not `:END:`.
     fn is_drawer_begin(line: &str) -> bool {
-        let trimmed = line.trim();
-        let Some(name) = trimmed.strip_prefix(':').and_then(|s| s.strip_suffix(':')) else {
-            return false;
-        };
-        !name.is_empty()
-            && !name.eq_ignore_ascii_case("END")
-            && name
-                .bytes()
-                .all(|b| matches!(b, b'A'..=b'Z' | b'a'..=b'z' | b'_' | b'-'))
+        is_org_drawer_begin(line)
     }
 
     /// Check if a line ends a drawer
@@ -2286,6 +2292,65 @@ mod tests {
             "prose after :END: must reflow, got:\n{out}"
         );
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+
+    /// GitHub #318 / snapper-p6ng: NAME is hyphen, underscore, or word.
+    #[test]
+    fn is_org_drawer_begin_matches_emacs_word_hyphen() {
+        assert!(is_org_drawer_begin(":LOG1:"));
+        assert!(is_org_drawer_begin(":föö:"));
+        assert!(is_org_drawer_begin(":1:"));
+        assert!(is_org_drawer_begin(":ID2:"));
+        assert!(is_org_drawer_begin(":LOGBOOK:"));
+        assert!(is_org_drawer_begin("  :LOG1:  "));
+        assert!(!is_org_drawer_begin(":END:"));
+        assert!(!is_org_drawer_begin(":end:"));
+        assert!(!is_org_drawer_begin(":See also:"));
+        assert!(!is_org_drawer_begin(": text"));
+        assert!(!is_org_drawer_begin(":"));
+        assert!(!is_org_drawer_begin("::"));
+    }
+
+    /// GitHub #318 / snapper-p6ng: Emacs `org-element-drawer-re` NAME is
+    /// `(any ?- ?_ word)`, so digits and unicode letters open a drawer.
+    #[test]
+    fn word_char_drawer_names_are_structure_until_end() {
+        use crate::format_text;
+
+        for name in ["LOG1", "föö", "1", "ID2"] {
+            let input = format!(":{name}:\npayload text. More text.\n:END:\nAfter drawer. Next.\n");
+            let regions = OrgParser.parse(&input);
+            assert!(
+                regions
+                    .iter()
+                    .any(|r| matches!(r, Region::Structure(s) if s.contains(&format!(":{name}:")))),
+                ":{name}: must be a drawer opener, got: {regions:?}"
+            );
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Structure(s) if s.contains("payload text. More text.")
+                )),
+                ":{name}: body must stay Structure, got: {regions:?}"
+            );
+            assert!(
+                !regions.iter().any(|r| matches!(
+                    r,
+                    Region::Prose(p) if p.contains("payload text.")
+                )),
+                ":{name}: body must not become Prose, got: {regions:?}"
+            );
+            let out = format_text(&input, &org_cfg()).unwrap();
+            assert!(
+                out.contains(&format!(":{name}:\npayload text. More text.\n:END:")),
+                ":{name}: drawer must not reflow, got:\n{out}"
+            );
+            assert!(
+                out.contains("After drawer.\nNext."),
+                "prose after :{name}: :END: must reflow, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+        }
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -685,7 +685,7 @@ fn org_opens_block(line: &str) -> bool {
     if t.starts_with("$$") {
         return true;
     }
-    if org_drawer_begin(t) || org_fixed_width(t) || org_horizontal_rule(t) {
+    if crate::parser::org::is_org_drawer_begin(t) || org_fixed_width(t) || org_horizontal_rule(t) {
         return true;
     }
     if org_planning_or_clock(t) {
@@ -705,19 +705,6 @@ fn org_planning_or_clock(line: &str) -> bool {
             .get(..k.len())
             .is_some_and(|head| head.eq_ignore_ascii_case(k.as_bytes()))
     })
-}
-
-/// org-element drawer opener: `:NAME:` with NAME=`[A-Za-z_-]+`, not `:END:`.
-fn org_drawer_begin(line: &str) -> bool {
-    let t = line.trim();
-    let Some(name) = t.strip_prefix(':').and_then(|s| s.strip_suffix(':')) else {
-        return false;
-    };
-    !name.is_empty()
-        && name
-            .bytes()
-            .all(|b| b.is_ascii_alphabetic() || b == b'_' || b == b'-')
-        && !name.eq_ignore_ascii_case("END")
 }
 
 /// org-element fixed-width: colon then a space, or a lone colon.

--- a/tests/org_drawer_word_names.rs
+++ b/tests/org_drawer_word_names.rs
@@ -1,0 +1,71 @@
+//! GitHub #318 / snapper-p6ng: Org drawer names follow Emacs
+//! `org-element-drawer-re` NAME = `(any ?- ?_ word)`.
+//! Digits and unicode letters open a drawer; `:See also:` does not.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Org / GitHub #318).
+fn word_drawer_fixture(name: &str) -> String {
+    format!(":{name}:\npayload text. More text.\n:END:\nAfter drawer. Next.\n")
+}
+
+#[test]
+fn digit_and_unicode_drawer_names_freeze_body() {
+    for name in ["LOG1", "föö", "1", "ID2"] {
+        let input = word_drawer_fixture(name);
+        let out = format_text(&input, &org_cfg()).unwrap();
+        assert_eq!(
+            out,
+            format!(":{name}:\npayload text. More text.\n:END:\nAfter drawer.\nNext.\n"),
+            ":{name}: must open a drawer; body frozen including :END:, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+}
+
+#[test]
+fn ascii_logbook_stays_structure() {
+    let input = ":LOGBOOK:\nCLOCK: [2026-01-01] First. Second.\n:END:\nAfter drawer. Next.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out, ":LOGBOOK:\nCLOCK: [2026-01-01] First. Second.\n:END:\nAfter drawer.\nNext.\n",
+        "ASCII :LOGBOOK: must stay a drawer, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn see_also_is_not_a_drawer() {
+    let input = ":See also:\nThis is a note. Second sentence.\nAfter the note. More.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("This is a note.\nSecond sentence."),
+        ":See also: is not a NAME; notes must reflow, got:\n{out}"
+    );
+    assert!(
+        out.contains("After the note.\nMore."),
+        ":See also: must not swallow following prose, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn fixed_width_colon_space_unchanged() {
+    let input = ": First sentence. Second sentence.\nAfter fixed. More after.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out, ": First sentence. Second sentence.\nAfter fixed.\nMore after.\n",
+        "fixed-width : text must stay frozen, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
Closes #318.

Emacs 30.2 `org-element-drawer-re` NAME is `(any ?- ?_ word)`: hyphen, underscore, or word-syntax (digits and unicode letters). `:LOG1:` / `:föö:` / `:1:` / `:ID2:` open a drawer. `:END:` / `:See also:` / fixed-width `: text` / ASCII `:LOGBOOK:` unchanged.

Cherry-picked 4d6c9dc onto origin/main 1af87b0 (auto-merged with planning case-fold). Terra: drawer/planning/table-rule/diary tests green, dogfood `--native --check` exit 0.