### PR TITLE
fix(latex): tokenize minted inputminted like mintinline

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -187,8 +187,9 @@ Adding =algorithm= stops reflow of that environment.
 
 String array of extra command names tokenized like the built-in verb command before sentence split.
 The next character after the name is the delimiter.
-Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb=, and piton.sty =\piton=; =lstinline= still accepts optional =[...]= and ={...}=.
+Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline=, =inputminted=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb=, and piton.sty =\piton=; =lstinline= still accepts optional =[...]= and ={...}=.
 =mintinline= / =mint= take optional =[...]=, a ={lang}= argument, then a delimiter or ={...}= body.
+=\inputminted= takes the same optional =[...]= and ={lang}= then a required ={filename}=; following flush prose stays on its own line.
 =SaveVerb= takes optional =[...]=, a ={name}= argument, then the same delimiter body as =Verb=.
 =\piton|...|= is verb-like (interior =.!?%= stay one token); =\piton{...}= stays one token via the generic command argument.
 =\lstinputlisting= takes optional =[...]= then a required ={filename}=; following flush prose stays on its own line.

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -134,9 +134,10 @@ These tokens within prose are not split across lines:
 - piton.sty =Piton= is a built-in code region (verbatim listing env)
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= / =minted*= language arg, =lstlisting= / =lstlisting*= =language== option)
-- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= / piton.sty =\piton= / listings.sty =\lstinputlisting= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment.
+- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= / piton.sty =\piton= / listings.sty =\lstinputlisting= / minted.sty =\inputminted= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment.
   =\piton|...|= is verb-like; =\piton{...}= stays one token via the generic command argument
   =\lstinputlisting= / =\lstinputlisting*= take optional =[...]= then a ={filename}=; a flush following sentence stays on its own line
