### PR TITLE
fix(org): keep latex-fragments atomic across interior punctuation

### DIFF
--- a/docs/orgmode/reference/abbreviations.org
+++ b/docs/orgmode/reference/abbreviations.org
@@ -128,8 +128,8 @@ Periods inside inline tokens never trigger sentence breaks, regardless of abbrev
 - Org radio / angle targets: =<<<the Fourier. transform>>>=, =<<sec. intro>>=
 - Org inline footnotes: =[fn:: the Fourier. transform]=, =[fn:note: the Fourier. transform]=
 - RST substitution references: =|fig. 1|=, =|version|=, =|name|_=, =|name|__=
-- LaTeX math: =$x = 3.14$=
-- LaTeX commands: =\cite{smith.2024}=
+- LaTeX math: =$x = 3.14$=, =\( x = 1. \)=, =\(\alpha. \beta\)=
+- LaTeX commands: =\cite{smith.2024}=, =\sqrt[2]{a. b}=
 - Markdown links: =[Example Inc.](url)=, =[the Fourier. transform][wiki]=
 - Inline code: =~std.io.Read~=, src_bash{`path.to.file`}
 

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -74,6 +74,7 @@ These tokens within prose are not split across lines:
 - Inline source: =src_lang{...}= / =src_lang[headers]{...}= (org-element-inline-src-block-parser; =\<src_= is word-start. After a word, =_src_= is a subscript, so =foo_src_python{...}= is not an object; =_src_python{...}= after space is)
 - Inline babel call: =call_name(...)= / =call_name[inside](...)[end]= (org-element-inline-babel-call-parser; same =\<call_= / subscript rule)
 - Inline footnotes: =[fn:: def]= / =[fn:name: def]= (org-element-footnote-reference-parser)
