### PR TITLE
fix(rst): treat unmatched simple-table top as structure

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -553,19 +553,20 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // `is_underline` rejects those borders (interior spaces), so without
         // this the header/body rows fall through to prose and get joined.
         // Interior blanks stay BlankLines; the walk still reaches the closer.
+        // A top with no matching closer still isolates the top line so
+        // SemBr cannot join it onto following flush prose (GitHub #347).
         if is_simple_table_border(line_text) {
-            if let Some(end) = simple_table_end(&lines, i) {
-                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-                for row in &lines[i..=end] {
-                    if row.text.trim().is_empty() {
-                        regions.push(SpannedRegion::blank(input, row.span()));
-                    } else {
-                        regions.push(SpannedRegion::structure(input, row.span()));
-                    }
+            flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            let end = simple_table_end(&lines, i).unwrap_or(i);
+            for row in &lines[i..=end] {
+                if row.text.trim().is_empty() {
+                    regions.push(SpannedRegion::blank(input, row.span()));
+                } else {
+                    regions.push(SpannedRegion::structure(input, row.span()));
                 }
-                i = end + 1;
-                continue;
             }
+            i = end + 1;
+            continue;
         }
 
         // Definition list: flush term plus an immediately indented definition.
@@ -1200,7 +1201,8 @@ fn is_definition_term(lines: &[Line<'_>], i: usize) -> bool {
 /// matching-width `=` border and does not stop on blanks. Close on the
 /// second matching-width border, or on the first when the next line is
 /// blank or the input ends. A different-width `=` border is malformed
-/// and is not a closer.
+/// and is not a closer. No matching closer: `None`, and the caller
+/// keeps the top as Structure (GitHub #347 / `simple_table_top`).
 fn simple_table_end(lines: &[Line<'_>], start: usize) -> Option<usize> {
     let toplen = lines[start].text.trim().len();
     let mut found = 0u32;

--- a/tests/rst_simple_table_top.rs
+++ b/tests/rst_simple_table_top.rs
@@ -1,0 +1,124 @@
+//! GitHub #347 / snapper-asnu: Docutils `simple_table_top` is
+//! `=+( +=+)+ *$`. A top with no matching closer is Structure; following
+//! flush prose stays Prose and still splits. A closed simple table stays
+//! identity.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst / GitHub #347).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        "=====  =====\n",
+        "After table. Next sentence.\n",
+    )
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        "Intro sentence here.\n",
+        "Another intro sentence.\n",
+        "=====  =====\n",
+        "After table.\n",
+        "Next sentence.\n",
+    )
+}
+
+fn closed_simple_table() -> &'static str {
+    concat!(
+        "=====  =====\n",
+        "Name   Value\n",
+        "=====  =====\n",
+        "A      B\n",
+        "=====  =====\n",
+    )
+}
+
+#[test]
+fn unclosed_simple_table_top_is_structure() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.trim() == "=====  =====")),
+        "unclosed simple_table_top must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains("=====")
+        )),
+        "unclosed simple_table_top must not fall through to Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("Another intro sentence.") && s.contains("After table.")
+        )),
+        "top must not join intro prose to following prose, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p)
+                if p.contains("Intro sentence here.") && p.contains("Another intro sentence.")
+        )),
+        "previous paragraph must stay Prose, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After table.") && p.contains("Next sentence.")
+        )),
+        "following prose must stay Prose, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_keeps_top_and_splits_neighbors() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn closed_simple_table_stays_identity() {
+    let input = closed_simple_table();
+    let regions = RstParser.parse(input);
+    for needle in ["=====  =====", "Name   Value", "A      B"] {
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains(needle))),
+            "closed table line {needle:?} must be Structure, got {regions:?}"
+        );
+    }
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("Name") || s.contains("A      B") || s.contains("=====")
+        )),
+        "closed simple table must not be Prose, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "closed simple table must stay identity, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}


### PR DESCRIPTION
Docutils `simple_table_top`. A top rule with no matching closer is
still a table opener, not Prose that joins the next flush line.

Closes #347.

Do not hand-edit CHANGELOG.md.
