### PR TITLE
fix(org): treat verse-block body as leftover structure

### DIFF
--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -19,9 +19,10 @@ The classification depends on the format.
 :CUSTOM_ID: org-structure
 :END:
 - Non-source =#+BEGIN_*= ...
-=#+END_*= fences, and the bodies of literal blocks (example, export, comment). An unmatched =#+BEGIN_EXPORT= is a paragraph (org-element export-block-parser)
+=#+END_*= fences, and the bodies of literal blocks (example, export, comment, verse). An unmatched =#+BEGIN_EXPORT= is a paragraph (org-element export-block-parser)
 - Dynamic blocks (=#+BEGIN: NAME= ... =#+END:=), including the generated body
-- Quote, verse, center, and special-block (NOTE and other unknown NAME) open/close lines; verse inner lines stay unjoined, and a two-sentence verse line stays one physical line
+- Quote, center, and special-block (NOTE and other unknown NAME) open/close lines
+- Verse-block body (org-element verse-lines; leftover opaque walker, GitHub #395)
 - Special-block interiors (NOTE, ABSTRACT, WARNING, ...) reflow as prose
 - =:PROPERTIES:= ...
 =:END:= drawers
@@ -53,7 +54,7 @@ The classification depends on the format.
 :END:
 - Paragraph text
 - List item text (after the marker); continuation sentences hang at the marker width so Org rejoins the item
-- Quote, verse, center, and special-block inner text (verse stays line-preserving)
+- Quote, center, and special-block inner text
 - =#+CAPTION:= value (org-element-parsed-keywords); continuation sentences hang at the opener width.
   Dual =#+CAPTION[short]:= keeps the short title on the opener
 

--- a/src/parser/org.rs
+++ b/src/parser/org.rs
@@ -151,8 +151,8 @@ enum DisplayMathDelim {
     Dollars,
 }
 
-/// Greater-block kind. Quote/verse/center contain paragraphs;
-/// example/export/comment and other names stay literal Structure.
+/// Greater-block kind. Quote/center contain paragraphs;
+/// example/export/comment/verse and other names stay literal Structure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum GreaterKind {
     Container,
@@ -524,11 +524,13 @@ impl OrgParser {
         org_export_snippet_line(line)
     }
 
-    /// org-element quote-block / verse-block / center-block contain paragraphs.
+    /// org-element quote-block / center-block contain paragraphs.
     /// org-element special-block (NOTE, ABSTRACT, WARNING, ...) contains
-    /// paragraphs. Only lesser/literal names stay opaque (GitHub #179).
+    /// paragraphs. Lesser/literal names stay opaque (GitHub #179).
+    /// verse-block is the leftover walker: org-element keeps verse-lines,
+    /// not paragraphs (GitHub #395).
     fn is_container_block_name(name: &str) -> bool {
-        !matches!(name, "SRC" | "EXAMPLE" | "EXPORT" | "COMMENT")
+        !matches!(name, "SRC" | "EXAMPLE" | "EXPORT" | "COMMENT" | "VERSE")
     }
 
     fn greater_kind(name: &str) -> GreaterKind {
@@ -620,14 +622,6 @@ impl OrgParser {
         stack.iter().any(|b| b.kind == GreaterKind::Opaque)
     }
 
-    fn innermost_container(stack: &[OpenGreater]) -> Option<&str> {
-        stack
-            .iter()
-            .rev()
-            .find(|b| b.kind == GreaterKind::Container)
-            .map(|b| b.name.as_str())
-    }
-
     fn push_greater(stack: &mut Vec<OpenGreater>, name: String) {
         let kind = Self::greater_kind(&name);
         stack.push(OpenGreater { name, kind });
@@ -640,26 +634,6 @@ impl OrgParser {
     }
 }
 
-/// True when `regions[idx]` sits inside an org-element verse-block.
-///
-/// Verse-line lineation is the object (Org manual: line breaks are
-/// preserved). The parser already flushes each verse line as its own
-/// Prose region; reflow must not insert new physical lines there.
-pub(crate) fn org_verse_inner_prose(idx: usize, regions: &[Region]) -> bool {
-    let mut stack: Vec<OpenGreater> = Vec::new();
-    for region in regions.iter().take(idx) {
-        let Region::Structure(s) = region else {
-            continue;
-        };
-        if let Some(name) = OrgParser::block_begin_name(s) {
-            OrgParser::push_greater(&mut stack, name);
-        } else if let Some(name) = OrgParser::block_end_name(s) {
-            OrgParser::pop_matching_greater(&mut stack, &name);
-        }
-    }
-    OrgParser::innermost_container(&stack) == Some("VERSE")
-}
-
 impl FormatParser for OrgParser {
     fn parse_full(&self, input: &str) -> Vec<SpannedRegion> {
         let mut regions: Vec<SpannedRegion> = Vec::new();
@@ -667,7 +641,7 @@ impl FormatParser for OrgParser {
         let mut prose_span: Option<ByteSpan> = None;
         // Open greater-element names. `#+END_NAME` pops only a matching top
         // (org-element / orgize); a mismatched closer stays structure.
-        // Quote/verse/center are containers (inner Prose); other names are opaque.
+        // Quote/center are containers (inner Prose); verse and other names are opaque.
         let mut block_stack: Vec<OpenGreater> = Vec::new();
         let mut in_src_block = false;
         let mut in_dynamic_block = false;
@@ -720,8 +694,9 @@ impl FormatParser for OrgParser {
             }
 
             // Inside an opaque greater block -- everything is structure.
-            // Quote/verse/center are containers: fall through and parse inner
-            // regions (Prose, SRC, nested opaque blocks).
+            // Quote/center are containers: fall through and parse inner
+            // regions (Prose, SRC, nested opaque blocks). Verse-block
+            // body is leftover opaque (GitHub #395).
             if Self::inside_opaque(&block_stack) {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 if let Some(end_name) = Self::block_end_name(line_text) {
@@ -801,7 +776,7 @@ impl FormatParser for OrgParser {
                 }
             }
 
-            // #+BEGIN_NAME: container open (quote/verse/center) or opaque.
+            // #+BEGIN_NAME: container open (quote/center) or opaque.
             // Unmatched #+BEGIN_EXPORT is a paragraph (org-element
             // export-block-parser / GitHub #355). Unmatched #+BEGIN_SRC
             // falls through the src-begin look-ahead above.
@@ -1107,10 +1082,8 @@ impl FormatParser for OrgParser {
                 continue;
             }
 
-            // Regular prose line -- accumulate. Verse keeps physical lines.
+            // Regular prose line -- accumulate.
             // Org `\\` at EOL is a line-break object, not a join (GitHub #232).
-            let verse_line = Self::innermost_container(&block_stack) == Some("VERSE");
-            let before = regions.len();
             Self::push_prose_or_line_break(
                 input,
                 &line,
@@ -1120,16 +1093,6 @@ impl FormatParser for OrgParser {
                 &mut regions,
                 true,
             );
-            if verse_line {
-                flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-                // org-element verse-line: lineation is the object (GitHub #281).
-                // Keep Region::Prose; splice must not invent physical lines.
-                for sr in &mut regions[before..] {
-                    if matches!(sr.region, Region::Prose(_)) {
-                        sr.line_preserving = true;
-                    }
-                }
-            }
         }
 
         // Flush remaining. Unmatched #+BEGIN_SRC never enters in_src_block
@@ -2063,23 +2026,24 @@ mod tests {
     }
 
     #[test]
-    fn verse_block_inner_is_line_preserving_prose() {
+    fn verse_block_inner_is_structure_not_reflowed_prose() {
         use crate::format_text;
 
         let input = "#+BEGIN_VERSE\nGreat clouds overhead\nTiny black birds rise and fall\n#+END_VERSE\nAfter. Next.\n";
         let regions = OrgParser.parse(input);
         assert!(
-            regions
-                .iter()
-                .any(|r| matches!(r, Region::Prose(p) if p.contains("Great clouds overhead"))),
-            "verse inner must be Prose, got: {regions:?}"
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("Great clouds overhead")
+            )),
+            "verse inner must be Structure, got: {regions:?}"
         );
         assert!(
             !regions.iter().any(|r| matches!(
                 r,
-                Region::Structure(s) if s.contains("Great clouds overhead")
+                Region::Prose(p) if p.contains("Great clouds overhead")
             )),
-            "verse inner must not be Structure, got: {regions:?}"
+            "verse inner must not be reflowed Prose, got: {regions:?}"
         );
         let out = format_text(input, &org_cfg()).unwrap();
         assert!(
@@ -2104,23 +2068,21 @@ mod tests {
         let input =
             "#+BEGIN_VERSE\nFirst line. Second line.\n#+END_VERSE\nAfter the block. Next.\n";
         let spanned = OrgParser.parse_full(input);
-        let verse_prose = spanned.iter().any(|s| match &s.region {
-            Region::Prose(p)
-                if p.contains("First line.") && p.contains("Second line.") && s.line_preserving =>
-            {
-                true
-            }
-            _ => false,
+        let verse_structure = spanned.iter().any(|s| {
+            matches!(
+                &s.region,
+                Region::Structure(t) if t.contains("First line.") && t.contains("Second line.")
+            )
         });
         assert!(
-            verse_prose,
-            "verse line must be line-preserving Prose, got: {spanned:?}"
+            verse_structure,
+            "verse line must be Structure, got: {spanned:?}"
         );
         assert!(
-            !spanned.iter().any(|s| {
-                matches!(&s.region, Region::Structure(t) if t.contains("First line."))
-            }),
-            "verse inner must not flip to Structure, got: {spanned:?}"
+            !spanned
+                .iter()
+                .any(|s| { matches!(&s.region, Region::Prose(p) if p.contains("First line.")) }),
+            "verse inner must not be reflowed Prose, got: {spanned:?}"
         );
         let out = format_text(input, &org_cfg()).unwrap();
         assert!(
@@ -2179,6 +2141,7 @@ mod tests {
             ("EXAMPLE", "foo. bar."),
             ("EXPORT", "<p>Hello. World.</p>"),
             ("COMMENT", "Secret one. Secret two."),
+            ("VERSE", "First line. Second line."),
         ] {
             let input = format!("#+BEGIN_{name}\n{body}\n#+END_{name}\nAfter. Next.\n");
             let out = format_text(&input, &cfg).unwrap();

--- a/src/parser/span.rs
+++ b/src/parser/span.rs
@@ -84,7 +84,7 @@ pub struct CodeSpans {
 pub struct SpannedRegion {
     pub region: Region,
     pub origin: Option<RegionOrigin>,
-    /// When true, splice keeps the source physical line (Org verse-line).
+    /// When true, splice keeps the source physical line.
     /// The region stays [`Region::Prose`]; sentence breaks do not invent lines.
     pub line_preserving: bool,
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -101,7 +101,6 @@ fn splice(
         match (&sr.region, origin) {
             (Region::Prose(text), RegionOrigin::Whole(span)) => {
                 if sr.line_preserving {
-                    // Org verse-line: keep the source physical line (GitHub #281).
                     continue;
                 }
                 let replacement = reflow_prose(text, idx, &regions, splitter, config);
@@ -231,9 +230,6 @@ fn reflow_prose(
     splitter: &dyn SentenceSplitter,
     config: &ReflowConfig,
 ) -> String {
-    if config.format == Format::Org && crate::parser::org::org_verse_inner_prose(idx, regions) {
-        return reflow_verse_line(text, idx, regions);
-    }
     let mut output = String::new();
     let hang = match idx.checked_sub(1).and_then(|i| regions.get(i)) {
         Some(Region::Structure(s)) => hanging_prefix(s),
@@ -301,28 +297,6 @@ fn reflow_prose(
         if !suppress {
             output.push('\n');
         }
-    }
-    output
-}
-
-/// Org verse-line: keep the source physical line. Sentence, clause, or
-/// wrap breaks would invent lineation the Org manual says to preserve.
-fn reflow_verse_line(text: &str, idx: usize, regions: &[Region]) -> String {
-    let mut output = text.trim_end_matches(['\n', '\r']).to_string();
-    if output.is_empty() && text.is_empty() {
-        return output;
-    }
-    let suppress = match regions.get(idx + 1) {
-        Some(Region::Structure(s)) if suppress_prose_trailing_newline(s) => true,
-        Some(Region::Structure(s))
-            if s.trim_start().starts_with('%') && text.ends_with([' ', '\t']) =>
-        {
-            true
-        }
-        _ => false,
-    };
-    if !suppress {
-        output.push('\n');
     }
     output
 }
@@ -1285,7 +1259,7 @@ mod tests {
     fn org_verse_two_sentence_line_stays_one_physical_line() {
         let regions = vec![
             Region::Structure("#+BEGIN_VERSE\n".into()),
-            Region::Prose("First line. Second line.".into()),
+            Region::Structure("First line. Second line.\n".into()),
             Region::Structure("#+END_VERSE\n".into()),
             Region::Prose("After the block. Next.".into()),
         ];
@@ -1303,7 +1277,7 @@ mod tests {
                 "After the block.\n",
                 "Next.\n",
             ),
-            "verse line stays one physical line; after-block still splits, got:\n{result}"
+            "verse body is Structure; after-block still splits, got:\n{result}"
         );
     }
 

--- a/tests/org_verse.rs
+++ b/tests/org_verse.rs
@@ -1,7 +1,7 @@
-//! snapper-hw7m / GitHub #281: an org verse line with two sentences
-//! stays one physical line. org-element verse-line lineation is the
-//! object. Inner stays Prose, not Structure. After the block still
-//! splits. Quote / center / special-block reflow is unchanged.
+//! snapper-wlvj / GitHub #395: org-element verse-block body is leftover
+//! opaque Structure (verse-lines, not paragraphs). SemBr must not split
+//! interior punct. After. / Next. stay unindented Prose and still split.
+//! Quote / src unchanged.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::org::OrgParser;
@@ -17,18 +17,18 @@ fn org_cfg() -> FormatConfig {
     .without_safety_backstops()
 }
 
-/// Ticket fixture (Format::Org).
+/// Ticket fixture (Format::Org / GitHub #395).
 fn ticket_fixture() -> &'static str {
     concat!(
         "#+BEGIN_VERSE\n",
         "First line. Second line.\n",
         "#+END_VERSE\n",
-        "After the block. Next.\n",
+        "After. Next.\n",
     )
 }
 
 #[test]
-fn verse_line_is_prose_not_structure() {
+fn verse_body_is_structure_not_reflowed_prose() {
     let regions = OrgParser.parse(ticket_fixture());
     assert!(
         regions
@@ -39,15 +39,22 @@ fn verse_line_is_prose_not_structure() {
     assert!(
         regions.iter().any(|r| matches!(
             r,
-            Region::Prose(p) if p.contains("First line.") && p.contains("Second line.")
+            Region::Structure(s) if s.contains("First line.") && s.contains("Second line.")
         )),
-        "verse line must be Prose, got {regions:?}"
+        "verse body must be Structure, got {regions:?}"
     );
     assert!(
         !regions
             .iter()
-            .any(|r| matches!(r, Region::Structure(s) if s.contains("First line."))),
-        "verse inner must not flip to Structure, got {regions:?}"
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line."))),
+        "verse body must not be reflowed Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Code { body, .. } if body.contains("First line.")
+        )),
+        "verse body is leftover Structure, not Code, got {regions:?}"
     );
 }
 
@@ -61,10 +68,10 @@ fn ticket_fixture_keeps_verse_line_and_splits_after() {
             "#+BEGIN_VERSE\n",
             "First line. Second line.\n",
             "#+END_VERSE\n",
-            "After the block.\n",
+            "After.\n",
             "Next.\n",
         ),
-        "verse line stays one physical line; After the block. / Next. still splits, got:\n{out}"
+        "verse body stays one source line; After. / Next. still splits, got:\n{out}"
     );
     assert!(
         !out.contains("First line.\nSecond line."),
@@ -121,4 +128,74 @@ fn quote_center_special_block_still_split() {
         n.contains("Quoted one.\nQuoted two."),
         "special-block inner must still split, got:\n{n}"
     );
+}
+
+#[test]
+fn src_body_unchanged() {
+    let input = concat!(
+        "#+BEGIN_SRC python\n",
+        "print(\"a. b\")\n",
+        "#+END_SRC\n",
+        "After. Next.\n",
+    );
+    let regions = OrgParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Code { body, .. } if body.contains("print(\"a. b\")")
+        )),
+        "SRC body must stay Code, got {regions:?}"
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert!(
+        out.contains("print(\"a. b\")"),
+        "SRC body must not reflow, got:\n{out}"
+    );
+    assert!(
+        !out.contains("a.\nb"),
+        "SRC body must not split at the period, got:\n{out}"
+    );
+    assert!(
+        out.contains("#+END_SRC\nAfter.\nNext."),
+        "prose after SRC must still split, got:\n{out}"
+    );
+}
+
+/// GitHub #395 leftover walker: lowercase begin_verse is the same
+/// opaque class as BEGIN_VERSE.
+#[test]
+fn leftover_lowercase_verse_is_structure_and_does_not_reflow() {
+    let input = concat!(
+        "#+begin_verse\n",
+        "First line. Second line.\n",
+        "#+end_verse\n",
+        "After. Next.\n",
+    );
+    let regions = OrgParser.parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("First line.") && s.contains("Second line.")
+        )),
+        "lowercase verse body must be Structure, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(p) if p.contains("First line."))),
+        "lowercase verse body must not be Prose, got {regions:?}"
+    );
+    let out = format_text(input, &org_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "#+begin_verse\n",
+            "First line. Second line.\n",
+            "#+end_verse\n",
+            "After.\n",
+            "Next.\n",
+        ),
+        "lowercase verse body stays one source line; After. / Next. still splits, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &org_cfg()).unwrap(), out);
 }


### PR DESCRIPTION
org-element `verse-block`. Body stays one source line. Following prose still splits.

Closes #395.

Do not hand-edit CHANGELOG.md.