+  =\inputminted= / =\inputminted*= take optional =[...]=, ={lang}=, then a ={filename}=; a flush following sentence stays on its own line
 
 *** Prose regions (reflowed)
 :PROPERTIES:

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub struct FormatOverrides {
     pub structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
     /// Meaningful under `[latex]` only. Missing or empty keeps
-    /// verb/lstinline/lstinputlisting/spverb/mintinline/mint/Verb/SaveVerb/piton.
+    /// verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/piton.
     pub verbatim_commands: Vec<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub struct FormatConfig {
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.
     pub latex_structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
-    /// Empty keeps verb/lstinline/lstinputlisting/spverb/mintinline/mint/Verb/SaveVerb/piton.
+    /// Empty keeps verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/piton.
     pub latex_verbatim_commands: Vec<String>,
 }
 

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -502,7 +502,7 @@ impl LatexParser {
     /// Byte offset of the first `%` that is not escaped as `\%` and is not
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
     /// `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
-    /// configured verbatim commands.
+    /// `\inputminted` / configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -874,8 +874,8 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 }
 
 /// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` /
-/// `\spverb` / `\mintinline` / `\mint` / `\Verb` / `\SaveVerb` /
-/// `\piton` / `\lstinputlisting` spans.
+/// `\spverb` / `\mintinline` / `\mint` / `\inputminted` / `\Verb` /
+/// `\SaveVerb` / `\piton` / `\lstinputlisting` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -906,12 +906,29 @@ fn find_lstinputlisting_at(
     from: usize,
     extra_cmds: &[String],
 ) -> Option<(usize, usize)> {
+    find_leftover_cmd_at(line, from, extra_cmds, lstinputlisting_cs_at)
+}
+
+/// Leftover minted.sty `\inputminted` / `\inputminted*` (optional
+/// `[...]`, `{lang}`, `{file}`; GitHub #394). Other verb spans are
+/// skipped so `\verb|\inputminted{python}{x}|` is not stolen. Walk
+/// stops at an unescaped `%` so a comment is not a command tail.
+fn find_inputminted_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<(usize, usize)> {
+    find_leftover_cmd_at(line, from, extra_cmds, inputminted_cs_at)
+}
+
+fn find_leftover_cmd_at(
+    line: &str,
+    from: usize,
+    extra_cmds: &[String],
+    is_cs: fn(&str, usize) -> bool,
+) -> Option<(usize, usize)> {
     let bytes = line.as_bytes();
     let mut i = from;
     let stop = unescaped_percent_with(line, extra_cmds).unwrap_or(line.len());
     while i < stop {
         if bytes[i] == b'\\' {
-            if lstinputlisting_cs_at(line, i) {
+            if is_cs(line, i) {
                 if let Some(end) = latex_verb_span_end_with(line, i, extra_cmds) {
                     return Some((i, end));
                 }
@@ -935,6 +952,16 @@ fn lstinputlisting_cs_at(line: &str, at: usize) -> bool {
         return false;
     };
     let Some(after) = tail.strip_prefix("lstinputlisting") else {
+        return false;
+    };
+    !after.starts_with(|c: char| c.is_ascii_alphabetic())
+}
+
+fn inputminted_cs_at(line: &str, at: usize) -> bool {
+    let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
+        return false;
+    };
+    let Some(after) = tail.strip_prefix("inputminted") else {
         return false;
     };
     !after.starts_with(|c: char| c.is_ascii_alphabetic())
@@ -1624,6 +1651,7 @@ impl<'a> ParseState<'a> {
             }
             if let Some((start, end)) =
                 find_lstinputlisting_at(code, i, &self.parser.extra_verbatim_commands)
+                    .or_else(|| find_inputminted_at(code, i, &self.parser.extra_verbatim_commands))
             {
                 self.append_item_or_prose(line.start + i, &code[i..start]);
                 self.push_structure(ByteSpan::new(
@@ -2452,6 +2480,104 @@ Some text.
             format_text(&lstlisting_out, &latex_cfg()).unwrap(),
             lstlisting_out
         );
+    }
+
+    /// Ticket fixture (GitHub #394): minted.sty `\inputminted{lang}{file}`
+    /// is one leftover command. Following flush prose does not join the
+    /// command line. `After.` / `Next.` still split. `mintinline` /
+    /// `minted` unchanged.
+    #[test]
+    fn inputminted_does_not_join_following_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "Before. Next.\n",
+            "\\inputminted{python}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\inputminted{python}{foo.py}")
+            )),
+            "inputminted must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\inputminted{python}{foo.py}")
+            )),
+            "inputminted must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+            )),
+            "After. / Next. must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\inputminted{python}{foo.py}\n"),
+            "inputminted must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\inputminted{python}{foo.py} After."),
+            "following flush prose must not join the command line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before.\nNext."),
+            "prose before inputminted must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after inputminted must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let opts = concat!(
+            "Before. Next.\n",
+            "\\inputminted[linenos]{python}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let opts_out = format_text(opts, &latex_cfg()).unwrap();
+        assert!(
+            opts_out.contains("\\inputminted[linenos]{python}{foo.py}\n"),
+            "inputminted optional args must stay atomic, got:\n{opts_out}"
+        );
+        assert!(
+            !opts_out.contains("\\inputminted[linenos]{python}{foo.py} After."),
+            "optional-arg inputminted must not join following prose, got:\n{opts_out}"
+        );
+        assert!(
+            opts_out.contains("After.\nNext."),
+            "prose after optional-arg inputminted must still split, got:\n{opts_out}"
+        );
+
+        let mintinline = "Use \\mintinline{python}|a.b! c| here. Next sentence.\n";
+        let mintinline_out = format_text(mintinline, &latex_cfg()).unwrap();
+        assert!(
+            mintinline_out.contains("Use \\mintinline{python}|a.b! c| here.\nNext sentence."),
+            "mintinline must stay intact and still split, got:\n{mintinline_out}"
+        );
+
+        let minted = concat!(
+            "\\begin{minted}{python}\n",
+            "First line. Second line.\n",
+            "\\end{minted}\n",
+            "After the block. Next.\n",
+        );
+        let minted_out = format_text(minted, &latex_cfg()).unwrap();
+        assert!(
+            minted_out.contains("\\begin{minted}{python}\nFirst line. Second line.\n\\end{minted}"),
+            "minted must stay a code env, got:\n{minted_out}"
+        );
+        assert!(
+            minted_out.contains("After the block.\nNext."),
+            "prose after minted must still split, got:\n{minted_out}"
+        );
+        assert_eq!(format_text(&minted_out, &latex_cfg()).unwrap(), minted_out);
     }
 
     /// Ticket fixture (GitHub #245): minted `\mintinline{lang}|body|` is

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -197,7 +197,8 @@ pub fn protect_inline_tokens_with(
 }
 
 /// `\verb|...|` / `\lstinline[...]!...!` / `\spverb|...|` /
-/// `\mintinline{lang}|...|` / `\mint{lang}{...}` / `\Verb|...|` /
+/// `\mintinline{lang}|...|` / `\mint{lang}{...}` /
+/// `\inputminted{lang}{file}` / `\Verb|...|` /
 /// `\SaveVerb{name}|...|` / `\piton|...|` /
 /// `\lstinputlisting[...]{file}` so inner `.!?%` cannot
 /// split or comment. `\piton{...}` stays on the generic `\cmd{arg}`
@@ -226,7 +227,8 @@ fn protect_latex_verbatim(
 }
 
 /// Byte end of a `\verb` / `\lstinline` / `\spverb` / `\mintinline` /
