### PR TITLE
fix(rst): treat interior-colon field names as field markers

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -373,12 +373,32 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             continue;
         }
 
-        // Field list (`:field: value` or empty `:name:` at EOL).
-        // Docutils field_marker is `:(?![: ])...:( +|$)`.
+        // Field list. Docutils field_marker is
+        // `:(?![: ])([^:\\]|\\.|:(?!([ `]|$)))*(?<! ):( +|$)`.
+        // Interior colons in the name are allowed (GitHub #341).
         // `:role:`text`` is interpreted text, not a field.
-        if is_rst_field_list_line(trimmed) {
+        // Empty `:name:` and simple `:Author:` stay whole-line
+        // Structure (GitHub #330). Interior-colon names hang the body
+        // as Prose so SemBr still splits.
+        if let Some(marker_len) = rst_field_marker_len(line_text) {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-            regions.push(SpannedRegion::structure(input, line.span()));
+            let body = &line_text[marker_len..];
+            let name = line_text[line_text.len() - trimmed.len()..marker_len].trim();
+            let interior_colon = name
+                .strip_prefix(':')
+                .and_then(|s| s.strip_suffix(':'))
+                .is_some_and(|inner| inner.contains(':'));
+            if interior_colon && !body.trim().is_empty() {
+                list_hang = Some(marker_len);
+                regions.push(SpannedRegion::structure(
+                    input,
+                    ByteSpan::new(line.start, line.start + marker_len),
+                ));
+                current_prose.push_str(body.trim());
+                prose_span = Some(ByteSpan::new(line.start + marker_len, line.end));
+            } else {
+                regions.push(SpannedRegion::structure(input, line.span()));
+            }
             i += 1;
             continue;
         }
@@ -764,24 +784,74 @@ pub(crate) fn source_has_dropped_rst_comments(input: &str) -> bool {
         .any(|line| is_rst_dropped_comment_opener(line.trim_start()))
 }
 
-/// True when `trimmed` is an RST field-list item (`:name: value` or
-/// empty `:name:` at EOL). Docutils `field_marker` is
-/// `:(?![: ])...:( +|$)`. `:role:`text`` is interpreted text, not a
-/// field (GitHub #126 / #330).
+/// True when `trimmed` is an RST field-list item (`:name: value`,
+/// interior-colon `:py:mod: value`, or empty `:name:` at EOL).
+/// Docutils `field_marker` is
+/// `:(?![: ])([^:\\]|\\.|:(?!([ `]|$)))*(?<! ):( +|$)`.
+/// `:role:`text`` is interpreted text, not a field
+/// (GitHub #126 / #330 / #341).
 pub(crate) fn is_rst_field_list_line(trimmed: &str) -> bool {
-    if !trimmed.starts_with(':') || trimmed.len() < 3 {
-        return false;
+    rst_field_marker_end(trimmed).is_some()
+}
+
+/// Byte length of a Docutils field marker on `line`, including leading
+/// indent and the spaces after the closing colon.
+pub(crate) fn rst_field_marker_len(line: &str) -> Option<usize> {
+    let indent = line.len() - line.trim_start().len();
+    rst_field_marker_end(&line[indent..]).map(|n| indent + n)
+}
+
+/// Byte length of the field marker at the start of `trimmed` (no
+/// leading indent). Walks the Docutils `field_marker` so an interior
+/// colon in the name (`:py:mod:`) is not taken as the closer.
+fn rst_field_marker_end(trimmed: &str) -> Option<usize> {
+    let bytes = trimmed.as_bytes();
+    if bytes.len() < 3 || bytes[0] != b':' {
+        return None;
     }
     // `(?![: ])`: first name byte is not `:` or space.
-    let second = trimmed.as_bytes()[1];
-    if second == b':' || second == b' ' {
-        return false;
+    if bytes[1] == b':' || bytes[1] == b' ' {
+        return None;
     }
-    let Some(name_end) = trimmed[1..].find(':') else {
-        return false;
-    };
-    let after = name_end + 2;
-    after == trimmed.len() || trimmed.as_bytes()[after].is_ascii_whitespace()
+    // Name body: `([^:\\]|\\.|:(?!([ `]|$)))*`
+    let mut i = 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' => {
+                if i + 1 >= bytes.len() {
+                    return None;
+                }
+                i += 2;
+            }
+            b':' => {
+                let next = bytes.get(i + 1).copied();
+                // Interior colon is `:(?!([ `]|$)`.
+                if !matches!(next, None | Some(b' ') | Some(b'`')) {
+                    i += 1;
+                    continue;
+                }
+                // Closing colon. `(?<! )`: previous byte is not space.
+                if bytes[i - 1] == b' ' {
+                    return None;
+                }
+                let after = i + 1;
+                if after == bytes.len() {
+                    return Some(after);
+                }
+                // `( +|$)`, plus the pre-#341 tab-as-separator form.
+                if !bytes[after].is_ascii_whitespace() {
+                    return None;
+                }
+                let mut end = after;
+                while end < bytes.len() && bytes[end] == b' ' {
+                    end += 1;
+                }
+                return Some(end);
+            }
+            _ => i += 1,
+        }
+    }
+    None
 }
 
 /// Byte length of a Docutils line-block opener on `line`, including
