### PR TITLE
fix(org): keep angular links atomic across interior punctuation

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -62,6 +62,7 @@ The classification depends on the format.
 :END:
 These tokens within prose are not split across lines:
 - Links: =[[url][description]]=
+- Angular links: =<file:fig. 1.png>= (org-link-angle-re; spaces allowed)
 - Emphasis: =*bold*=, =/italic/=, =_underline_=, =+strike+=
 - Inline code: =~code~=, ===verbatim===
 - A =~code~= or ===verbatim=== span may contain the marker character; pairing matches pandoc's org reader, so =x = 1= stays one span

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -3231,6 +3231,53 @@ mod tests {
         assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
     }
 
+    #[test]
+    fn org_angle_link_interior_punct_is_not_a_sentence_boundary() {
+        use crate::format_text;
+
+        let link = "<file:fig. 1.png>";
+        let input = "See <file:fig. 1.png> today. Next.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(link) && p.contains("Next.")
+            )),
+            "angle link stays inline Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &org_cfg()).unwrap();
+        assert!(
+            out.contains("See <file:fig. 1.png> today.\nNext."),
+            "sentence after the angle link must reflow, got:\n{out}"
+        );
+        assert!(
+            !out.contains("fig.\n") && !out.contains("<file:fig.\n"),
+            "must not split inside the angle link, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+        let wrap_cfg = crate::FormatConfig {
+            format: crate::format::Format::Org,
+            max_width: 16,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let wrapped = format_text(input, &wrap_cfg).unwrap();
+        assert!(
+            wrapped.lines().any(|l| l.contains(link)),
+            "wrap must not cut inside the angle link, got:\n{wrapped}"
+        );
+        assert!(
+            !wrapped.contains("fig.\n1.png") && !wrapped.contains("fig. \n"),
+            "must not wrap on the interior period, got:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("Next."),
+            "sentence after the angle link must still reflow, got:\n{wrapped}"
+        );
+        assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+    }
+
     /// Ticket fixture (Format::Org / GitHub #212): org-element macros
     /// stay one token so an interior period is not a sentence boundary.
     /// `Next sentence.` still splits.

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2380,6 +2380,20 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_org_angle_link_atomic() {
+        let token = "<file:fig. 1.png>";
+        let sentence = "See <file:fig. 1.png> today. Next.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 16, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("fig.\n") && !wrapped.contains("fig. \n"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn max_width_keeps_org_macro_atomic() {
         let token = "{{{cite(Smith. 2020)}}}";
         let sentence = "See {{{cite(Smith. 2020)}}} for the source. Next sentence.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -67,6 +67,14 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             // paired below: a regex that forbids the delimiter inside the
             // span closes on the first inner copy and leaves the real closer
             // (and any period before it) unprotected.
+            // Org angular links (ol.el org-link-angle-re / GitHub #335):
+            // `<%s:\([^>\n]*\(?:\n[ \t]*[^> \t\n][^>\n]*\)*\)>` where %s
+            // is org-link-types. Path may contain spaces; folded
+            // continuation is the Emacs `\n[ \t]*[^> \t\n][^>\n]*` arm.
+            // Type is lowercase so `Vec<T: Bound>` is not stolen.
+            // Must precede the bare `file:` token. CommonMark autolinks
+            // stay the no-space alternative below.
+            r"<[a-z][a-z0-9+.\-]*:[^<>\n]*(?:\n[ \t]*[^<> \t\n][^<>\n]*)*>",
             r"<[A-Za-z][A-Za-z0-9+.\-]*:[^\s<>]*>", // Autolink: <http://...>
             r"<[^\s<>@]+@[^\s<>]+>",                // Autolink: <user@host>
             r#"https?://\S+[^.\s!?,;:)\]'""]"#,     // URLs (don't swallow trailing punctuation)
@@ -991,7 +999,8 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 /// Byte ranges of inline tokens that wrapping must not split (links, images,
 /// reference links `[text][ref]`, inline code, autolinks, math, Org `[[...]]`,
 /// Org `[cite...]`, Org `[fn::…]` / `[fn:LABEL:…]`, Org `<<<...>>>` /
-/// `<<...>>`, Org `{{{name}}}` / `{{{name(args)}}}`, Org timestamps
+/// `<<...>>`, Org angular `<type:path with spaces>` (org-link-angle-re),
+/// Org `{{{name}}}` / `{{{name(args)}}}`, Org timestamps
 /// (`<YYYY-MM-DD…>`, `[YYYY-MM-DD…]`, ranges `--`, diary `<%%(...)>`),
 /// Org `src_lang{...}` / `call_name(...)`, RST `|fig. 1|` / `|name|_` /
 /// `|name|__`, paired spans).
@@ -2245,6 +2254,84 @@ mod tests {
             vec![
                 "See [[https://example.com][Ex. Site]] for details.",
                 "Then continue."
+            ]
+        );
+    }
+
+    #[test]
+    fn inline_org_angle_link_interior_punct_is_not_a_sentence_boundary() {
+        // GitHub #335 / snapper-rhqk: ol.el org-link-angle-re allows
+        // spaces, so `<file:fig. 1.png>` stays one token. `Next.` still
+        // splits. Bracket `[[file:fig. 1.png]]` stays its own token.
+        let angle = "<file:fig. 1.png>";
+        let bracket = "[[file:fig. 1.png]]";
+        let text = "See <file:fig. 1.png> today. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == angle),
+            "angle link must be one token, got {placeholders:?}"
+        );
+        assert!(
+            !placeholders.iter().any(|p| p == "file:fig"),
+            "bare file: must not steal the angle link, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == angle),
+            "angle link must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See <file:fig. 1.png> today.".to_string(),
+                "Next.".to_string()
+            ]
+        );
+        let bracket_text = "See [[file:fig. 1.png]] today. Next.";
+        let (_, bracket_ph) = protect_inline_tokens(bracket_text);
+        assert!(
+            bracket_ph.iter().any(|p| p == bracket),
+            "bracket link must stay one token, got {bracket_ph:?}"
+        );
+        assert_eq!(
+            split(bracket_text),
+            vec![
+                "See [[file:fig. 1.png]] today.".to_string(),
+                "Next.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn rust_generic_bound_is_not_an_org_angle_link() {
+        let text = "Use Vec<T: Bound> today. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            !placeholders.iter().any(|p| p == "<T: Bound>"),
+            "Pascal-case generic must not match org-link-angle-re, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec!["Use Vec<T: Bound> today.".to_string(), "Next.".to_string()]
+        );
+    }
+
+    #[test]
+    fn org_angle_link_folded_continuation_is_one_token() {
+        // Emacs org-link-angle-re folded arm: `\n[ \t]*[^> \t\n][^>\n]*`.
+        let link = "<file:fig.\n  1.png>";
+        let text = "See <file:fig.\n  1.png> today. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == link),
+            "folded angle link must be one token, got {placeholders:?}"
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                "See <file:fig.\n  1.png> today.".to_string(),
+                "Next.".to_string()
             ]
         );
     }