-/// `\mint` / `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
+/// `\mint` / `\inputminted` / `\Verb` / `\SaveVerb` / `\piton` /
+/// `\lstinputlisting` /
 /// extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
@@ -235,17 +237,19 @@ fn protect_latex_verbatim(
 /// `\lstinline*` may take optional `[...]` before a delimiter or a
 /// `{...}` brace body. `\mintinline` / `\mint` (and stars) take optional
 /// `[...]`, a required `{lang}`, then a delimiter or `{...}` body
-/// (minted.sty / FVExtraReadVArg; GitHub #245). `\SaveVerb` / `\SaveVerb*`
-/// take optional `[...]`, a required `{name}`, then the same delimiter
-/// body as `\Verb` (fancyvrb FVExtraReadVArg; GitHub #275). `\piton`
-/// (piton.sty; GitHub #305) is verb-like for a non-brace delimiter
-/// (`\piton|...|`); a following `{` is not a delimiter so `\piton{...}`
-/// stays on the generic `\cmd{arg}` path. `\lstinputlisting` /
-/// `\lstinputlisting*` (listings.sty leftover; GitHub #391) take optional
-/// `[...]` then a required `{filename}`; no brace is not a span.
-/// Extra names are tokenized
-/// like `\verb`. With no closer, the span runs to end of line so an
-/// inner `%` is not a comment.
+/// (minted.sty / FVExtraReadVArg; GitHub #245). `\inputminted` /
+/// `\inputminted*` (minted.sty leftover; GitHub #394) use the same
+/// `{lang}` then brace-body walk as `\mintinline`. `\SaveVerb` /
+/// `\SaveVerb*` take optional `[...]`, a required `{name}`, then the
+/// same delimiter body as `\Verb` (fancyvrb FVExtraReadVArg; GitHub
+/// #275). `\piton` (piton.sty; GitHub #305) is verb-like for a
+/// non-brace delimiter (`\piton|...|`); a following `{` is not a
+/// delimiter so `\piton{...}` stays on the generic `\cmd{arg}` path.
+/// `\lstinputlisting` / `\lstinputlisting*` (listings.sty leftover;
+/// GitHub #391) take optional `[...]` then a required `{filename}`;
+/// no brace is not a span. Extra names are tokenized like `\verb`.
+/// With no closer, the span runs to end of line so an inner `%` is
+/// not a comment.
 pub(crate) fn latex_verb_span_end_with(
     text: &str,
     at: usize,
@@ -257,12 +261,19 @@ pub(crate) fn latex_verb_span_end_with(
     }
     let after_bs = at + 1;
     let tail = text.get(after_bs..)?;
-    // `mintinline` before `mint` so `\mintinline` is not `\mint` + leftover.
+    // `mintinline` / `inputminted` before `mint` so those names are not
+    // `\mint` + leftover. `inputminted` is the same `{lang}` + body
+    // walk as mintinline (minted.sty leftover; GitHub #394).
     let (mut i, kind) = if let Some(stripped) = tail.strip_prefix("mintinline") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
         }
         (after_bs + "mintinline".len(), VerbKind::Mint)
+    } else if let Some(stripped) = tail.strip_prefix("inputminted") {
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (after_bs + "inputminted".len(), VerbKind::Mint)
     } else if let Some(stripped) = tail.strip_prefix("lstinputlisting") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -403,7 +414,8 @@ enum VerbKind {
     Lstinline,
     /// `\lstinputlisting`: optional `[...]` then required `{filename}`.
     Lstinputlisting,
-    /// `\mintinline` / `\mint`: optional `[...]`, `{lang}`, then body.
+    /// `\mintinline` / `\mint` / `\inputminted`: optional `[...]`,
+    /// `{lang}`, then body.
     Mint,
     /// `\SaveVerb`: optional `[...]`, `{name}`, then delimiter body like `\Verb`.
     SaveVerb,
@@ -429,6 +441,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "lstinputlisting"
             || name == "spverb"
             || name == "mintinline"
+            || name == "inputminted"
             || name == "mint"
             || name == "Verb"
             || name == "SaveVerb"
@@ -2252,6 +2265,74 @@ mod tests {
                 r"See \mintinline[escapeinside=||]{python}|a.b%| please.".to_string(),
                 "Next.".to_string()
             ]
+        );
+    }
+
+    /// Ticket fixture (GitHub #394): minted.sty `\inputminted{lang}{file}`
+    /// is one token like `\mintinline`; following `After.` still splits.
+    #[test]
+    fn latex_inputminted_stays_atomic() {
+        let text = r"See \inputminted{python}{foo.py} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders
+                .iter()
+                .any(|p| p == r"\inputminted{python}{foo.py}"),
+            "inputminted span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputminted{python}{foo.py}", 0, &[]),
+            Some(r"\inputminted{python}{foo.py}".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \inputminted{python}{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        let opts = r"See \inputminted[linenos]{python}{foo.py} here. After.";
+        let (_, opt_ph) = protect_inline_tokens(opts);
+        assert!(
+            opt_ph
+                .iter()
+                .any(|p| p == r"\inputminted[linenos]{python}{foo.py}"),
+            "inputminted optional args must be protected, got {opt_ph:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputminted[linenos]{python}{foo.py}", 0, &[]),
+            Some(r"\inputminted[linenos]{python}{foo.py}".len())
+        );
+        assert_eq!(
+            split(opts),
+            vec![
+                r"See \inputminted[linenos]{python}{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputminted*{python}{foo.py}", 0, &[]),
+            Some(r"\inputminted*{python}{foo.py}".len())
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputminted foo.py", 0, &[]),
+            None,
+            "inputminted without a {{lang}} arg is not a verb span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\mintinline{python}|a.b! c|", 0, &[]),
+            Some(r"\mintinline{python}|a.b! c|".len()),
+            "inputminted must not steal mintinline"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\mint{python}|a.b! c|", 0, &[]),
+            Some(r"\mint{python}|a.b! c|".len()),
+            "inputminted must not steal mint"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\input{foo.py}", 0, &[]),
+            None,
+            "inputminted must not steal \\input"
         );
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -9,6 +9,8 @@
 //! GitHub #235: spverbatim.sty env and \\spverb are the same class as verb.
 //! GitHub #244: fancyvrb Verbatim* / BVerbatim* / LVerbatim* are the same FV@Scan class.
 //! GitHub #245: minted.sty \\mintinline / \\mint take {lang} then a FancyVerb body.