@@ -1452,13 +1522,22 @@ mod tests {
         assert!(is_rst_field_list_line(":class: test"));
         assert!(is_rst_field_list_line(":name:"));
         assert!(is_rst_field_list_line(":name: "));
+        assert!(is_rst_field_list_line(
+            ":py:mod: some.module.Name is here. Second sentence."
+        ));
+        assert!(is_rst_field_list_line(r":foo\:bar: value"));
         assert!(!is_rst_field_list_line(
             ":class:`CloudDatabase` exceeds a rate"
         ));
         assert!(!is_rst_field_list_line(":py:class:`CloudDatabase`"));
+        assert!(!is_rst_field_list_line(":role:`text`"));
         assert!(!is_rst_field_list_line("::"));
         assert!(!is_rst_field_list_line(": name:"));
         assert!(!is_rst_field_list_line("Hello"));
+        assert_eq!(
+            rst_field_marker_len(":py:mod: some.module.Name is here."),
+            Some(9)
+        );
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -786,7 +786,7 @@ fn rst_opens_block(line: &str) -> bool {
     if crate::parser::rst::rst_list_marker_len(line).is_some() {
         return true;
     }
-    if t.starts_with(':') && t[1..].contains(':') {
+    if crate::parser::rst::is_rst_field_list_line(t) {
         return true;
     }
     if crate::parser::rst::rst_option_column_len(t).is_some() {
@@ -1127,6 +1127,11 @@ fn hanging_indent_width(s: &str) -> usize {
     // RST footnote/citation (`.. [1] `, `.. [CIT2002] `): hang at
     // marker width so the body stays a hung paragraph (GitHub #175).
     if crate::parser::rst::rst_footnote_citation_marker_len(s) == Some(s.len()) {
+        return s.chars().count();
+    }
+    // RST field marker (`:Author: `, `:py:mod: `): hang at marker
+    // width so the body stays a hung paragraph (GitHub #341).
+    if crate::parser::rst::rst_field_marker_len(s) == Some(s.len()) {
         return s.chars().count();
     }
     // Org footnote definition (`[fn:1] `, `[fn:note] `): hang at

--- a/tests/rst_interior_colon_field.rs
+++ b/tests/rst_interior_colon_field.rs
@@ -1,0 +1,124 @@
+//! GitHub #341 / snapper-1n4x: Docutils `Body.patterns` field_marker is
+//! `:(?![: ])([^:\\]|\\.|:(?!([ `]|$)))*(?<! ):( +|$)`. Interior colons
+//! are allowed (`:py:mod: name`). Distinct from snapper-pn97 / GH #330
+//! (empty `:name:` at EOL). `:role:`text`` stays interpreted text.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst / GitHub #341).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        ":py:mod: some.module.Name is here. Second sentence.\n",
+    )
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        "Intro sentence here.\n",
+        "Another intro sentence.\n",
+        ":py:mod: some.module.Name is here.\n",
+        "         Second sentence.\n",
+    )
+}
+
+#[test]
+fn interior_colon_field_marker_is_structure() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == ":py:mod: ")),
+        ":py:mod: must be Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("some.module.Name is here.") && s.contains("Second sentence.")
+        )),
+        "field body must stay Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains(":py:mod:") && s.contains("Intro sentence")
+        )),
+        "field must not stay one Prose region with the intro, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_hangs_field_and_splits_second() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn interpreted_text_role_is_not_a_field() {
+    let input = concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        ":role:`text` stays interpreted. Next sentence.\n",
+    );
+    let regions = RstParser.parse(input);
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(":role:`text`")
+        )),
+        "role must not be a field-list Structure, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Intro sentence here.\n",
+            "Another intro sentence.\n",
+            ":role:`text` stays interpreted.\n",
+            "Next sentence.\n",
+        ),
+        "role line must stay prose and split, got:\n{out}"
+    );
+}
+
+#[test]
+fn empty_name_field_still_structure() {
+    let input = concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        ":name:\n",
+        "After field. Next sentence.\n",
+    );
+    let regions = RstParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.trim() == ":name:")),
+        "empty :name: is snapper-pn97, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Intro sentence here.\n",
+            "Another intro sentence.\n",
+            ":name:\n",
+            "After field.\n",
+            "Next sentence.\n",
+        ),
+        "empty :name: must stay Structure and following prose split, got:\n{out}"
+    );
+}


### PR DESCRIPTION
Docutils field_marker allows interior colons:
`:(?![: ])([^:\\]|\\.|:(?!([ `]|$)))*(?<! ):( +|$)`.

`:py:mod: some.module.Name` is a field. Snapper must not reject the
line at the first interior colon.

Closes #341.

Do not hand-edit CHANGELOG.md.
