### PR TITLE
fix(org): keep brace subscript wrap atomic across interior punct

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -75,6 +75,7 @@ These tokens within prose are not split across lines:
 - Inline babel call: =call_name(...)= / =call_name[inside](...)[end]= (org-element-inline-babel-call-parser; same =\<call_= / subscript rule)
 - Inline footnotes: =[fn:: def]= / =[fn:name: def]= (org-element-footnote-reference-parser)
 - LaTeX fragments: =\(...\)=, =$...$=, =\cmd{arg}=, =\cmd[opt]{arg}= (org-element-latex-fragment-parser; interior backslash and optional =[arg]= stay one token). Same-line =\[...\]= is Structure
+- Brace sub/superscripts: =H_{2. 0}= / =x^{n. 1}= (org-match-substring-regexp brace arm; interior punct stays one wrap token). Bare =H_2= / =x^n= and no-space =H_{2.0}= are unchanged. Distinct from latex-fragment.
 - URLs: =https://...= (trailing sentence punctuation not swallowed)
 
 ** LaTeX (=--format latex=)

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -3484,6 +3484,70 @@ mod tests {
         assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
     }
 
+    /// Ticket fixture (Format::Org / GitHub #338): org-match-substring-regexp
+    /// brace subscript stays one wrap token. `Next.` still splits.
+    /// Distinct from latex-fragment (snapper-e6tw).
+    fn brace_subscript_fixture() -> &'static str {
+        "See H_{2. 0} today. Next.\n"
+    }
+
+    #[test]
+    fn org_brace_subscript_wrap_keeps_interior_punct() {
+        use crate::format_text;
+
+        let token = "H_{2. 0}";
+        let input = brace_subscript_fixture();
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(token) && p.contains("Next.")
+            )),
+            "brace subscript stays inline Prose, got: {regions:?}"
+        );
+        let wrap_cfg = crate::FormatConfig {
+            format: crate::format::Format::Org,
+            max_width: 10,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let wrapped = format_text(input, &wrap_cfg).unwrap();
+        assert!(
+            wrapped.lines().any(|l| l.contains(token)),
+            "wrap must not cut inside the brace subscript, got:\n{wrapped}"
+        );
+        assert!(
+            !wrapped.contains("2.\n0") && !wrapped.contains("H_{2.\n"),
+            "must not wrap on the interior period, got:\n{wrapped}"
+        );
+        assert!(
+            wrapped.contains("today.\nNext."),
+            "following sentence must still split, got:\n{wrapped}"
+        );
+        assert_eq!(format_text(&wrapped, &wrap_cfg).unwrap(), wrapped);
+
+        let super_in = "See x^{n. 1} today. Next.\n";
+        let super_out = format_text(super_in, &wrap_cfg).unwrap();
+        assert!(
+            super_out.lines().any(|l| l.contains("x^{n. 1}")),
+            "wrap must not cut inside the brace superscript, got:\n{super_out}"
+        );
+        assert!(
+            super_out.contains("today.\nNext."),
+            "following sentence must still split after superscript, got:\n{super_out}"
+        );
+
+        let tight = format_text("See H_{2.0} today. Next.\n", &wrap_cfg).unwrap();
+        assert!(
+            tight.lines().any(|l| l.contains("H_{2.0}")),
+            "no-space H_{{2.0}} unchanged, got:\n{tight}"
+        );
+        assert!(
+            tight.contains("today.\nNext."),
+            "following sentence must still split after no-space form, got:\n{tight}"
+        );
+    }
+
     /// Ticket fixture (Format::Org / GitHub #231): org-element inline
     /// footnote references stay one token so an interior period is not
     /// a sentence boundary. `Next sentence.` still splits.

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2514,6 +2514,76 @@ They are endowed with reason and conscience and should act towards one another i
     }
 
     #[test]
