### PR TITLE
fix(org): wrap export snippets without freezing trailing prose

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -35,7 +35,7 @@ The classification depends on the format.
 - LaTeX environments (=\begin{equation}= ... =\end{equation}=, =\begin{align}=, etc.)
 - Display math (=\[= ... =\]=)
 - Line breaks (org-element-line-break-parser: =\\= plus optional spaces or tabs at end of line)
-- Inline export snippets (=@@latex:\newpage@@=, =@@html:<br>@@=)
+- A line that is only an export snippet (=@@latex:\newpage@@=). Trailing prose after the closer stays Prose.
 
 *** Code regions (=#+BEGIN_SRC= ... =#+END_SRC=)
 :PROPERTIES:
@@ -67,7 +67,7 @@ These tokens within prose are not split across lines:
 - Inline code: =~code~=, ===verbatim===
 - A =~code~= or ===verbatim=== span may contain the marker character; pairing matches pandoc's org reader, so =x = 1= stays one span
 - Markdown inline code: a run of =n= backticks closes on the next run of the same length (CommonMark / pandoc), so a double span can hold a single backtick
-- Inline export snippets: =@@backend:value@@=
+- Inline export snippets: =@@backend:value@@= (org-element-export-snippet-parser; backend =[-A-Za-z0-9]+= so =html5= and hyphen names stay one token)
 - Radio targets: =<<<contents>>>= (org-element-radio-target-parser)
 - Angle targets: =<<contents>>= (org-element-target-parser)
 - Macros: ={{{name}}}= / ={{{name(args)}}}= (org-element-macro-parser)

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -24,9 +24,25 @@ static LATEX_BEGIN_RE: LazyLock<Regex> =
 static LATEX_END_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"^\s*\\end\{([^}]+)\}").unwrap());
 
-/// Matches org inline export snippets: @@backend:value@@
+/// org-element-export-snippet-parser prefix: `@@BACKEND:VALUE@@`.
+/// Backend is `[-A-Za-z0-9]+`. Value may contain spaces (GitHub #354).
 static EXPORT_SNIPPET_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"@@[a-zA-Z]+:[^@]*@@").unwrap());
+    LazyLock::new(|| Regex::new(r"^@@[-A-Za-z0-9]+:[^@]*@@").unwrap());
+
+/// True when the trimmed line is exactly one export snippet.
+pub(crate) fn org_export_snippet_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    EXPORT_SNIPPET_RE
+        .find(trimmed)
+        .is_some_and(|m| m.start() == 0 && m.end() == trimmed.len())
+}
+
+/// True when the line starts with a complete export snippet.
+/// Wrap skip-cut uses this so a snippet with interior spaces is not
+/// parked at BOL (that line would then be Structure).
+pub(crate) fn org_export_snippet_starts(line: &str) -> bool {
+    EXPORT_SNIPPET_RE.is_match(line.trim_start())
+}
 
 /// org-footnote.el `org-footnote-definition-re`: `^\[fn:([-_[:word:]]+)\]`.
 /// Trailing spaces after `]` stay in the marker so reflow hangs the body.
@@ -483,10 +499,9 @@ impl OrgParser {
         }
     }
 
-    /// Check if a line is entirely an inline export snippet (@@backend:...@@)
+    /// Whole-line export snippet. `@@latex:\newpage@@ After.` stays Prose.
     fn is_export_snippet_line(line: &str) -> bool {
-        let trimmed = line.trim();
-        EXPORT_SNIPPET_RE.is_match(trimmed) && trimmed.starts_with("@@")
+        org_export_snippet_line(line)
     }
 
     /// org-element quote-block / verse-block / center-block contain paragraphs.
