### PR TITLE
fix(latex): tokenize listings lstinputlisting like lstinline

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -187,10 +187,11 @@ Adding =algorithm= stops reflow of that environment.
 
 String array of extra command names tokenized like the built-in verb command before sentence split.
 The next character after the name is the delimiter.
-Built-in names are =verb=, =lstinline=, =spverb=, =mintinline=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb=, and piton.sty =\piton=; =lstinline= still accepts optional =[...]= and ={...}=.
+Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb=, and piton.sty =\piton=; =lstinline= still accepts optional =[...]= and ={...}=.
 =mintinline= / =mint= take optional =[...]=, a ={lang}= argument, then a delimiter or ={...}= body.
 =SaveVerb= takes optional =[...]=, a ={name}= argument, then the same delimiter body as =Verb=.
 =\piton|...|= is verb-like (interior =.!?%= stay one token); =\piton{...}= stays one token via the generic command argument.
+=\lstinputlisting= takes optional =[...]= then a required ={filename}=; following flush prose stays on its own line.
 Adding another name keeps that command's delimited body atomic and treats an inner =%= as content, not a comment.
 
 * Code-block sections (=[code.<lang>]=)

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -134,8 +134,9 @@ These tokens within prose are not split across lines:
 - piton.sty =Piton= is a built-in code region (verbatim listing env)
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= / =minted*= language arg, =lstlisting= / =lstlisting*= =language== option)
-- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= / piton.sty =\piton= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment.
+- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= / piton.sty =\piton= / listings.sty =\lstinputlisting= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment.
   =\piton|...|= is verb-like; =\piton{...}= stays one token via the generic command argument
+  =\lstinputlisting= / =\lstinputlisting*= take optional =[...]= then a ={filename}=; a flush following sentence stays on its own line
 
 *** Prose regions (reflowed)
 :PROPERTIES:

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub struct FormatOverrides {
     pub structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
     /// Meaningful under `[latex]` only. Missing or empty keeps
-    /// verb/lstinline/spverb/mintinline/mint/Verb/SaveVerb/piton.
+    /// verb/lstinline/lstinputlisting/spverb/mintinline/mint/Verb/SaveVerb/piton.
     pub verbatim_commands: Vec<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub struct FormatConfig {
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.
     pub latex_structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
-    /// Empty keeps verb/lstinline/spverb/mintinline/mint/Verb/SaveVerb/piton.
+    /// Empty keeps verb/lstinline/lstinputlisting/spverb/mintinline/mint/Verb/SaveVerb/piton.
     pub latex_verbatim_commands: Vec<String>,
 }
 

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -501,7 +501,8 @@ impl LatexParser {
 
     /// Byte offset of the first `%` that is not escaped as `\%` and is not
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
-    /// `\Verb` / `\SaveVerb` / `\piton` / configured verbatim commands.
+    /// `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
+    /// configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -874,7 +875,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 
 /// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` /
 /// `\spverb` / `\mintinline` / `\mint` / `\Verb` / `\SaveVerb` /
-/// `\piton` spans.
+/// `\piton` / `\lstinputlisting` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -889,6 +890,30 @@ fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usi
                     return Some(i);
                 }
                 i += name.len();
+                continue;
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// listings.sty `\lstinputlisting[...]{file}` span, skipping other verb
+/// commands so `\verb|\lstinputlisting{x}|` is not stolen (GitHub #391).
+fn find_lstinputlisting_span(
+    text: &str,
+    from: usize,
+    extra_cmds: &[String],
+) -> Option<(usize, usize)> {
+    let bytes = text.as_bytes();
+    let mut i = from;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' {
+            if let Some(end) = latex_verb_span_end_with(text, i, extra_cmds) {
+                if text[i + 1..].starts_with("lstinputlisting") {
+                    return Some((i, end));
+                }
+                i = end;
                 continue;
             }
         }
@@ -1578,6 +1603,19 @@ impl<'a> ParseState<'a> {
                     ByteSpan::new(line.start + open, line.end),
                 ));
                 return true;
