### PR TITLE
fix(rst): treat empty explicit markup as a comment not a title underline

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -1086,12 +1086,17 @@ fn rst_quoted_literal_continues(line: &str, quote: u8) -> bool {
 /// 7-bit ASCII except alphanumerics (same set as quoted-literal quotes).
 /// Body.doctest wins over Body.line: prompt-only `>>>` / `>>> ` are not
 /// `>` adornments. `>>>>>` (and `>>` / `>>>>`) stay underlines.
+/// Body.explicit wins over Body.line: lone `..` is an empty comment
+/// (GitHub #343), not a `.` section underline. `...` / `....` stay underlines.
 fn is_underline(line: &str) -> bool {
     let trimmed = line.trim();
     if trimmed.len() < 2 {
         return false;
     }
     if is_rst_doctest_opener(trimmed) {
+        return false;
+    }
+    if is_rst_comment_opener(trimmed) {
         return false;
     }
     let first = trimmed.as_bytes()[0];
@@ -3257,6 +3262,17 @@ mod tests {
         assert!(is_underline(">>>>>"));
         assert!(is_underline("===== "));
         assert!(is_underline(":::::"));
+    }
+
+    #[test]
+    fn empty_explicit_comment_is_not_a_section_underline() {
+        assert!(!is_underline(".."));
+        assert!(!is_underline(".. "));
+        assert!(!is_underline("  .."));
+        assert!(!is_underline(".. a comment."));
+        assert!(is_underline("..."));
+        assert!(is_underline("...."));
+        assert!(is_underline("....."));
     }
 
     #[test]

--- a/tests/rst_empty_explicit_comment.rs
+++ b/tests/rst_empty_explicit_comment.rs
@@ -1,0 +1,147 @@
+//! GitHub #343 / snapper-wr17: Docutils `Body.explicit` / comment is a
+//! lone `..` at EOL. That is Structure (empty comment), not a `.`
+//! section underline, so the previous paragraph stays Prose and still
+//! splits. `.. a comment.` already works. `...` stays an adornment.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst / GitHub #343).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        "..\n",
+        "After markup. Next sentence.\n",
+    )
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        "Intro sentence here.\n",
+        "Another intro sentence.\n",
+        "..\n",
+        "After markup.\n",
+        "Next sentence.\n",
+    )
+}
+
+#[test]
+fn empty_explicit_markup_is_structure() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.trim() == "..")),
+        "lone .. at EOL must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("Intro sentence here.")
+        )),
+        "previous paragraph must not become a section title, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p)
+                if p.contains("Intro sentence here.") && p.contains("Another intro sentence.")
+        )),
+        "previous paragraph must stay Prose, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After markup.") && p.contains("Next sentence.")
+        )),
+        "following prose must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_empty_comment_and_splits_neighbors() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn text_comment_already_works() {
+    let input = concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        ".. a comment.\n",
+        "After markup. Next sentence.\n",
+    );
+    let regions = RstParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(".. a comment."))),
+        ".. a comment. must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p)
+                if p.contains("Intro sentence here.") && p.contains("Another intro sentence.")
+        )),
+        "previous paragraph must stay Prose, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After markup.") && p.contains("Next sentence.")
+        )),
+        "following prose must stay Prose, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Intro sentence here.\n",
+            "Another intro sentence.\n",
+            ".. a comment.\n",
+            "After markup.\n",
+            "Next sentence.\n",
+        ),
+        "got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn three_dots_stay_a_section_underline() {
+    let input = "Intro sentence here. Another intro sentence.\n...\n";
+    let regions = RstParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("Intro sentence here.")
+        )),
+        "title above ... must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.trim() == "...")),
+        "... must stay a . adornment, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, input, "... must stay a section underline, got:\n{out}");
+    assert!(
+        !out.contains("Intro sentence here.\nAnother intro sentence.\n..."),
+        "must not split a title above ..., got:\n{out}"
+    );
+}


### PR DESCRIPTION
Docutils `Body.explicit` / `comment()`. A lone `..` line is empty
explicit markup, not a section underline.

Snapper treats `..` as a title adornment and freezes the previous
paragraph, so SemBr does not split it.

`..` at EOL is a comment. The previous paragraph stays Prose and
still splits. Following prose still splits. `.. a comment.` already
works.

Closes #343.

Do not hand-edit CHANGELOG.md.