@@ -1587,6 +1602,29 @@ mod tests {
         assert!(matches!(&regions[0], Region::Prose(_)));
         assert!(matches!(&regions[1], Region::Structure(s) if s.contains("@@latex:")));
         assert!(matches!(&regions[2], Region::Prose(_)));
+    }
+
+    #[test]
+    fn export_snippet_trailing_prose_stays_prose() {
+        let input = "@@latex:\\newpage@@ After the snippet. Next.\n";
+        let regions = OrgParser.parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("@@latex:\\newpage@@")
+                        && s.contains("After the snippet.")
+                        && s.contains("Next.")
+            )),
+            "trailing prose after a snippet must stay Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("After the snippet.")
+            )),
+            "trailing prose must not freeze as Structure, got {regions:?}"
+        );
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -697,6 +697,9 @@ fn org_opens_block(line: &str) -> bool {
     if t.starts_with("$$") {
         return true;
     }
+    if crate::parser::org::org_export_snippet_starts(t) {
+        return true;
+    }
     if crate::parser::org::is_org_drawer_begin(t) || org_fixed_width(t) || org_horizontal_rule(t) {
         return true;
     }
@@ -2797,6 +2800,31 @@ They are endowed with reason and conscience and should act towards one another i
         assert!(
             ten.lines().any(|l| l.starts_with("1234567890. ")),
             "10-digit number may start a wrap line:\n{ten}"
+        );
+    }
+
+    #[test]
+    fn wrap_created_export_snippet_skips_cut_in_org() {
+        // A wrap that parked `@@html5:1. 2@@` at BOL would be Structure
+        // (GitHub #354). Skip-cut keeps the snippet on the previous line.
+        let input = "See @@html5:1. 2@@ today. Next.";
+        let config = crate::FormatConfig {
+            format: crate::format::Format::Org,
+            max_width: 16,
+            ..Default::default()
+        };
+        let result = crate::format_text(input, &config).unwrap();
+        assert!(
+            !result.lines().any(|l| l.starts_with("@@")),
+            "wrap must not invent a whole-line export snippet:\n{result}"
+        );
+        assert!(
+            result.contains("See @@html5:1. 2@@"),
+            "snippet stays on the previous line:\n{result}"
+        );
+        assert!(
+            result.contains("today.\nNext."),
+            "following sentence must still split:\n{result}"
         );
     }
 

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -83,7 +83,9 @@ static INLINE_TOKEN_RE: LazyLock<Regex> = LazyLock::new(|| {
             r"<[^\s<>@]+@[^\s<>]+>",                // Autolink: <user@host>
             r#"https?://\S+[^.\s!?,;:)\]'""]"#,     // URLs (don't swallow trailing punctuation)
             r#"file:\S+[^.\s!?,;:)\]'""]"#, // Org file: links (don't swallow trailing punctuation)
-            r"@@[a-zA-Z]+:[^@]*@@",         // Org inline export snippets: @@backend:value@@
+            // org-element-export-snippet-parser. Backend is [-A-Za-z0-9]+
+            // so html5 and hyphen names stay one token (GitHub #354).
+            r"@@[-A-Za-z0-9]+:[^@]*@@",
         ]
         .join("|"),
     )
@@ -3008,6 +3010,24 @@ mod tests {
             split(text),
             vec!["See H_(2. 0) today.".to_string(), "Next.".to_string()]
         );
+    }
+
+    #[test]
+    fn org_export_snippet_html5_and_hyphen_backends_stay_atomic() {
+        // GitHub #354 / snapper-sxte: org-element backend is [-A-Za-z0-9]+.
+        for token in ["@@html5:1. 2@@", "@@html-5:1. 2@@", "@@latex:1. 2@@"] {
+            let text = format!("See {token} today. Next.");
+            let spans = atomic_inline_spans(&text);
+            assert!(
+                spans.iter().any(|&(s, e)| &text[s..e] == token),
+                "{token} must be an atomic wrap span, got {:?}",
+                spans.iter().map(|&(s, e)| &text[s..e]).collect::<Vec<_>>()
+            );
+            assert_eq!(
+                split(&text),
+                vec![format!("See {token} today."), "Next.".to_string()]
+            );
+        }
     }
 
     #[test]