+- LaTeX fragments: =\(...\)=, =$...$=, =\cmd{arg}=, =\cmd[opt]{arg}= (org-element-latex-fragment-parser; interior backslash and optional =[arg]= stay one token). Same-line =\[...\]= is Structure
 - URLs: =https://...= (trailing sentence punctuation not swallowed)
 
 ** LaTeX (=--format latex=)

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2538,6 +2538,34 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_org_latex_fragment_interior_backslash_atomic() {
+        let token = r"\(\alpha. \beta\)";
+        let sentence = r"The root is \(\alpha. \beta\) today. Next.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 12, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("\\(\\alpha.\n") && !wrapped.contains("alpha.\n\\beta"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_keeps_org_latex_fragment_optional_arg_atomic() {
+        let token = r"\sqrt[2]{a. b}";
+        let sentence = r"See \sqrt[2]{a. b} today. Next.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 12, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("\\sqrt[2]{a.\n") && !wrapped.contains("a.\nb}"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn max_width_keeps_autolink_atomic() {
         let token = "<https://example.com/a/long-path>";
         let sentence = "Visit <https://example.com/a/long-path> today.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -49,11 +49,15 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             // is not matched: that would swallow every bracket group.
             r"!\[[^\]]*\]\[[^\]]*\]", // Markdown reference images: ![alt][ref]
             r"\[[^\]]+\]\[[^\]]*\]",  // Markdown reference links: [text][ref]
-            r"\$\$[^$\n]+\$\$",       // Display math: $$...$$
-            r"\$[^$\n]+\$",           // Inline math: $...$
-            r"\\\([^\\\n]+\\\)",      // LaTeX inline math: \(...\)
-            r"\\\[[^\n]+?\\\]",       // Org / LaTeX display math fragment: \[...\]
-            r"\\([a-zA-Z]+)\{[^}]*\}", // LaTeX commands: \cmd{arg}
+            r"\$\$[^$\n]+\$\$", // Display math: $$...$$
+            r"\$[^$\n]+\$",     // Inline math: $...$
+            // org-element-latex-fragment-parser: \(...\) / \[...\] search
+            // to the closer. `[^\\\n]` dropped interior `\alpha` / `\beta`.
+            r"\\\([^\n]+?\\\)", // LaTeX inline math: \(...\)
+            r"\\\[[^\n]+?\\\]", // Org / LaTeX display math fragment: \[...\]
+            // org-element-latex-fragment-parser macro:
+            // \\[a-zA-Z]+\*? then optional [arg] and one or more {arg}.
+            r"\\[a-zA-Z]+\*?(?:\[[^\]\[\n{}]*\])?(?:\{[^{}\n]*\})+",
             // Org emphasis must be protected before sentence splits so a line
             // cannot begin with `*rest` (false headline) or leave markers open.
             // Org requires a non-space immediately after the opener and before
@@ -1002,6 +1006,7 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 /// `<<...>>`, Org angular `<type:path with spaces>` (org-link-angle-re),
 /// Org `{{{name}}}` / `{{{name(args)}}}`, Org timestamps
 /// (`<YYYY-MM-DD…>`, `[YYYY-MM-DD…]`, ranges `--`, diary `<%%(...)>`),
+/// Org latex-fragments (`\(...\)`, `$...$`, `\cmd{arg}`, `\cmd[opt]{arg}`),
 /// Org `src_lang{...}` / `call_name(...)`, RST `|fig. 1|` / `|name|_` /
 /// `|name|__`, paired spans).
 ///
@@ -1738,6 +1743,68 @@ mod tests {
             vec![
                 r"According to X, \(E=mc^2\).".to_string(),
                 "Next.".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn latex_inline_math_interior_backslash_stays_atomic() {
+        // GitHub #336 / snapper-e6tw: org-element \(...\) allows `\alpha`.
+        let frag = r"\(\alpha. \beta\)";
+        let text = r"The root is \(\alpha. \beta\) today. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == frag),
+            "\\( with interior \\\\ must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == frag),
+            "fragment must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"The root is \(\alpha. \beta\) today.".to_string(),
+                "Next.".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn latex_inline_math_and_dollar_without_backslash_stay_atomic() {
+        assert_eq!(
+            split(r"See \( x = 1. \) here. Next."),
+            vec![r"See \( x = 1. \) here.".to_string(), "Next.".to_string()]
+        );
+        assert_eq!(
+            split("See $a. b$ here. Next."),
+            vec!["See $a. b$ here.".to_string(), "Next.".to_string()]
+        );
+    }
+
+    #[test]
+    fn latex_command_optional_arg_stays_atomic() {
+        // GitHub #336 / snapper-e6tw: org-element `\name[opt]{arg}`.
+        let frag = r"\sqrt[2]{a. b}";
+        let text = r"See \sqrt[2]{a. b} today. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == frag),
+            "\\sqrt[2]{{a. b}} must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == frag),
+            "\\sqrt[2]{{a. b}} must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \sqrt[2]{a. b} today.".to_string(),
+                "Next.".to_string()
             ]
         );
     }

--- a/tests/org_latex_fragment.rs
+++ b/tests/org_latex_fragment.rs
@@ -1,0 +1,164 @@
+//! GitHub #336 / snapper-e6tw: org-element latex-fragment wrap must
+//! not split on interior punctuation. `\( x = 1. \)` and `$a. b$` stay
+//! atomic. Interior backslash (`\(\alpha. \beta\)`) and optional `[arg]`
+//! (`\sqrt[2]{a. b}`) must too. The fragment stays one token; `Next.`
+//! still splits. Same-line `\[ \]` Structure is unchanged.
+//! Brace subscript `H_{2. 0}` is snapper-upgw, not this ticket.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn wrap_cfg(width: usize) -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: width,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "The root is \\(\\alpha. \\beta\\) today. Next.\n"
+}
+
+#[test]
+fn ticket_fragment_stays_prose() {
+    let frag = "\\(\\alpha. \\beta\\)";
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(frag) && s.contains("Next.")
+        )),
+        "latex fragment must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_wrap_keeps_fragment_and_splits_next() {
+    let input = ticket_fixture();
+    let out = format_text(input, &wrap_cfg(12)).unwrap();
+    assert!(
+        out.contains("\\(\\alpha. \\beta\\)"),
+        "fragment must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\(\\alpha.\n") && !out.contains("alpha.\n\\beta"),
+        "must not wrap inside the fragment, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("today. Next."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &wrap_cfg(12)).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        max_width: 12,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn paren_and_dollar_without_interior_backslash_stay_atomic() {
+    let cfg = org_cfg();
+    let paren = "See \\( x = 1. \\) here. Next.\n";
+    let out = format_text(paren, &cfg).unwrap();
+    assert!(
+        out.contains("\\( x = 1. \\)"),
+        "\\( x = 1. \\) must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("here.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &cfg).unwrap(), out);
+
+    let dollar = "See $a. b$ here. Next.\n";
+    let out = format_text(dollar, &cfg).unwrap();
+    assert!(
+        out.contains("$a. b$"),
+        "$a. b$ must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("here.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &cfg).unwrap(), out);
+}
+
+#[test]
+fn sqrt_optional_arg_stays_one_span() {
+    let input = "See \\sqrt[2]{a. b} today. Next.\n";
+    let frag = "\\sqrt[2]{a. b}";
+    let regions = OrgParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(frag) && s.contains("Next.")
+        )),
+        "\\sqrt[2]{{a. b}} must stay Prose, got {regions:?}"
+    );
+    let out = format_text(input, &wrap_cfg(12)).unwrap();
+    assert!(
+        out.contains(frag),
+        "\\sqrt[2]{{a. b}} must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\sqrt[2]{a.\n") && !out.contains("a.\nb}"),
+        "must not wrap inside \\sqrt[2]{{a. b}}, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &wrap_cfg(12)).unwrap(), out);
+}
+
+#[test]
+fn same_line_bracket_display_stays_structure() {
+    let input = "The root is \\[ x = 1. \\] today. Next.\n";
+    let regions = OrgParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains("x = 1."))),
+        "same-line \\[ \\] must stay Structure, got: {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("x = 1."))),
+        "same-line \\[ body must not be Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("\\[ x = 1. \\] today.\nNext."),
+        "same-line \\[ \\] Structure unchanged; Next. still splits, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\[ x = 1.\n"),
+        "must not break after the math period, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
`\( x = 1. \)` and `$a. b$` stay atomic. Interior backslash and
optional `[arg]` did not: wrap split `\(\alpha. \beta\)` and
`\sqrt[2]{a. b}`.

The fragment stays one token. `Next.` still splits.
Same-line `\[ \]` Structure unchanged. Brace subscript wrap is
snapper-upgw, not this change.

Closes #336.

Do not hand-edit CHANGELOG.md.
