### PR TITLE
fix(org): treat empty list bullets at EOL as Structure

### DIFF
--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -9,11 +9,12 @@ use crate::parser::{
 static HEADLINE_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^(\*+\s+(?:TODO\s+|DONE\s+|NEXT\s+|WAIT\s+)?)(.*)$").unwrap());
 
-/// Org unordered/ordered marker plus a trailing space.
+/// Org unordered/ordered marker plus a trailing space or EOL.
+/// Emacs 30.2 `org-item-re` is bullet then `[ \t]+` or `$` (GitHub #320).
 /// org-syntax 4.2.6 / orgize: `*` is a bullet only when indent > 0;
 /// column-0 `*` is a headline (`HEADLINE_RE` is matched first).
 static LIST_ITEM_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^(\s*(?:[-+]|\d+[.)]) |[ \t]+\* )(.*)$").unwrap());
+    LazyLock::new(|| Regex::new(r"^(\s*(?:[-+]|\d+[.)])(?: |$)|[ \t]+\*(?: |$))(.*)$").unwrap());
 
 /// Matches LaTeX \begin{env} lines embedded in org prose.
 static LATEX_BEGIN_RE: LazyLock<Regex> =
@@ -1279,6 +1280,66 @@ mod tests {
         assert_eq!(regions.len(), 5);
         assert_eq!(regions[0], Region::Structure("- ".to_string()));
         assert_eq!(regions[1], Region::Prose("First item text".to_string()));
+    }
+
+    /// GitHub #320: Emacs `org-item-re` accepts a bullet at EOL.
+    #[test]
+    fn empty_list_item_at_eol_is_structure() {
+        let input =
+            "Intro sentence here. Another intro sentence.\n-\nAfter empty item. Next sentence.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "-")),
+            "lone - at EOL must be a list marker, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains('-') && p.contains("After empty item.")
+            )),
+            "empty dash must not join the following prose, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After empty item.") && p.contains("Next sentence.")
+            )),
+            "following prose must stay Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn numbered_empty_item_at_eol_is_structure_not_uax() {
+        let input =
+            "Intro sentence here. Another intro sentence.\n1.\nAfter empty item. Next sentence.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == "1.")),
+            "1. at EOL must be a list marker, not a UAX sentence, got {regions:?}"
+        );
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(p) if p.contains("1."))),
+            "1. at EOL must not stay Prose, got {regions:?}"
+        );
+    }
+
+    #[test]
+    fn column_0_star_at_eol_is_not_a_list() {
+        let input =
+            "Intro sentence here. Another intro sentence.\n*\nAfter empty item. Next sentence.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.trim() == "*")),
+            "column-0 * is a headline, not a list, got {regions:?}"
+        );
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -679,7 +679,9 @@ fn org_opens_block(line: &str) -> bool {
     if stars > 0 {
         return t.len() == stars || matches!(t.as_bytes()[stars], b' ' | b'\t');
     }
-    if t.starts_with("- ") || t.starts_with("+ ") {
+    // Emacs org-item-re: `-`/`+` then space or EOL. Lone markers must
+    // not be wrap-created at column 0 (GitHub #320).
+    if t == "-" || t == "+" || t.starts_with("- ") || t.starts_with("+ ") {
         return true;
     }
     if t.starts_with("$$") {
@@ -2956,6 +2958,22 @@ They are endowed with reason and conscience and should act towards one another i
             result.contains("apples %%("),
             "%%( stays with the previous line:\n{result}"
         );
+    }
+
+    #[test]
+    fn wrap_created_org_empty_list_marker_is_not_a_block() {
+        for token in ["-", "+", "1.", "1)"] {
+            let result = wrap_fmt(
+                &format!("The options are apples {token} extra words here."),
+                23,
+                crate::format::Format::Org,
+            );
+            assert_no_col0_block(&result, &[token]);
+            assert!(
+                result.contains(&format!("apples {token}")),
+                "{token} stays with the previous line:\n{result}"
+            );
+        }
     }
 
     #[test]

--- a/tests/org_empty_list_item.rs
+++ b/tests/org_empty_list_item.rs
@@ -1,0 +1,183 @@
+//! GitHub #320 / snapper-fsdk: Emacs 30.2 `org-item-re` allows a
+//! bullet then whitespace or EOL. A lone `-` / `+` / `1)` / `1.` /
+//! indented `*` is Structure; following prose still splits. Column-0
+//! `*` is a headline, not a list. Trailing-space markers stay.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Org / GitHub #320).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        "-\n",
+        "After empty item. Next sentence.\n",
+    )
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        "Intro sentence here.\n",
+        "Another intro sentence.\n",
+        "-\n",
+        "After empty item.\n",
+        "Next sentence.\n",
+    )
+}
+
+fn wrapped(marker: &str) -> String {
+    format!(
+        "Intro sentence here. Another intro sentence.\n{marker}\nAfter empty item. Next sentence.\n"
+    )
+}
+
+fn expected_wrapped(marker: &str) -> String {
+    format!(
+        "Intro sentence here.\nAnother intro sentence.\n{marker}\nAfter empty item.\nNext sentence.\n"
+    )
+}
+
+#[test]
+fn empty_dash_is_structure() {
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "-")),
+        "lone - at EOL must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains('-') && p.contains("After empty item.")
+        )),
+        "empty dash must not join the following prose, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After empty item.") && p.contains("Next sentence.")
+        )),
+        "following prose must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_empty_dash_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn empty_plus_is_list_marker() {
+    let input = wrapped("+");
+    let regions = OrgParser.parse(&input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "+")),
+        "lone + at EOL must be Structure, got {regions:?}"
+    );
+    let out = format_text(&input, &org_cfg()).unwrap();
+    assert_eq!(out, expected_wrapped("+"), "got:\n{out}");
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn empty_paren_number_is_list_marker() {
+    let input = wrapped("1)");
+    let regions = OrgParser.parse(&input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "1)")),
+        "lone 1) at EOL must be Structure, got {regions:?}"
+    );
+    let out = format_text(&input, &org_cfg()).unwrap();
+    assert_eq!(out, expected_wrapped("1)"), "got:\n{out}");
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn empty_dot_number_is_list_marker_not_uax_sentence() {
+    let input = wrapped("1.");
+    let regions = OrgParser.parse(&input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "1.")),
+        "1. at EOL must be a list marker, not a UAX sentence, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("1."))),
+        "1. at EOL must not stay Prose, got {regions:?}"
+    );
+    let out = format_text(&input, &org_cfg()).unwrap();
+    assert_eq!(out, expected_wrapped("1."), "got:\n{out}");
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn empty_indented_star_is_list_marker() {
+    let input = wrapped("  *");
+    let regions = OrgParser.parse(&input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "  *")),
+        "indented * at EOL must be Structure, got {regions:?}"
+    );
+    let out = format_text(&input, &org_cfg()).unwrap();
+    assert_eq!(out, expected_wrapped("  *"), "got:\n{out}");
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn column_0_star_is_not_a_list() {
+    let input = wrapped("*");
+    let regions = OrgParser.parse(&input);
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.trim() == "*")),
+        "column-0 * is a headline, not a list, got {regions:?}"
+    );
+}
+
+#[test]
+fn trailing_space_markers_unchanged() {
+    for input in [
+        "- item\n",
+        "1. Hello world.\n",
+        "1) Hello world.\n",
+        "  * child\n",
+    ] {
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert_eq!(out, input, "trailing-space marker must stay, got:\n{out}");
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+    }
+    let regions = OrgParser.parse("- item\n");
+    assert_eq!(regions[0], Region::Structure("- ".to_string()));
+    assert_eq!(regions[1], Region::Prose("item".to_string()));
+    let numbered = OrgParser.parse("1. Hello world.\n");
+    assert_eq!(numbered[0], Region::Structure("1. ".to_string()));
+    assert_eq!(numbered[1], Region::Prose("Hello world.".to_string()));
+    let paren = OrgParser.parse("1) Hello world.\n");
+    assert_eq!(paren[0], Region::Structure("1) ".to_string()));
+    assert_eq!(paren[1], Region::Prose("Hello world.".to_string()));
+}


### PR DESCRIPTION
Closes #320.

Emacs 30.2 `org-item-re` allows a bullet then whitespace or EOL. Snapper `LIST_ITEM_RE` required a trailing space, so a lone `-` / `+` / `1)` / indented `*` joined the next paragraph (CLI `--native` identity-hid this via `render_backstop`).

Cherry-picked cebed79 onto origin/main c23c3e9. Terra: empty-list 8/8, drawer/planning/table-rule/diary green, lib 11/11, dogfood `--native --check` exit 0.

Column-0 `*` stays a headline. Trailing-space markers unchanged.