+            }
+            if let Some((start, end)) =
+                find_lstinputlisting_span(code, i, &self.parser.extra_verbatim_commands)
+            {
+                self.append_item_or_prose(line.start + i, &code[i..start]);
+                let cmd_end = if code[end..].trim().is_empty() {
+                    thru_eol_if_blank_rest(line, end)
+                } else {
+                    line.start + end
+                };
+                self.push_structure(ByteSpan::new(line.start + start, cmd_end));
+                i = end;
+                continue;
             }
             if SECTION_CMD_RE.is_match(rest) {
                 self.push_structure(ByteSpan::new(line.start + i, line.end));
@@ -2296,6 +2334,108 @@ Some text.
             "prose after lstinline must remain, got:\n{out}"
         );
         assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    /// Ticket fixture (GitHub #391): listings.sty `\lstinputlisting{file}`
+    /// is one atomic command. Following flush prose does not join onto
+    /// the command line. `After.` / `Next.` still split. `lstinline` /
+    /// `lstlisting` unchanged.
+    #[test]
+    fn lstinputlisting_does_not_join_following_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "Before. Next.\n",
+            "\\lstinputlisting{foo.py}\n",
+            "After. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\lstinputlisting{foo.py}")
+            )),
+            "lstinputlisting must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\lstinputlisting{foo.py}")
+            )),
+            "lstinputlisting must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+            )),
+            "After. / Next. must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\lstinputlisting{foo.py}\n"),
+            "lstinputlisting must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\lstinputlisting{foo.py} After."),
+            "following flush prose must not join the command line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before.\nNext."),
+            "prose before lstinputlisting must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after lstinputlisting must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let opts = concat!(
+            "Before. Next.\n",
+            "\\lstinputlisting[language=Python]{foo.py}\n",
+            "After. Next.\n",
+        );
+        let opts_out = format_text(opts, &latex_cfg()).unwrap();
+        assert!(
+            opts_out.contains("\\lstinputlisting[language=Python]{foo.py}\n"),
+            "lstinputlisting optional args must stay atomic, got:\n{opts_out}"
+        );
+        assert!(
+            !opts_out.contains("\\lstinputlisting[language=Python]{foo.py} After."),
+            "optional-arg lstinputlisting must not join following prose, got:\n{opts_out}"
+        );
+        assert!(
+            opts_out.contains("After.\nNext."),
+            "prose after optional-arg lstinputlisting must still split, got:\n{opts_out}"
+        );
+
+        let lstinline = "Use \\lstinline!a.b! here. Next sentence.\n";
+        let lstinline_out = format_text(lstinline, &latex_cfg()).unwrap();
+        assert!(
+            lstinline_out.contains("Use \\lstinline!a.b! here.\nNext sentence."),
+            "lstinline must stay intact and still split, got:\n{lstinline_out}"
+        );
+
+        let lstlisting = concat!(
+            "\\begin{lstlisting}\n",
+            "First line. Second line.\n",
+            "\\end{lstlisting}\n",
+            "After the block. Next.\n",
+        );
+        let lstlisting_out = format_text(lstlisting, &latex_cfg()).unwrap();
+        assert!(
+            lstlisting_out
+                .contains("\\begin{lstlisting}\nFirst line. Second line.\n\\end{lstlisting}"),
+            "lstlisting must stay a code env, got:\n{lstlisting_out}"
+        );
+        assert!(
+            lstlisting_out.contains("After the block.\nNext."),
+            "prose after lstlisting must still split, got:\n{lstlisting_out}"
+        );
+        assert_eq!(
+            format_text(&lstlisting_out, &latex_cfg()).unwrap(),
+            lstlisting_out
+        );
     }
 
     /// Ticket fixture (GitHub #245): minted `\mintinline{lang}|body|` is

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -898,28 +898,46 @@ fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usi
     None
 }
 
