### PR TITLE
fix(rst): treat empty field-list markers at EOL as Structure

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -367,8 +367,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             continue;
         }
 
-        // Field list (`:field: value`). Docutils field_marker needs
-        // space after the closing colon; `:role:`text`` is prose.
+        // Field list (`:field: value` or empty `:name:` at EOL).
+        // Docutils field_marker is `:(?![: ])...:( +|$)`.
+        // `:role:`text`` is interpreted text, not a field.
         if is_rst_field_list_line(trimmed) {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
             regions.push(SpannedRegion::structure(input, line.span()));
@@ -749,21 +750,24 @@ pub(crate) fn source_has_dropped_rst_comments(input: &str) -> bool {
         .any(|line| is_rst_dropped_comment_opener(line.trim_start()))
 }
 
-/// True when `trimmed` is an RST field-list item (`:name: value`).
-/// Docutils `field_marker` requires whitespace after the closing colon.
-/// `:role:`text`` is interpreted text, not a field (GitHub #126).
+/// True when `trimmed` is an RST field-list item (`:name: value` or
+/// empty `:name:` at EOL). Docutils `field_marker` is
+/// `:(?![: ])...:( +|$)`. `:role:`text`` is interpreted text, not a
+/// field (GitHub #126 / #330).
 pub(crate) fn is_rst_field_list_line(trimmed: &str) -> bool {
     if !trimmed.starts_with(':') || trimmed.len() < 3 {
+        return false;
+    }
+    // `(?![: ])`: first name byte is not `:` or space.
+    let second = trimmed.as_bytes()[1];
+    if second == b':' || second == b' ' {
         return false;
     }
     let Some(name_end) = trimmed[1..].find(':') else {
         return false;
     };
-    if name_end == 0 {
-        return false;
-    }
     let after = name_end + 2;
-    after < trimmed.len() && trimmed.as_bytes()[after].is_ascii_whitespace()
+    after == trimmed.len() || trimmed.as_bytes()[after].is_ascii_whitespace()
 }
 
 /// Byte length of a Docutils line-block opener on `line`, including
@@ -1432,11 +1436,14 @@ mod tests {
     fn field_list_line_rejects_interpreted_text_role() {
         assert!(is_rst_field_list_line(":Author: Someone"));
         assert!(is_rst_field_list_line(":class: test"));
+        assert!(is_rst_field_list_line(":name:"));
+        assert!(is_rst_field_list_line(":name: "));
         assert!(!is_rst_field_list_line(
             ":class:`CloudDatabase` exceeds a rate"
         ));
         assert!(!is_rst_field_list_line(":py:class:`CloudDatabase`"));
         assert!(!is_rst_field_list_line("::"));
+        assert!(!is_rst_field_list_line(": name:"));
         assert!(!is_rst_field_list_line("Hello"));
     }
 

--- a/tests/rst_empty_field_list.rs
+++ b/tests/rst_empty_field_list.rs
@@ -1,0 +1,123 @@
+//! GitHub #330 / snapper-pn97: Docutils `Body.patterns` field_marker is
+//! `:(?![: ])...:( +|$)`. Lone `:name:` at EOL is Structure; following
+//! prose still splits. `:name: value` with a trailing space hangs as
+//! today. `:role:`text`` stays interpreted text, not a field.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst / GitHub #330).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        ":name:\n",
+        "After field. Next sentence.\n",
+    )
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        "Intro sentence here.\n",
+        "Another intro sentence.\n",
+        ":name:\n",
+        "After field.\n",
+        "Next sentence.\n",
+    )
+}
+
+#[test]
+fn empty_field_marker_is_structure() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.trim() == ":name:")),
+        "lone :name: at EOL must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(":name:") && p.contains("After field.")
+        )),
+        "empty :name: must not join the following prose, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After field.") && p.contains("Next sentence.")
+        )),
+        "following prose must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_empty_field_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn valued_field_with_trailing_space_hangs() {
+    let input = ":name: value \n";
+    let regions = RstParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(":name: value"))),
+        ":name: value with trailing space must stay Structure, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        ":name: value with trailing space must hang as today, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn valued_field_without_trailing_space_hangs() {
+    let input = ":Author: Someone\n";
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, input, "valued field must hang as today, got:\n{out}");
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn interpreted_text_role_is_not_a_field() {
+    let input = concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        ":class:`CloudDatabase` exceeds a rate. Next sentence.\n",
+    );
+    let regions = RstParser.parse(input);
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(":class:`CloudDatabase`")
+        )),
+        "role must not be a field-list Structure, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Intro sentence here.\n",
+            "Another intro sentence.\n",
+            ":class:`CloudDatabase` exceeds a rate.\n",
+            "Next sentence.\n",
+        ),
+        "role line must stay prose and split, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Closes #330.

Docutils `Body.patterns['field_marker']` is `:(?![: ])...:( +|$)`.
Snapper required a space after the closing colon, so a lone `:name:`
at EOL joined the next paragraph.

Cherry-picked bd9fe9a onto origin/main db841d1.

`:name:` at EOL is Structure. Following prose still splits.
`:name: value` with a trailing space hangs as today.
`:role:`text`` stays interpreted text, not a field.