--- a/tests/org_export_snippet.rs
+++ b/tests/org_export_snippet.rs
@@ -1,0 +1,225 @@
+//! GitHub #354 / snapper-sxte: org-element-export-snippet-parser.
+//! A line that starts with `@@` is not whole-line Structure when prose
+//! follows the closer. Backend is `[-A-Za-z0-9]+` so `html5` and hyphen
+//! names stay one wrap token. Trailing `After the snippet.` / `Next.`
+//! stay Prose and still split. Letter-backend `@@latex:1. 2@@` stays
+//! one token. latex-fragment and brace-subscript wrap stay atomic.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::org::OrgParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn org_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn wrap_cfg(width: usize) -> FormatConfig {
+    FormatConfig {
+        format: Format::Org,
+        max_width: width,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+fn ticket_fixture() -> &'static str {
+    "@@latex:\\newpage@@ After the snippet. Next.\n"
+}
+
+#[test]
+fn ticket_trailing_prose_stays_prose() {
+    let regions = OrgParser.parse(ticket_fixture());
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("@@latex:\\newpage@@")
+                    && s.contains("After the snippet.")
+                    && s.contains("Next.")
+        )),
+        "only the snippet is the object; trailing prose stays Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("After the snippet.")
+        )),
+        "trailing prose must not freeze as Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_identity_splits_trailing_prose() {
+    let input = ticket_fixture();
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("@@latex:\\newpage@@ After the snippet.\nNext."),
+        "After the snippet. / Next. must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("After the snippet. Next."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn ticket_html5_wrap_keeps_snippet_and_splits_next() {
+    let input = "See @@html5:1. 2@@ today. Next.\n";
+    let token = "@@html5:1. 2@@";
+    let out = format_text(input, &wrap_cfg(16)).unwrap();
+    assert!(
+        out.lines().any(|l| l.contains(token)),
+        "html5 snippet must stay one wrap token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("html5:1.\n") && !out.contains("1.\n2@@"),
+        "must not wrap-split inside the html5 snippet, got:\n{out}"
+    );
+    assert!(
+        !out.lines().any(|l| l.trim_start().starts_with("@@")),
+        "wrap must not park the snippet at BOL (that line is Structure), got:\n{out}"
+    );
+    assert!(
+        out.contains("See @@html5:1. 2@@"),
+        "skip-cut keeps the snippet with See, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("today. Next."),
+        "fused trailing prose must not survive, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &wrap_cfg(16)).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        max_width: 16,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn ticket_hyphen_backend_stays_one_wrap_token() {
+    let input = "See @@html-5:1. 2@@ today. Next.\n";
+    let token = "@@html-5:1. 2@@";
+    let out = format_text(input, &wrap_cfg(16)).unwrap();
+    assert!(
+        out.lines().any(|l| l.contains(token)),
+        "hyphen backend must stay one wrap token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("html-5:1.\n") && !out.contains("1.\n2@@"),
+        "must not wrap-split inside the hyphen snippet, got:\n{out}"
+    );
+    assert!(
+        !out.lines().any(|l| l.trim_start().starts_with("@@")),
+        "wrap must not park the hyphen snippet at BOL, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &wrap_cfg(16)).unwrap(), out);
+
+    let guarded = FormatConfig {
+        format: Format::Org,
+        max_width: 16,
+        ..Default::default()
+    };
+    let guarded_out = format_text(input, &guarded).unwrap();
+    assert_eq!(
+        guarded_out, out,
+        "oracle-on path must match, got:\n{guarded_out}"
+    );
+}
+
+#[test]
+fn ticket_letter_backend_stays_one_token() {
+    let input = "See @@latex:1. 2@@ today. Next.\n";
+    let token = "@@latex:1. 2@@";
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains(token),
+        "letter-backend snippet must stay one token, got:\n{out}"
+    );
+    assert!(
+        !out.contains("latex:1.\n") && !out.contains("1.\n2@@"),
+        "must not split inside @@latex:1. 2@@, got:\n{out}"
+    );
+    assert!(
+        out.contains("today.\nNext."),
+        "following sentence must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
+}
+
+#[test]
+fn whole_line_snippet_stays_structure() {
+    let input = "Text before.\n@@latex:\\newpage@@\nText after.\n";
+    let regions = OrgParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains("@@latex:\\newpage@@"))),
+        "a line that is only a snippet stays Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn latex_fragment_and_brace_subscript_stay_atomic() {
+    let frag = format_text(
+        "The root is \\(\\alpha. \\beta\\) today. Next.\n",
+        &wrap_cfg(12),
+    )
+    .unwrap();
+    assert!(
+        frag.contains("\\(\\alpha. \\beta\\)"),
+        "latex-fragment wrap must stay atomic, got:\n{frag}"
+    );
+    assert!(
+        !frag.contains("\\(\\alpha.\n") && !frag.contains("alpha.\n\\beta"),
+        "must not wrap inside the fragment, got:\n{frag}"
+    );
+    assert!(
+        frag.contains("today.\nNext."),
+        "fragment trailing sentence must still split, got:\n{frag}"
+    );
+
+    let sub = format_text("See H_{2. 0} today. Next.\n", &wrap_cfg(10)).unwrap();
+    assert!(
+        sub.lines().any(|l| l.contains("H_{2. 0}")),
+        "brace-subscript wrap must stay atomic, got:\n{sub}"
+    );
+    assert!(
+        !sub.contains("2.\n0") && !sub.contains("H_{2.\n"),
+        "must not wrap on the interior period, got:\n{sub}"
+    );
+    assert!(
+        sub.contains("today.\nNext."),
+        "subscript trailing sentence must still split, got:\n{sub}"
+    );
+}


### PR DESCRIPTION
Emacs `org-element-export-snippet-parser`. A line that starts with
`@@` becomes whole-line Structure, so trailing prose does not SemBr.
Backend must be `[A-Za-z]+` so html5 and hyphen backends wrap-split.

Only the snippet is the object. Trailing prose still splits. Backend
is `[-A-Za-z0-9]+`. Letter-backend `@@latex:1. 2@@` stays one token.

Closes #354.

Do not hand-edit CHANGELOG.md.