-/// listings.sty `\lstinputlisting[...]{file}` span, skipping other verb
-/// commands so `\verb|\lstinputlisting{x}|` is not stolen (GitHub #391).
-fn find_lstinputlisting_span(
-    text: &str,
+/// Leftover listings.sty `\lstinputlisting` / `\lstinputlisting*`
+/// (optional `[...]`, required `{file}`; GitHub #391). Other verb
+/// spans are skipped so `\verb|\lstinputlisting{x}|` is not stolen.
+fn find_lstinputlisting_at(
+    line: &str,
     from: usize,
     extra_cmds: &[String],
 ) -> Option<(usize, usize)> {
-    let bytes = text.as_bytes();
+    let bytes = line.as_bytes();
     let mut i = from;
-    while i < bytes.len() {
+    let stop = unescaped_percent_with(line, extra_cmds).unwrap_or(line.len());
+    while i < stop {
         if bytes[i] == b'\\' {
-            if let Some(end) = latex_verb_span_end_with(text, i, extra_cmds) {
-                if text[i + 1..].starts_with("lstinputlisting") {
+            if lstinputlisting_cs_at(line, i) {
+                if let Some(end) = latex_verb_span_end_with(line, i, extra_cmds) {
                     return Some((i, end));
                 }
+            }
+            if let Some(end) = latex_verb_span_end_with(line, i, extra_cmds) {
                 i = end;
+                continue;
+            }
+            if let Some(name) = tex_cs_at(line, i) {
+                i += name.len();
                 continue;
             }
         }
         i += 1;
     }
     None
+}
+
+fn lstinputlisting_cs_at(line: &str, at: usize) -> bool {
+    let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
+        return false;
+    };
+    let Some(after) = tail.strip_prefix("lstinputlisting") else {
+        return false;
+    };
+    !after.starts_with(|c: char| c.is_ascii_alphabetic())
 }
 
 struct ParseState<'a> {
@@ -1605,15 +1623,13 @@ impl<'a> ParseState<'a> {
                 return true;
             }
             if let Some((start, end)) =
-                find_lstinputlisting_span(code, i, &self.parser.extra_verbatim_commands)
+                find_lstinputlisting_at(code, i, &self.parser.extra_verbatim_commands)
             {
                 self.append_item_or_prose(line.start + i, &code[i..start]);
-                let cmd_end = if code[end..].trim().is_empty() {
-                    thru_eol_if_blank_rest(line, end)
-                } else {
-                    line.start + end
-                };
-                self.push_structure(ByteSpan::new(line.start + start, cmd_end));
+                self.push_structure(ByteSpan::new(
+                    line.start + start,
+                    thru_eol_if_blank_rest(line, end),
+                ));
                 i = end;
                 continue;
             }
@@ -2337,8 +2353,8 @@ Some text.
     }
 
     /// Ticket fixture (GitHub #391): listings.sty `\lstinputlisting{file}`
-    /// is one atomic command. Following flush prose does not join onto
-    /// the command line. `After.` / `Next.` still split. `lstinline` /
+    /// is one leftover command. Following flush prose does not join the
+    /// command line. `After.` / `Next.` still split. `lstinline` /
     /// `lstlisting` unchanged.
     #[test]
     fn lstinputlisting_does_not_join_following_prose() {

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -198,7 +198,8 @@ pub fn protect_inline_tokens_with(
 
 /// `\verb|...|` / `\lstinline[...]!...!` / `\spverb|...|` /
 /// `\mintinline{lang}|...|` / `\mint{lang}{...}` / `\Verb|...|` /
-/// `\SaveVerb{name}|...|` / `\piton|...|` so inner `.!?%` cannot
+/// `\SaveVerb{name}|...|` / `\piton|...|` /
+/// `\lstinputlisting[...]{file}` so inner `.!?%` cannot
 /// split or comment. `\piton{...}` stays on the generic `\cmd{arg}`
 /// path (piton.sty brace syntax is not verbatim; GitHub #305).
 fn protect_latex_verbatim(
@@ -225,8 +226,8 @@ fn protect_latex_verbatim(
 }
 
 /// Byte end of a `\verb` / `\lstinline` / `\spverb` / `\mintinline` /
-/// `\mint` / `\Verb` / `\SaveVerb` / `\piton` / extra-name span
-/// starting at `at`.
+/// `\mint` / `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
+/// extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
 /// character is the
@@ -239,7 +240,10 @@ fn protect_latex_verbatim(
 /// body as `\Verb` (fancyvrb FVExtraReadVArg; GitHub #275). `\piton`
 /// (piton.sty; GitHub #305) is verb-like for a non-brace delimiter
 /// (`\piton|...|`); a following `{` is not a delimiter so `\piton{...}`
-/// stays on the generic `\cmd{arg}` path. Extra names are tokenized
+/// stays on the generic `\cmd{arg}` path. `\lstinputlisting` /
+/// `\lstinputlisting*` (listings.sty; GitHub #391) take optional
+/// `[...]` then a required `{filename}` brace; no brace is not a span
+/// so a following delimiter is not stolen. Extra names are tokenized
 /// like `\verb`. With no closer, the span runs to end of line so an
 /// inner `%` is not a comment.
 pub(crate) fn latex_verb_span_end_with(
@@ -259,6 +263,14 @@ pub(crate) fn latex_verb_span_end_with(
             return None;
         }
         (after_bs + "mintinline".len(), VerbKind::Mint)
+    } else if let Some(stripped) = tail.strip_prefix("lstinputlisting") {
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (
+            after_bs + "lstinputlisting".len(),
+            VerbKind::Lstinputlisting,
+        )
     } else if let Some(stripped) = tail.strip_prefix("lstinline") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -315,7 +327,7 @@ pub(crate) fn latex_verb_span_end_with(
 
     if matches!(
         kind,
-        VerbKind::Lstinline | VerbKind::Mint | VerbKind::SaveVerb
+        VerbKind::Lstinline | VerbKind::Lstinputlisting | VerbKind::Mint | VerbKind::SaveVerb
     ) {
         i = skip_ascii_ws(text, i);
         if text.get(i..).is_some_and(|s| s.starts_with('[')) {
@@ -324,6 +336,15 @@ pub(crate) fn latex_verb_span_end_with(
                 None => return Some(line_end(text, i)),
             }
         }
+    }
+
+    // listings.sty `\lstinputlisting[opts]{file}` is brace-only.
+    if kind == VerbKind::Lstinputlisting {
+        if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
+            return None;
+        }
+        i += 1;
+        return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
     }
 
     if kind == VerbKind::Mint {
@@ -380,6 +401,8 @@ enum VerbKind {
     Delim,
     /// `\lstinline`: optional `[...]` then delimiter or `{...}`.
     Lstinline,
+    /// `\lstinputlisting`: optional `[...]` then required `{filename}`.
+    Lstinputlisting,
     /// `\mintinline` / `\mint`: optional `[...]`, `{lang}`, then body.
     Mint,
     /// `\SaveVerb`: optional `[...]`, `{name}`, then delimiter body like `\Verb`.
@@ -403,6 +426,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
         if name.is_empty()
             || name == "verb"
             || name == "lstinline"
+            || name == "lstinputlisting"
             || name == "spverb"
             || name == "mintinline"
             || name == "mint"
@@ -2051,6 +2075,55 @@ mod tests {
                 r"See \lstinline[language=TeX]!a.b%! please.".to_string(),
                 "Next.".to_string()
             ]
+        );
+    }
+
+    /// Ticket fixture (GitHub #391): listings.sty `\lstinputlisting{file}`
+    /// is one token like `\lstinline`; following `After.` still splits.
+    #[test]
+    fn latex_lstinputlisting_stays_atomic() {
+        let text = r"See \lstinputlisting{foo.py} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders
+                .iter()
+                .any(|p| p == r"\lstinputlisting{foo.py}"),
+            "lstinputlisting span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\lstinputlisting{foo.py}", 0, &[]),
+            Some(r"\lstinputlisting{foo.py}".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \lstinputlisting{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        let opts = r"See \lstinputlisting[language=Python]{foo.py} here. After.";
+        let (_, opt_ph) = protect_inline_tokens(opts);
+        assert!(
+            opt_ph
+                .iter()
+                .any(|p| p == r"\lstinputlisting[language=Python]{foo.py}"),
+            "lstinputlisting optional args must be protected, got {opt_ph:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\lstinputlisting[language=Python]{foo.py}", 0, &[]),
+            Some(r"\lstinputlisting[language=Python]{foo.py}".len())
+        );
+        assert_eq!(
+            split(opts),
+            vec![
+                r"See \lstinputlisting[language=Python]{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\lstinputlisting foo.py", 0, &[]),
+            None,
+            "lstinputlisting without a brace file arg is not a verb span"
         );
     }
 

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -241,9 +241,9 @@ fn protect_latex_verbatim(
 /// (piton.sty; GitHub #305) is verb-like for a non-brace delimiter
 /// (`\piton|...|`); a following `{` is not a delimiter so `\piton{...}`
 /// stays on the generic `\cmd{arg}` path. `\lstinputlisting` /
-/// `\lstinputlisting*` (listings.sty; GitHub #391) take optional
-/// `[...]` then a required `{filename}` brace; no brace is not a span
-/// so a following delimiter is not stolen. Extra names are tokenized
+/// `\lstinputlisting*` (listings.sty leftover; GitHub #391) take optional
+/// `[...]` then a required `{filename}`; no brace is not a span.
+/// Extra names are tokenized
 /// like `\verb`. With no closer, the span runs to end of line so an
 /// inner `%` is not a comment.
 pub(crate) fn latex_verb_span_end_with(
@@ -2124,6 +2124,11 @@ mod tests {
             latex_verb_span_end_with(r"\lstinputlisting foo.py", 0, &[]),
             None,
             "lstinputlisting without a brace file arg is not a verb span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\lstinline{foo.py}", 0, &[]),
+            Some(r"\lstinline{foo.py}".len()),
+            "lstinputlisting must not steal lstinline"
         );
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -66,6 +66,8 @@
 //! body is a raw listing.
 //! GitHub #342: texments.sty / pygmentex.sty pygmented is
 //! VerbatimEnvironment plus VerbatimOut.
+//! GitHub #391: listings.sty \\lstinputlisting is one atomic command;
+//! following flush prose does not join the command line.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -2958,6 +2960,82 @@ fn saveverb_fixture_is_atomic_and_does_not_reflow() {
         "prose after SaveVerb must still split, got:\n{out}"
     );
     assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+}
+
+/// Ticket fixture (GitHub #391): listings.sty `\lstinputlisting{file}`
+/// stays one atomic command. Following flush `After.` does not join
+/// the command line. `After.` / `Next.` still split. lstinline /
+/// lstlisting unchanged.
+#[test]
+fn lstinputlisting_fixture_does_not_join_following_prose() {
+    let input = concat!(
+        "Before. Next.\n",
+        "\\lstinputlisting{foo.py}\n",
+        "After. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\lstinputlisting{foo.py}")
+        )),
+        "lstinputlisting must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\lstinputlisting{foo.py}")
+        )),
+        "lstinputlisting must not leak into Prose, got: {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+        )),
+        "After. / Next. must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\lstinputlisting{foo.py}\n"),
+        "lstinputlisting must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\lstinputlisting{foo.py} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before lstinputlisting must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after lstinputlisting must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let lstinline = "Use \\lstinline!a.b! here. Next sentence.\n";
+    let lstinline_out = format_text(lstinline, &latex_cfg()).unwrap();
+    assert!(
+        lstinline_out.contains("Use \\lstinline!a.b! here.\nNext sentence."),
+        "lstinline must stay intact and still split, got:\n{lstinline_out}"
+    );
+
+    let lstlisting = concat!(
+        "\\begin{lstlisting}\n",
+        "First line. Second line.\n",
+        "\\end{lstlisting}\n",
+        "After the block. Next.\n",
+    );
+    let lstlisting_out = format_text(lstlisting, &latex_cfg()).unwrap();
+    assert!(
+        lstlisting_out.contains("\\begin{lstlisting}\nFirst line. Second line.\n\\end{lstlisting}"),
+        "lstlisting must stay a code env, got:\n{lstlisting_out}"
+    );
+    assert!(
+        lstlisting_out.contains("After the block.\nNext."),
+        "prose after lstlisting must still split, got:\n{lstlisting_out}"
+    );
 }
 
 /// Ticket fixture (GitHub #305): piton.sty `{Piton}` body stays Code


### PR DESCRIPTION
listings.sty `\\lstinputlisting{file}`.

The command stays atomic. Following prose still splits. `lstinline` / `lstlisting` unchanged.

Closes #391.

Do not hand-edit CHANGELOG.md.