+//! GitHub #394: minted.sty \\inputminted is one leftover command;
+//! following flush prose stays on its own line.
 //! GitHub #273: minted.sty minted* is the starred twin of minted (same raw body).
 //! GitHub #275: fancyvrb \\SaveVerb{name}|body| is the same delimiter body as \\Verb.
 //! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
@@ -2883,6 +2885,82 @@ fn pythontex_option_family_envs_fixture_is_code_and_does_not_reflow() {
         "prose after landed pycode/pyconsole must still split, got:\n{landed_out}"
     );
     assert_eq!(format_text(&landed_out, &latex_cfg()).unwrap(), landed_out);
+}
+
+/// Ticket fixture (GitHub #394): minted.sty `\inputminted{lang}{file}`
+/// stays one atomic command. Following flush `After.` does not join
+/// the command line. `After.` / `Next.` still split. mintinline /
+/// minted unchanged.
+#[test]
+fn inputminted_fixture_does_not_join_following_prose() {
+    let input = concat!(
+        "Before. Next.\n",
+        "\\inputminted{python}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\inputminted{python}{foo.py}")
+        )),
+        "inputminted must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\inputminted{python}{foo.py}")
+        )),
+        "inputminted must not leak into Prose, got: {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+        )),
+        "After. / Next. must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\inputminted{python}{foo.py}\n"),
+        "inputminted must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\inputminted{python}{foo.py} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before inputminted must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after inputminted must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let mintinline = "Use \\mintinline{python}|a.b! c| here. Next sentence.\n";
+    let mintinline_out = format_text(mintinline, &latex_cfg()).unwrap();
+    assert!(
+        mintinline_out.contains("Use \\mintinline{python}|a.b! c| here.\nNext sentence."),
+        "mintinline must stay intact and still split, got:\n{mintinline_out}"
+    );
+
+    let minted = concat!(
+        "\\begin{minted}{python}\n",
+        "First line. Second line.\n",
+        "\\end{minted}\n",
+        "After the block. Next.\n",
+    );
+    let minted_out = format_text(minted, &latex_cfg()).unwrap();
+    assert!(
+        minted_out.contains("\\begin{minted}{python}\nFirst line. Second line.\n\\end{minted}"),
+        "minted must stay a code env, got:\n{minted_out}"
+    );
+    assert!(
+        minted_out.contains("After the block.\nNext."),
+        "prose after minted must still split, got:\n{minted_out}"
+    );
 }
 
 /// Ticket fixture (GitHub #245): `\mintinline{python}|a.b! c|` is one


### PR DESCRIPTION
minted.sty `\\inputminted{lang}{file}`.

The command stays atomic. Following prose still splits. `mintinline` / `minted` unchanged.

Closes #394.

Do not hand-edit CHANGELOG.md.
