### PR TITLE
fix(rst): hang and split same-line note body after ::

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -259,9 +259,26 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // hangs and reflows like a block quote. Opaque names keep the
         // old freeze (GitHub #54). A flush paragraph after a compact
         // container body is a new paragraph, not more note (GitHub #344).
+        // Specific admonitions nested-parse same-line text after `::`
+        // as the first body paragraph: marker Structure, body hung
+        // Prose that still splits (GitHub #349).
         let trimmed = line_text.trim_start();
         if trimmed.starts_with(".. ") && trimmed.contains("::") {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
+            if let Some(marker_len) = rst_admonition_marker_len(line_text) {
+                if line_text.len() > marker_len && !line_text[marker_len..].trim().is_empty() {
+                    list_hang = Some(marker_len);
+                    in_container_body = true;
+                    regions.push(SpannedRegion::structure(
+                        input,
+                        ByteSpan::new(line.start, line.start + marker_len),
+                    ));
+                    current_prose.push_str(line_text[marker_len..].trim());
+                    prose_span = Some(ByteSpan::new(line.start + marker_len, line.end));
+                    i += 1;
+                    continue;
+                }
+            }
             regions.push(SpannedRegion::structure(input, line.span()));
             if rst_directive_name(trimmed).is_some_and(|n| is_rst_container_directive(&n)) {
                 in_container_body = true;
@@ -743,10 +760,9 @@ fn rst_directive_name(trimmed: &str) -> Option<String> {
     Some(name.to_ascii_lowercase())
 }
 
-/// Docutils admonitions plus figure/topic/sidebar/container: bodies
-/// nested-parse, so hang + reflow. Option fields stay Structure via
-/// the field-list arm. Other directive names stay opaque.
-fn is_rst_container_directive(name: &str) -> bool {
+/// Docutils specific admonitions: no arguments; same-line text after
+/// `::` is the first nested-parsed body paragraph (GitHub #349).
+fn is_rst_specific_admonition(name: &str) -> bool {
     matches!(
         name,
         "note"
@@ -758,12 +774,50 @@ fn is_rst_container_directive(name: &str) -> bool {
             | "hint"
             | "error"
             | "attention"
-            | "admonition"
-            | "figure"
-            | "topic"
-            | "sidebar"
-            | "container"
     )
+}
+
+/// Docutils admonitions plus figure/topic/sidebar/container: bodies
+/// nested-parse, so hang + reflow. Option fields stay Structure via
+/// the field-list arm. Other directive names stay opaque.
+fn is_rst_container_directive(name: &str) -> bool {
+    is_rst_specific_admonition(name)
+        || matches!(
+            name,
+            "admonition" | "figure" | "topic" | "sidebar" | "container"
+        )
+}
+
+/// Byte length of a specific-admonition opener (`.. note::` plus
+/// following whitespace, including leading indent). `None` when the
+/// line is not a no-argument admonition. Body text after the marker
+/// is not included, so `Some(s.len())` is the Structure prefix used
+/// for hang (GitHub #349).
+pub(crate) fn rst_admonition_marker_len(line: &str) -> Option<usize> {
+    let indent = line.len() - line.trim_start().len();
+    let trimmed = &line[indent..];
+    let rest = trimmed.strip_prefix("..")?;
+    if !rest.starts_with([' ', '\t']) {
+        return None;
+    }
+    let name_off = rest.len() - rest.trim_start().len();
+    let after_ws = &rest[name_off..];
+    let name_end = after_ws.find("::")?;
+    let name = after_ws[..name_end].trim();
+    if name.is_empty()
+        || !name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'-' | b'_' | b'.'))
+    {
+        return None;
+    }
+    if !is_rst_specific_admonition(&name.to_ascii_lowercase()) {
+        return None;
+    }
+    let colons_at = indent + 2 + name_off + name_end;
+    let after_colons = &line[colons_at + 2..];
+    let pad = after_colons.len() - after_colons.trim_start().len();
+    Some(colons_at + 2 + pad)
 }
 
 /// True when `trimmed` is an RST comment opener, not a `.. name::`
@@ -3106,6 +3160,43 @@ mod tests {
             "After markup must not inherit the note hang, got:\n{out}"
         );
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
+    /// Ticket fixture (Format::Rst / GitHub #349): same-line note body.
+    fn same_line_note_fixture() -> &'static str {
+        ".. note:: This is a long note sentence that must reflow. Second sentence.\n"
+    }
+
+    #[test]
+    fn same_line_note_opener_is_structure_body_is_hung_prose() {
+        let regions = RstParser.parse(same_line_note_fixture());
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == ".. note:: ")),
+            "opener .. note:: must stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("This is a long note sentence that must reflow.")
+                        && s.contains("Second sentence.")
+            )),
+            "same-line note body must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("This is a long note sentence")
+            )),
+            "same-line note body must not stay whole-line Structure, got {regions:?}"
+        );
+        assert_eq!(
+            rst_admonition_marker_len(".. note:: "),
+            Some(".. note:: ".len())
+        );
+        assert_eq!(rst_admonition_marker_len(".. figure:: image.png"), None);
     }
 
     #[test]

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1132,6 +1132,11 @@ fn hanging_indent_width(s: &str) -> usize {
     if crate::parser::rst::rst_footnote_citation_marker_len(s) == Some(s.len()) {
         return s.chars().count();
     }
+    // RST specific admonition (`.. note:: `): hang at marker width so
+    // same-line body stays a hung paragraph (GitHub #349).
+    if crate::parser::rst::rst_admonition_marker_len(s) == Some(s.len()) {
+        return s.chars().count();
+    }
     // RST field marker (`:Author: `, `:py:mod: `): hang at marker
     // width so the body stays a hung paragraph (GitHub #341).
     if crate::parser::rst::rst_field_marker_len(s) == Some(s.len()) {
@@ -1871,6 +1876,10 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_indent_width(".. [CIT2002] "), 13);
         assert_eq!(hanging_prefix(".. [1] "), "       ");
         assert_eq!(hanging_prefix(".. [CIT2002] "), "             ");
+        assert_eq!(hanging_indent_width(".. note:: "), 10);
+        assert_eq!(hanging_prefix(".. note:: "), "          ");
+        assert_eq!(hanging_indent_width(".. warning:: "), 13);
+        assert_eq!(hanging_indent_width(".. figure:: "), 0);
         assert_eq!(hanging_indent_width("[fn:1] "), 7);
         assert_eq!(hanging_indent_width("[fn:note] "), 10);
         assert_eq!(hanging_prefix("[fn:1] "), "       ");
@@ -1921,6 +1930,28 @@ They are endowed with reason and conscience and should act towards one another i
         assert!(
             !result.contains("\nSecond sentence."),
             "second sentence must not land at column 0, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn rst_same_line_note_hangs_second_sentence() {
+        let result = reflow_regions(vec![
+            Region::Structure(".. note:: ".to_string()),
+            Region::Prose(
+                "This is a long note sentence that must reflow. Second sentence.".to_string(),
+            ),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            concat!(
+                ".. note:: This is a long note sentence that must reflow.\n",
+                "          Second sentence.\n",
+            )
+        );
+        assert!(
+            !result.contains("\nSecond sentence."),
+            "second sentence must hang, got:\n{result}"
         );
     }
 

--- a/tests/rst_same_line_note.rs
+++ b/tests/rst_same_line_note.rs
@@ -1,0 +1,247 @@
+//! GitHub #349 / snapper-lo9y: Docutils note nested-parses same-line
+//! text after `::`. The opener is Structure; the two sentences stay
+//! Prose and still split. Indented note bodies already hang.
+//! Isolate after #347 (unmatched simple-table top).
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst / GitHub #349).
+fn ticket_fixture() -> &'static str {
+    ".. note:: This is a long note sentence that must reflow. Second sentence.\n"
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        ".. note:: This is a long note sentence that must reflow.\n",
+        "          Second sentence.\n",
+    )
+}
+
+#[test]
+fn same_line_note_opener_is_structure_body_is_prose() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == ".. note:: ")),
+        "opener .. note:: must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("This is a long note sentence that must reflow.")
+                    && s.contains("Second sentence.")
+        )),
+        "same-line note body must be Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("This is a long note sentence")
+        )),
+        "same-line note body must not stay whole-line Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_hangs_and_splits() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn indented_note_body_still_hangs() {
+    let input = concat!(
+        ".. note::\n",
+        "\n",
+        "   This is a long note sentence that must reflow. Second sentence.\n",
+        "\n",
+        "After the note. Next.\n",
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            ".. note::\n",
+            "\n",
+            "   This is a long note sentence that must reflow.\n",
+            "   Second sentence.\n",
+            "\n",
+            "After the note.\n",
+            "Next.\n",
+        ),
+        "indented note body from #54 must stay, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn compact_note_flush_paragraph_still_stays_unindented() {
+    let input = concat!(
+        "Intro sentence here. Another intro sentence.\n",
+        ".. note::\n",
+        "   Body here. Second body.\n",
+        "After markup. Next sentence.\n",
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "Intro sentence here.\n",
+            "Another intro sentence.\n",
+            ".. note::\n",
+            "   Body here.\n",
+            "   Second body.\n",
+            "After markup.\n",
+            "Next sentence.\n",
+        ),
+        "#344 compact note must stay, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\n   After markup."),
+        "After markup must stay flush, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn same_line_note_does_not_swallow_flush_paragraph() {
+    let input = concat!(
+        ".. note:: This is a long note sentence that must reflow. Second sentence.\n",
+        "After markup. Next sentence.\n",
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            ".. note:: This is a long note sentence that must reflow.\n",
+            "          Second sentence.\n",
+            "After markup.\n",
+            "Next sentence.\n",
+        ),
+        "After markup must stay flush after same-line note, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\n          After markup."),
+        "After markup must not inherit the note hang, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn leftover_specific_admonitions_same_line_hang() {
+    for name in [
+        "warning",
+        "caution",
+        "danger",
+        "tip",
+        "important",
+        "hint",
+        "error",
+        "attention",
+    ] {
+        let opener = format!(".. {name}:: ");
+        let hang = " ".repeat(opener.len());
+        let input = format!(
+            ".. {name}:: This is a long note sentence that must reflow. Second sentence.\n"
+        );
+        let out = format_text(&input, &rst_cfg()).unwrap();
+        assert_eq!(
+            out,
+            format!(
+                "{opener}This is a long note sentence that must reflow.\n{hang}Second sentence.\n"
+            ),
+            "{name} same-line body must hang and split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+    }
+}
+
+#[test]
+fn figure_same_line_argument_stays_structure() {
+    let input = ".. figure:: image.png\n\n   This is a long note sentence that must reflow. Second sentence.\n";
+    let regions = RstParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(".. figure:: image.png"))),
+        "figure URI argument must stay Structure, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(s) if s.contains("image.png"))),
+        "figure URI must not become Prose, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert!(
+        out.contains(".. figure:: image.png\n"),
+        "figure opener must stay identity, got:\n{out}"
+    );
+    assert!(
+        out.contains("   This is a long note sentence that must reflow.\n   Second sentence.\n"),
+        "figure body must still hang, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn closed_simple_table_stays_identity() {
+    let input = concat!(
+        "=====  =====\n",
+        "Name   Value\n",
+        "=====  =====\n",
+        "A      B\n",
+        "=====  =====\n",
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out, input,
+        "#347 closed simple table must stay, got:\n{out}"
+    );
+}
+
+#[test]
+fn opaque_directives_stay_frozen() {
+    for (label, input, needle) in [
+        (
+            "raw",
+            ".. raw:: html\n\n   <p>This is a long note sentence that must reflow. Second sentence.</p>\n",
+            "<p>This is a long note sentence that must reflow. Second sentence.</p>",
+        ),
+        (
+            "code-block",
+            ".. code-block:: python\n\n   print(\"This is a long note sentence that must reflow. Second sentence.\")\n",
+            "print(\"This is a long note sentence that must reflow. Second sentence.\")",
+        ),
+    ] {
+        let regions = RstParser.parse(input);
+        assert!(
+            !regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(s) if s.contains("This is a long note"))),
+            "{label} body must not be Prose, got {regions:?}"
+        );
+        let out = format_text(input, &rst_cfg()).unwrap();
+        assert!(
+            out.contains(needle),
+            "{label} body must stay opaque, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+    }
+}


### PR DESCRIPTION
Docutils nested-parses same-line text after `.. note::` as the first body paragraph.

The opener stays Structure. The two sentences stay Prose and still split. Indented note bodies already hang.

Closes #349.

Do not hand-edit CHANGELOG.md.