--- a/tests/org_angle_links.rs
+++ b/tests/org_angle_links.rs
@@ -1,0 +1,112 @@
+//! GitHub #335 / snapper-rhqk: Emacs 30.2 org-link-angle-re allows
+//! spaces, so `<file:fig. 1.png>` stays one inline token. Interior
+//! punctuation is not a sentence or wrap boundary. Bracket
+//! `[[file:fig. 1.png]]` stays atomic. `Next.` still splits.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "See <file:fig. 1.png> today. Next.\n"
+}
+
+#[test]
+fn ticket_angle_link_use_stays_prose() {
+    let link = "<file:fig. 1.png>";
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(link) && s.contains("Next.")
+        )),
+        "angle link must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_angle_link_span_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("<file:fig. 1.png>"),
+        "angle link must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("<file:fig.\n") && !out.contains("fig.\n1.png>"),
+        "must not split inside the angle link, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("today. Next."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn bracket_file_link_stays_one_span() {
+    let input = "See [[file:fig. 1.png]] today. Next.\n";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("[[file:fig. 1.png]]"),
+        "bracket link must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("fig.\n1.png"),
+        "must not split inside the bracket link, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn angle_link_stays_atomic_under_wrap() {
+    let input = ticket_fixture();
+    let cfg = FormatConfig {
+        format: Format::Org,
+        max_width: 16,
+        ..Default::default()
+    }
+    .without_safety_backstops();
+    let out = format_text(input, &cfg).unwrap();
+    assert!(
+        out.contains("<file:fig. 1.png>"),
+        "angle link must stay one token under wrap, got:\n{out}"
+    );
+    assert!(
+        !out.contains("fig.\n") && !out.contains("fig. \n"),
+        "must not wrap inside the angle link, got:\n{out}"
+    );
+    assert!(
+        out.contains("Next."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &cfg).unwrap(), out);
+}


### PR DESCRIPTION
Emacs `org-link-angle-re` allows spaces in `<TYPE:path>`.
`<file:fig. 1.png>` split on the interior period. Bracket
`[[file:fig. 1.png]]` already stays atomic.

The angle link stays one token. `Next.` still splits.
Bracket links unchanged.

Closes #335.

Do not hand-edit CHANGELOG.md.
