### PR TITLE
fix(rst): treat empty and unicode Docutils bullets as Structure

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -420,10 +420,15 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // Docutils opens a list only after a blank, a structure line,
         // or the start of the document. A list-like line that follows
         // an open paragraph with no blank stays in that paragraph
-        // (GitHub #134). Once a list is open (`list_hang`), the next
-        // marker is the next item.
+        // (GitHub #134). Empty ASCII `-`/`*` at EOL and unicode bullets
+        // (`•`/`‣`/`⁃`, with or without payload) interrupt (GitHub #324).
+        // Once a list is open (`list_hang`), the next marker is the
+        // next item.
         if let Some(marker_len) = rst_list_marker_len(line_text) {
-            if !current_prose.is_empty() && list_hang.is_none() {
+            if !current_prose.is_empty()
+                && list_hang.is_none()
+                && !rst_docutils_bullet_interrupts_paragraph(line_text)
+            {
                 push_prose_line(&mut current_prose, &mut prose_span, line, true, true);
                 i += 1;
                 continue;
@@ -790,11 +795,16 @@ pub(crate) fn rst_option_column_len(line: &str) -> Option<usize> {
 }
 
 /// Byte length of one compact RST list opener at the start of `t`
-/// (no leading indent): `* `, `- `, `+ ` (not a `+--+` table rule), or a
-/// Docutils enumerator plus the following space.
+/// (no leading indent). Docutils `Body.patterns` bullet is
+/// `[-+*\u2022\u2023\u2043]( +|$)`. ASCII `*` / `-` match a trailing
+/// space or EOL. Unicode `•` / `‣` / `⁃` match the same. Lone `+` is a
+/// grid-table leftover fragment, not a list opener (GitHub #324).
 fn rst_one_list_marker_len(t: &str) -> Option<usize> {
     if t.starts_with("* ") || t.starts_with("- ") {
         return Some(2);
+    }
+    if t == "*" || t == "-" {
+        return Some(1);
     }
     if let Some(after) = t.strip_prefix("+ ") {
         if after.starts_with('-') || after.starts_with('+') {
@@ -802,13 +812,30 @@ fn rst_one_list_marker_len(t: &str) -> Option<usize> {
         }
         return Some(2);
     }
+    for bullet in ["•", "‣", "⁃"] {
+        if t == bullet {
+            return Some(bullet.len());
+        }
+        if t.starts_with(bullet) && t[bullet.len()..].starts_with(' ') {
+            return Some(bullet.len() + 1);
+        }
+    }
     rst_enumerator_marker_len(t)
 }
 
+/// Empty ASCII `-`/`*` at EOL and unicode Docutils bullets interrupt an
+/// open paragraph. Trailing-space ASCII `* ` / `- ` / `+ ` still follow
+/// GitHub #134 (GitHub #324).
+fn rst_docutils_bullet_interrupts_paragraph(line: &str) -> bool {
+    let t = line.trim_start();
+    t == "-" || t == "*" || t.starts_with('•') || t.starts_with('‣') || t.starts_with('⁃')
+}
+
 /// Byte length of a compact RST list opener on `line`, including the
-/// trailing space: `* `, `- `, `+ ` (not a `+--+` table rule), or a
+/// trailing space: `* `, `- `, `+ ` (not a `+--+` table rule), empty
+/// `-`/`*` at EOL, unicode `•`/`‣`/`⁃` plus space or EOL, or a
 /// Docutils enumerator (`1.`, `a.`, `i.`, `#.`, `1)`, `(1)`) plus the
-/// following space (GitHub #91).
+/// following space (GitHub #91, #324).
 ///
 /// Same-line nested markers (`- - item`, `- 1. item`) are consumed so
 /// the hang is the inner item width. A two-space continuation after
@@ -3434,6 +3461,18 @@ mod tests {
         assert_eq!(rst_list_marker_len("*  "), Some(3));
         assert_eq!(rst_list_marker_len("-  Term"), Some(3));
         assert_eq!(rst_list_marker_len("  *  Nested"), Some(5));
+        assert_eq!(rst_list_marker_len("-"), Some(1));
+        assert_eq!(rst_list_marker_len("*"), Some(1));
+        assert_eq!(rst_list_marker_len("  -"), Some(3));
+        assert_eq!(rst_list_marker_len("+"), None);
+        assert_eq!(rst_list_marker_len("•"), Some("•".len()));
+        assert_eq!(rst_list_marker_len("‣"), Some("‣".len()));
+        assert_eq!(rst_list_marker_len("⁃"), Some("⁃".len()));
+        assert_eq!(rst_list_marker_len("• After empty item."), Some("• ".len()));
+        assert_eq!(rst_list_marker_len("‣ payload"), Some("‣ ".len()));
+        assert_eq!(rst_list_marker_len("⁃ payload"), Some("⁃ ".len()));
+        assert_eq!(rst_list_marker_len("•After"), None);
+        assert_eq!(rst_list_marker_len("-item"), None);
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2977,6 +2977,22 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn wrap_created_rst_empty_bullet_is_not_a_block() {
+        for token in ["-", "*", "•", "‣", "⁃"] {
+            let result = wrap_fmt(
+                &format!("The options are apples {token} extra words here."),
+                23,
+                crate::format::Format::Rst,
+            );
+            assert_no_col0_block(&result, &[token]);
+            assert!(
+                result.contains(&format!("apples {token}")),
+                "{token} stays with the previous line:\n{result}"
+            );
+        }
+    }
+
+    #[test]
     fn skip_cut_loops_until_next_line_is_not_a_block() {
         // Org: break_at += 1 only eats `-`, then `* oranges` is a headline.
         let result = wrap_fmt(

--- a/tests/rst_empty_list_item.rs
+++ b/tests/rst_empty_list_item.rs
@@ -1,0 +1,206 @@
+//! GitHub #324 / snapper-nd8i: Docutils `Body.patterns` bullet is
+//! `[-+*\u2022\u2023\u2043]( +|$)`. Lone `-` / `*` at EOL and unicode
+//! `•` / `‣` / `⁃` (with or without payload) are Structure; following
+//! prose still splits. Lone `+` stays a grid-table leftover fragment.
+//! Trailing-space ASCII bullets and enumerators stay.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst / GitHub #324).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        "-\n",
+        "After empty item. Next sentence.\n",
+    )
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        "Intro sentence here.\n",
+        "Another intro sentence.\n",
+        "-\n",
+        "After empty item.\n",
+        "Next sentence.\n",
+    )
+}
+
+fn wrapped(marker: &str) -> String {
+    format!(
+        "Intro sentence here. Another intro sentence.\n{marker}\nAfter empty item. Next sentence.\n"
+    )
+}
+
+fn expected_wrapped(marker: &str) -> String {
+    format!(
+        "Intro sentence here.\nAnother intro sentence.\n{marker}\nAfter empty item.\nNext sentence.\n"
+    )
+}
+
+fn expected_payload(marker: &str) -> String {
+    let hang = " ".repeat(marker.chars().count());
+    format!(
+        "Intro sentence here.\nAnother intro sentence.\n{marker}After empty item.\n{hang}Next sentence.\n"
+    )
+}
+
+#[test]
+fn empty_dash_is_structure() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "-")),
+        "lone - at EOL must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains('-') && p.contains("After empty item.")
+        )),
+        "empty dash must not join the following prose, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After empty item.") && p.contains("Next sentence.")
+        )),
+        "following prose must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_empty_dash_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn empty_star_is_list_marker() {
+    let input = wrapped("*");
+    let regions = RstParser.parse(&input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == "*")),
+        "lone * at EOL must be Structure, got {regions:?}"
+    );
+    let out = format_text(&input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_wrapped("*"), "got:\n{out}");
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn unicode_bullets_empty_and_payload_are_list_markers() {
+    for bullet in ["•", "‣", "⁃"] {
+        let empty = wrapped(bullet);
+        let regions = RstParser.parse(&empty);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == bullet)),
+            "lone {bullet} at EOL must be Structure, got {regions:?}"
+        );
+        let out = format_text(&empty, &rst_cfg()).unwrap();
+        assert_eq!(out, expected_wrapped(bullet), "empty {bullet} got:\n{out}");
+        assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+
+        let marked = format!("{bullet} ");
+        let payload = format!(
+            "Intro sentence here. Another intro sentence.\n{marked}After empty item. Next sentence.\n"
+        );
+        let regions = RstParser.parse(&payload);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == marked.as_str())),
+            "{bullet} with payload must be Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After empty item.") && p.contains("Next sentence.")
+            )),
+            "{bullet} payload must stay Prose, got {regions:?}"
+        );
+        let out = format_text(&payload, &rst_cfg()).unwrap();
+        assert_eq!(
+            out,
+            expected_payload(&marked),
+            "payload {bullet} got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+    }
+}
+
+#[test]
+fn lone_plus_stays_grid_table_leftover() {
+    let input = wrapped("+");
+    let regions = RstParser.parse(&input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.trim() == "+")),
+        "lone + at EOL must stay leftover Structure, got {regions:?}"
+    );
+    let out = format_text(&input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_wrapped("+"), "got:\n{out}");
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn trailing_space_ascii_bullets_and_enumerators_unchanged() {
+    for input in [
+        "- item\n",
+        "* Hello world.\n",
+        "+ Hello world.\n",
+        "1. Hello world.\n",
+        "a. Alpha item.\n",
+        "(1) Paren arabic.\n",
+    ] {
+        let out = format_text(input, &rst_cfg()).unwrap();
+        assert_eq!(out, input, "trailing-space marker must stay, got:\n{out}");
+        assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+    }
+    let regions = RstParser.parse("- item\n");
+    assert_eq!(regions[0], Region::Structure("- ".to_string()));
+    assert_eq!(regions[1], Region::Prose("item".to_string()));
+    let numbered = RstParser.parse("1. Hello world.\n");
+    assert_eq!(numbered[0], Region::Structure("1. ".to_string()));
+    assert_eq!(numbered[1], Region::Prose("Hello world.".to_string()));
+    let star = RstParser.parse("* Hello world.\n");
+    assert_eq!(star[0], Region::Structure("* ".to_string()));
+    assert_eq!(star[1], Region::Prose("Hello world.".to_string()));
+}
+
+#[test]
+fn option_lists_and_anonymous_targets_stay() {
+    let option = "-a            Output all.\n";
+    let out = format_text(option, &rst_cfg()).unwrap();
+    assert_eq!(out, option, "option list must stay, got:\n{out}");
+    let target = "__ https://www.python.org/some/very/long/path\n";
+    let out = format_text(target, &rst_cfg()).unwrap();
+    assert_eq!(out, target, "anonymous target must stay, got:\n{out}");
+    let regions = RstParser.parse(target);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("__ https://www.python.org")
+        )),
+        "anonymous target must stay Structure, got {regions:?}"
+    );
+}


### PR DESCRIPTION
Closes #324.

Docutils `Body.patterns` bullet is `[-+*\u2022\u2023\u2043]( +|$)`. Snapper only matched ASCII `* ` / `- ` / `+ ` with a trailing space, so a lone `-` / `*` and unicode `•` / `‣` / `⁃` joined the next paragraph.

Cherry-picked 0f45c32 onto origin/main cf49b1d. Terra: `rst_empty_list_item` 7/7, lib empty-list green, org dogfood `--native --check` exit 0.

Lone `+` stays a grid-table leftover fragment. Trailing-space ASCII bullets and enumerators unchanged.