+    fn max_width_keeps_org_brace_subscript_atomic() {
+        // GitHub #338 / snapper-upgw: org-match-substring-regexp brace
+        // form stays one wrap token. Distinct from latex-fragment.
+        let token = "H_{2. 0}";
+        let sentence = "See H_{2. 0} today. Next.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 10, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("2.\n0") && !wrapped.contains("H_{2.\n"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+            assert!(
+                wrapped.contains("today.\nNext."),
+                "following sentence must still split, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_keeps_org_brace_superscript_atomic() {
+        let token = "x^{n. 1}";
+        let sentence = "See x^{n. 1} today. Next.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 10, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("n.\n1") && !wrapped.contains("x^{n.\n"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+            assert!(
+                wrapped.contains("today.\nNext."),
+                "following sentence must still split, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_keeps_org_paren_subscript_atomic() {
+        let token = "H_(2. 0)";
+        let sentence = "See H_(2. 0) today. Next.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 10, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                !wrapped.contains("2.\n0") && !wrapped.contains("H_(2.\n"),
+                "must not wrap on the interior period, got:\n{wrapped}"
+            );
+            assert!(
+                wrapped.contains("today.\nNext."),
+                "following sentence must still split, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
+    fn max_width_keeps_no_space_org_brace_subscript_unchanged() {
+        let token = "H_{2.0}";
+        let sentence = "See H_{2.0} today. Next.";
+        for clause in [false, true] {
+            let wrapped = wrap_sentence(sentence, 10, clause);
+            assert_atomic_token(&wrapped, token);
+            assert!(
+                wrapped.contains("today.\nNext."),
+                "following sentence must still split, got:\n{wrapped}"
+            );
+        }
+    }
+
+    #[test]
     fn max_width_keeps_rst_substitution_ref_atomic() {
         let token = "|fig. 1|";
         let sentence = "See |fig. 1| in the caption. Next sentence.";

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -1049,7 +1049,6 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 /// Org `src_lang{...}` / `call_name(...)`, Org brace `H_{...}` / `x^{...}`
 /// (org-match-substring-regexp), RST `|fig. 1|` / `|name|_` / `|name|__`,
 /// paired spans).
-
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -544,13 +544,15 @@ fn rst_substitution_ref_span_end(text: &str, at: usize) -> Option<usize> {
 /// org-element-inline-src-block-parser / org-element-inline-babel-call-parser.
 /// `src_LANG[headers]{body}` and `call_NAME[inside](args)[end]` stay one
 /// object so an interior period is not a sentence or wrap boundary.
-/// Footnote references run in the same walk (GitHub #231).
+/// Footnote references and org-match-substring-regexp brace scripts run
+/// in the same walk (GitHub #231 / #338).
 fn protect_org_inline_src_and_call(text: &str, placeholders: &mut Vec<String>) -> String {
     let mut out = String::with_capacity(text.len());
     let mut i = 0;
     while i < text.len() {
         if let Some(end) = org_inline_src_or_call_span_end(text, i)
             .or_else(|| org_footnote_reference_span_end(text, i))
+            .or_else(|| org_brace_script_span_end(text, i))
         {
             push_placeholder(&mut out, placeholders, &text[i..end]);
             i = end;
@@ -728,6 +730,43 @@ fn org_inline_call_span_end(text: &str, at: usize) -> Option<usize> {
         }
     }
     Some(i)
+}
+
+/// org-match-substring-regexp brace/paren arms (Emacs 30.2 / GitHub #338).
+///
+/// `\\(\\S-\\)\\([_^]\\)` then `org-create-multibrace-regexp` on `{` `}`
+/// or `(` `)` (`org_scan_lists` is the nest). Interior punct is not a
+/// wrap boundary. Bare `H_2` / `x^n` is the other arm and is unchanged.
+/// A space or `\` before `[_^]` is not a match (`\_` is escaped).
+/// Distinct from latex-fragment `\(...\)` / `\name{arg}`. Leftover
+/// `foo_call_name(1. 2)` is `_name` then `(...)`, not `_(...)`.
+fn org_brace_script_span_end(text: &str, at: usize) -> Option<usize> {
+    let rest = text.get(at..)?;
+    let marker = rest.as_bytes().first()?;
+    if *marker != b'_' && *marker != b'^' {
+        return None;
+    }
+    if !org_brace_script_predecessor_ok(text, at) {
+        return None;
+    }
+    let open_at = at + 1;
+    let open = *text.as_bytes().get(open_at)?;
+    let close = match open {
+        b'{' => b'}',
+        b'(' => b')',
+        _ => return None,
+    };
+    org_scan_lists(text, open_at, open, close)
+}
+
+/// Emacs `\\S-` predecessor: one non-whitespace character. Reject `\` so
+/// `\_` is not a subscript opener. BOL / after newline is not `\\S-`.
+fn org_brace_script_predecessor_ok(text: &str, at: usize) -> bool {
+    if at == 0 {
+        return false;
+    }
+    let prev = text[..at].chars().next_back().expect("at > 0");
+    !prev.is_whitespace() && prev != '\\'
 }
 
 /// Org `=`/`~`, Markdown backtick spans, CommonMark `*`/`**`, and GFM `~~`,
@@ -1007,8 +1046,10 @@ fn find_md_code_span(text: &str, open_at: usize) -> Option<usize> {
 /// Org `{{{name}}}` / `{{{name(args)}}}`, Org timestamps
 /// (`<YYYY-MM-DD…>`, `[YYYY-MM-DD…]`, ranges `--`, diary `<%%(...)>`),
 /// Org latex-fragments (`\(...\)`, `$...$`, `\cmd{arg}`, `\cmd[opt]{arg}`),
-/// Org `src_lang{...}` / `call_name(...)`, RST `|fig. 1|` / `|name|_` /
-/// `|name|__`, paired spans).
+/// Org `src_lang{...}` / `call_name(...)`, Org brace `H_{...}` / `x^{...}`
+/// (org-match-substring-regexp), RST `|fig. 1|` / `|name|_` / `|name|__`,
+/// paired spans).
+
 ///
 /// Ranges are half-open `[start, end)`, sorted, non-overlapping, and merged
 /// when a regex match wraps a paired span.
@@ -1031,6 +1072,12 @@ pub fn atomic_inline_spans(text: &str) -> Vec<(usize, usize)> {
         }
         if let Some(end) = org_footnote_reference_span_end(text, i) {
             spans.push((i, end));
+            i = end;
+            continue;
+        }
+        if let Some(end) = org_brace_script_span_end(text, i) {
+            spans.push((i, end));
+            org_src_call_spans.push((i, end));
             i = end;
             continue;
         }
@@ -2847,6 +2894,121 @@ mod tests {
                 "Next sentence. still splits, got {parts:?} for {text:?}"
             );
         }
+    }
+
+    #[test]
+    fn inline_org_brace_subscript_is_atomic_wrap_span() {
+        // GitHub #338 / snapper-upgw: org-match-substring-regexp brace
+        // arm. `H_{2. 0}` stays one wrap token. `Next.` still splits.
+        let token = "_{2. 0}";
+        let text = "See H_{2. 0} today. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == token),
+            "brace subscript must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == token),
+            "brace subscript must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec!["See H_{2. 0} today.".to_string(), "Next.".to_string()]
+        );
+    }
+
+    #[test]
+    fn inline_org_brace_superscript_is_atomic_wrap_span() {
+        let token = "^{n. 1}";
+        let text = "See x^{n. 1} today. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == token),
+            "brace superscript must be one token, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == token),
+            "brace superscript must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec!["See x^{n. 1} today.".to_string(), "Next.".to_string()]
+        );
+    }
+
+    #[test]
+    fn no_space_org_brace_subscript_is_unchanged() {
+        let token = "_{2.0}";
+        let text = "See H_{2.0} today. Next.";
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == token),
+            "no-space brace form stays one span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec!["See H_{2.0} today.".to_string(), "Next.".to_string()]
+        );
+    }
+
+    #[test]
+    fn space_before_org_brace_script_is_not_a_span() {
+        let text = "See _{2. 0} today. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            !placeholders.iter().any(|p| p.contains("_{2. 0}")),
+            "space before [_^] is not a subscript, got {placeholders:?}"
+        );
+        let spans = atomic_inline_spans(text);
+        assert!(
+            !spans.iter().any(|&(s, e)| text[s..e].contains("_{2. 0}")),
+            "space before [_^] must not be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn bol_org_brace_script_is_not_a_span() {
+        // `\\S-` requires a predecessor. `_{2. 0}` at BOL is not a match.
+        let text = "_{2. 0} today. Next.";
+        let spans = atomic_inline_spans(text);
+        assert!(
+            !spans.iter().any(|&(s, e)| text[s..e].contains("_{2. 0}")),
+            "BOL [_^] must not be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn escaped_org_brace_script_is_not_a_span() {
+        let text = "See H\\_{2. 0} today. Next.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            !placeholders.iter().any(|p| p.contains("_{2. 0}")),
+            "backslash before [_^] is not a subscript, got {placeholders:?}"
+        );
+    }
+
+    #[test]
+    fn inline_org_paren_subscript_is_atomic_wrap_span() {
+        // Same regexp: org-create-multibrace-regexp on `(` `)`.
+        let token = "_(2. 0)";
+        let text = "See H_(2. 0) today. Next.";
+        let spans = atomic_inline_spans(text);
+        assert!(
+            spans.iter().any(|&(s, e)| &text[s..e] == token),
+            "paren subscript must be an atomic wrap span, got {:?}",
+            spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            split(text),
+            vec!["See H_(2. 0) today.".to_string(), "Next.".to_string()]
+        );
     }
 
     #[test]

--- a/tests/org_brace_subscript.rs
+++ b/tests/org_brace_subscript.rs
@@ -1,0 +1,123 @@
+//! GitHub #338 / snapper-upgw: org-match-substring-regexp brace
+//! subscript/superscript (`H_{2. 0}` / `x^{n. 1}`) stay one wrap token.
+//! Interior punct is not a wrap boundary. `Next.` still splits.
+//! Distinct from latex-fragment (snapper-e6tw).
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_wrap10() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 10,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "See H_{2. 0} today. Next.\n"
+}
+
+#[test]
+fn ticket_brace_subscript_stays_prose() {
+    let token = "H_{2. 0}";
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(token) && s.contains("Next.")
+        )),
+        "brace subscript must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_brace_span_and_splits_next() {
+    let input = ticket_fixture();
+    let token = "H_{2. 0}";
+    let out = format_text(input, &org_wrap10()).unwrap();
+    assert!(
+        out.lines().any(|l| l.contains(token)),
+        "brace form must stay one wrap token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("2.\n0") && !out.contains("H_{2.\n"),
+        "must not wrap on the interior period, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("today. Next."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_wrap10()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        max_width: 10,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn ticket_brace_superscript_stays_one_wrap_token() {
+    let input = "See x^{n. 1} today. Next.\n";
+    let out = format_text(input, &org_wrap10()).unwrap();
+    assert!(
+        out.lines().any(|l| l.contains("x^{n. 1}")),
+        "brace superscript must stay one wrap token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("n.\n1") && !out.contains("x^{n.\n"),
+        "must not wrap on the interior period, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_wrap10()).unwrap(), out);
+}
+
+#[test]
+fn ticket_paren_form_stays_one_wrap_token() {
+    let input = "See H_(2. 0) today. Next.\n";
+    let out = format_text(input, &org_wrap10()).unwrap();
+    assert!(
+        out.lines().any(|l| l.contains("H_(2. 0)")),
+        "paren form must stay one wrap token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("H_(2.\n") && !out.contains("2.\n0)"),
+        "must not wrap-split inside the paren form, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_wrap10()).unwrap(), out);
+}
+
+#[test]
+fn no_space_brace_subscript_unchanged() {
+    let input = "See H_{2.0} today. Next.\n";
+    let out = format_text(input, &org_wrap10()).unwrap();
+    assert!(
+        out.lines().any(|l| l.contains("H_{2.0}")),
+        "no-space H_{{2.0}} must stay one token, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_wrap10()).unwrap(), out);
+}


### PR DESCRIPTION
Brace subscript/superscript stay one sentence (brace depth) but
wrap was not atomic. `H_{2. 0}` and `x^{n. 1}` wrap-split.

The brace form stays one wrap token. `Next.` still splits.
No-space `H_{2.0}` unchanged. Latex-fragment wrap is snapper-e6tw.

Closes #338.

Do not hand-edit CHANGELOG.md.
