### PR TITLE
fix(latex): tokenize tcolorbox tcbinputlisting like lstinputlisting

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -187,9 +187,10 @@ Adding =algorithm= stops reflow of that environment.
 
 String array of extra command names tokenized like the built-in verb command before sentence split.
 The next character after the name is the delimiter.
-Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline=, =inputminted=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb=, and piton.sty =\piton=; =lstinline= still accepts optional =[...]= and ={...}=.
+Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline=, =inputminted=, =tcbinputlisting=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb=, and piton.sty =\piton=; =lstinline= still accepts optional =[...]= and ={...}=.
 =mintinline= / =mint= take optional =[...]=, a ={lang}= argument, then a delimiter or ={...}= body.
 =\inputminted= takes the same optional =[...]= and ={lang}= then a required ={filename}=; following flush prose stays on its own line.
+=\tcbinputlisting= takes one keyval group; following flush prose stays on its own line.
 =SaveVerb= takes optional =[...]=, a ={name}= argument, then the same delimiter body as =Verb=.
 =\piton|...|= is verb-like (interior =.!?%= stay one token); =\piton{...}= stays one token via the generic command argument.
 =\lstinputlisting= takes optional =[...]= then a required ={filename}=; following flush prose stays on its own line.

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -135,10 +135,11 @@ These tokens within prose are not split across lines:
 - piton.sty =Piton= is a built-in code region (verbatim listing env)
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= / =minted*= language arg, =lstlisting= / =lstlisting*= =language== option)
-- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= / piton.sty =\piton= / listings.sty =\lstinputlisting= / minted.sty =\inputminted= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment.
+- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= / piton.sty =\piton= / listings.sty =\lstinputlisting= / minted.sty =\inputminted= / tcolorbox =\tcbinputlisting= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment.
   =\piton|...|= is verb-like; =\piton{...}= stays one token via the generic command argument
   =\lstinputlisting= / =\lstinputlisting*= take optional =[...]= then a ={filename}=; a flush following sentence stays on its own line
   =\inputminted= / =\inputminted*= take optional =[...]=, ={lang}=, then a ={filename}=; a flush following sentence stays on its own line
+  =\tcbinputlisting= takes one keyval group; a flush following sentence stays on its own line
 
 *** Prose regions (reflowed)
 :PROPERTIES:

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub struct FormatOverrides {
     pub structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
     /// Meaningful under `[latex]` only. Missing or empty keeps
-    /// verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/piton.
+    /// verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/tcbinputlisting/mint/Verb/SaveVerb/piton.
     pub verbatim_commands: Vec<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub struct FormatConfig {
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.
     pub latex_structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
-    /// Empty keeps verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/piton.
+    /// Empty keeps verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/tcbinputlisting/mint/Verb/SaveVerb/piton.
     pub latex_verbatim_commands: Vec<String>,
 }
 

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -502,7 +502,7 @@ impl LatexParser {
     /// Byte offset of the first `%` that is not escaped as `\%` and is not
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
     /// `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
-    /// `\inputminted` / configured verbatim commands.
+    /// `\inputminted` / `\tcbinputlisting` / configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -875,7 +875,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 
 /// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` /
 /// `\spverb` / `\mintinline` / `\mint` / `\inputminted` / `\Verb` /
-/// `\SaveVerb` / `\piton` / `\lstinputlisting` spans.
+/// `\SaveVerb` / `\piton` / `\lstinputlisting` / `\tcbinputlisting` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -915,6 +915,18 @@ fn find_lstinputlisting_at(
 /// stops at an unescaped `%` so a comment is not a command tail.
 fn find_inputminted_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<(usize, usize)> {
     find_leftover_cmd_at(line, from, extra_cmds, inputminted_cs_at)
+}
+
+/// Leftover tcolorbox `\tcbinputlisting` (one keyval group;
+/// GitHub #400). Other verb spans are skipped so
+/// `\verb|\tcbinputlisting{x}|` is not stolen. Walk stops at an
+/// unescaped `%` so a comment is not a command tail.
+fn find_tcbinputlisting_at(
+    line: &str,
+    from: usize,
+    extra_cmds: &[String],
+) -> Option<(usize, usize)> {
+    find_leftover_cmd_at(line, from, extra_cmds, tcbinputlisting_cs_at)
 }
 
 fn find_leftover_cmd_at(
@@ -962,6 +974,16 @@ fn inputminted_cs_at(line: &str, at: usize) -> bool {
         return false;
     };
     let Some(after) = tail.strip_prefix("inputminted") else {
+        return false;
+    };
+    !after.starts_with(|c: char| c.is_ascii_alphabetic())
+}
+
+fn tcbinputlisting_cs_at(line: &str, at: usize) -> bool {
+    let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
+        return false;
+    };
+    let Some(after) = tail.strip_prefix("tcbinputlisting") else {
         return false;
     };
     !after.starts_with(|c: char| c.is_ascii_alphabetic())
@@ -1652,6 +1674,9 @@ impl<'a> ParseState<'a> {
             if let Some((start, end)) =
                 find_lstinputlisting_at(code, i, &self.parser.extra_verbatim_commands)
                     .or_else(|| find_inputminted_at(code, i, &self.parser.extra_verbatim_commands))
+                    .or_else(|| {
+                        find_tcbinputlisting_at(code, i, &self.parser.extra_verbatim_commands)
+                    })
             {
                 self.append_item_or_prose(line.start + i, &code[i..start]);
                 self.push_structure(ByteSpan::new(
@@ -2578,6 +2603,117 @@ Some text.
             "prose after minted must still split, got:\n{minted_out}"
         );
         assert_eq!(format_text(&minted_out, &latex_cfg()).unwrap(), minted_out);
+    }
+
+    /// Ticket fixture (GitHub #400): tcolorbox `\tcbinputlisting{keyvals}`
+    /// is one leftover command. Following flush prose does not join the
+    /// command line. `After.` / `Next.` still split. `tcboutputlisting` /
+    /// `lstinputlisting` / `inputminted` unchanged.
+    #[test]
+    fn tcbinputlisting_does_not_join_following_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "Before. Next.\n",
+            "\\tcbinputlisting{listing file=foo.py}\n",
+            "After. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\tcbinputlisting{listing file=foo.py}")
+            )),
+            "tcbinputlisting must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\tcbinputlisting{listing file=foo.py}")
+            )),
+            "tcbinputlisting must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+            )),
+            "After. / Next. must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
+            "tcbinputlisting must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\tcbinputlisting{listing file=foo.py} After."),
+            "following flush prose must not join the command line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before.\nNext."),
+            "prose before tcbinputlisting must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after tcbinputlisting must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let tcboutput = concat!(
+            "\\begin{tcboutputlisting}\n",
+            "First line. Second line.\n",
+            "\\end{tcboutputlisting}\n",
+            "After the block. Next.\n",
+        );
+        let tcboutput_out = format_text(tcboutput, &latex_cfg()).unwrap();
+        assert!(
+            tcboutput_out.contains(
+                "\\begin{tcboutputlisting}\nFirst line. Second line.\n\\end{tcboutputlisting}"
+            ),
+            "tcboutputlisting must stay a code env, got:\n{tcboutput_out}"
+        );
+        assert!(
+            tcboutput_out.contains("After the block.\nNext."),
+            "prose after tcboutputlisting must still split, got:\n{tcboutput_out}"
+        );
+
+        let lstinput = concat!(
+            "Before. Next.\n",
+            "\\lstinputlisting{foo.py}\n",
+            "After. Next.\n",
+        );
+        let lstinput_out = format_text(lstinput, &latex_cfg()).unwrap();
+        assert!(
+            lstinput_out.contains("\\lstinputlisting{foo.py}\n"),
+            "lstinputlisting must stay one atomic command, got:\n{lstinput_out}"
+        );
+        assert!(
+            !lstinput_out.contains("\\lstinputlisting{foo.py} After."),
+            "lstinputlisting must not join following prose, got:\n{lstinput_out}"
+        );
+        assert!(
+            lstinput_out.contains("After.\nNext."),
+            "prose after lstinputlisting must still split, got:\n{lstinput_out}"
+        );
+
+        let minted_in = concat!(
+            "Before. Next.\n",
+            "\\inputminted{python}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let minted_in_out = format_text(minted_in, &latex_cfg()).unwrap();
+        assert!(
+            minted_in_out.contains("\\inputminted{python}{foo.py}\n"),
+            "inputminted must stay one atomic command, got:\n{minted_in_out}"
+        );
+        assert!(
+            !minted_in_out.contains("\\inputminted{python}{foo.py} After."),
+            "inputminted must not join following prose, got:\n{minted_in_out}"
+        );
+        assert!(
+            minted_in_out.contains("After.\nNext."),
+            "prose after inputminted must still split, got:\n{minted_in_out}"
+        );
     }
 
     /// Ticket fixture (GitHub #245): minted `\mintinline{lang}|body|` is

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::parser::{
-    flush_prose_spanned, iter_lines, join_prose_gap, ByteSpan, FormatParser, Line, SpannedRegion,
+    ByteSpan, FormatParser, Line, SpannedRegion, flush_prose_spanned, iter_lines, join_prose_gap,
 };
 use crate::sentence::unicode::latex_verb_span_end_with;
 
@@ -1925,7 +1925,7 @@ mod tests {
     #[test]
     fn multi_sentence_section_title_stays_one_line() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "\\begin{document}\n\\section{A long title. With two sentences.}\nBody text here. More body.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -1982,7 +1982,7 @@ mod tests {
     fn section_optional_short_title_stays_one_line() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input =
             "\\section[Short. Title.]{A long title. With two sentences.}\nBody. More body.\n";
@@ -2014,7 +2014,7 @@ mod tests {
     #[test]
     fn koma_addsec_addchap_addpart_optional_short_title_is_structure() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Latex,
@@ -2058,7 +2058,7 @@ mod tests {
     #[test]
     fn fragment_without_begin_document_is_prose() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "This sentence is a test. This sentence is also a test.\n";
         let cfg = FormatConfig {
@@ -2076,7 +2076,7 @@ mod tests {
     #[test]
     fn no_preamble_pragma_formats_body() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input =
             "% snapper:no-preamble\nThis sentence is a test. This sentence is also a test.\n";
@@ -2099,7 +2099,7 @@ mod tests {
     #[test]
     fn documentclass_without_begin_stays_preamble() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input =
             "\\documentclass{article}\nThis sentence is a test. This sentence is also a test.\n";
@@ -2167,7 +2167,7 @@ Some text.
     #[test]
     fn trailing_percent_is_nospace_join() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "\\begin{document}\nfoo%\nbar. Next sentence.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -2191,7 +2191,7 @@ Some text.
     #[test]
     fn escaped_percent_is_not_a_comment() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "\\begin{document}\n50\\% of cases. More text.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -2210,7 +2210,7 @@ Some text.
     #[test]
     fn mid_line_percent_comment_is_structure() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "\\begin{document}\nSee Fig. 1. % TODO cite\nNext sentence.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -6223,7 +6223,7 @@ Some text.
     fn enumerate_item_hangs_next_sentence() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Latex,

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -963,7 +963,6 @@ fn tcbinputlisting_cs_at(line: &str, at: usize) -> bool {
     !after.starts_with(|c: char| c.is_ascii_alphabetic())
 }
 
-
 fn find_leftover_cmd_at(
     line: &str,
     from: usize,

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -452,6 +452,8 @@ enum VerbKind {
     Lstinputlisting,
     /// `\\verbatiminput`: required `{filename}` (verbatim.sty leftover).
     Verbatiminput,
+    /// `\tcbinputlisting`: one required `{keyvals}` group.
+    Tcbinputlisting,
     /// `\mintinline` / `\mint` / `\inputminted`: optional `[...]`,
     /// `{lang}`, then body.
     Mint,
@@ -494,6 +496,8 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "spverb"
             || name == "mintinline"
             || name == "inputminted"
+            || name == "verbatiminput"
+            || name == "tcbinputlisting"
             || name == "mint"
             || name == "Verb"
             || name == "SaveVerb"

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -379,6 +379,15 @@ pub(crate) fn latex_verb_span_end_with(
         return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
     }
 
+    if kind == VerbKind::Tcbinputlisting {
+        i = skip_ascii_ws(text, i);
+        if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
+            return None;
+        }
+        i += 1;
+        return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
+    }
+
     if kind == VerbKind::Mint {
         if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
             return None;
@@ -437,6 +446,8 @@ enum VerbKind {
     Lstinputlisting,
     /// `\verbatiminput`: required `{filename}` (verbatim.sty leftover).
     Verbatiminput,
+    /// `\tcbinputlisting`: one required `{keyvals}` group.
+    Tcbinputlisting,
     /// `\mintinline` / `\mint` / `\inputminted`: optional `[...]`,
     /// `{lang}`, then body.
     Mint,
@@ -466,6 +477,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "mintinline"
             || name == "inputminted"
             || name == "verbatiminput"
+            || name == "tcbinputlisting"
             || name == "mint"
             || name == "Verb"
             || name == "SaveVerb"

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -3925,7 +3925,7 @@ mod tests {
     #[test]
     fn plaintext_format_keeps_dialogue_quote_together() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "He said \"Hello world. How are you?\" Then he left.\n";
         let cfg = FormatConfig {
@@ -4042,7 +4042,7 @@ mod tests {
     #[test]
     fn newlines_invariant_holds_on_dialogue_output() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let samples = [
             "He said \"Hello world. How are you?\" Then he left.\n",
@@ -4290,7 +4290,7 @@ mod tests {
     #[test]
     fn markdown_period_inside_closers_survives_format_roundtrip() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Markdown,
@@ -4304,7 +4304,7 @@ mod tests {
     #[test]
     fn org_markdown_style_bold_period_splits_without_headline() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Org,
@@ -4365,7 +4365,7 @@ mod tests {
     #[test]
     fn markdown_emphasis_format_text_does_not_break_inside_span() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Markdown,
@@ -4413,7 +4413,7 @@ mod tests {
     #[test]
     fn plaintext_bang_inside_code_span_stays_atomic_after_keep_break() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "?=\"`=!a`\n";
         let cfg = FormatConfig {
@@ -4433,7 +4433,7 @@ mod tests {
     #[test]
     fn keeps_break_before_lowercase_proper_noun() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "First sentence.\niCloud starts the second sentence.\n";
         for format in [
@@ -4460,7 +4460,7 @@ mod tests {
     #[test]
     fn splits_same_line_lowercase_proper_noun() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         assert_eq!(
             split("First sentence. iCloud starts the second sentence."),

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -200,7 +200,8 @@ pub fn protect_inline_tokens_with(
 /// `\mintinline{lang}|...|` / `\mint{lang}{...}` /
 /// `\inputminted{lang}{file}` / `\Verb|...|` /
 /// `\SaveVerb{name}|...|` / `\piton|...|` /
-/// `\lstinputlisting[...]{file}` so inner `.!?%` cannot
+/// `\lstinputlisting[...]{file}` /
+/// `\tcbinputlisting{keyvals}` so inner `.!?%` cannot
 /// split or comment. `\piton{...}` stays on the generic `\cmd{arg}`
 /// path (piton.sty brace syntax is not verbatim; GitHub #305).
 fn protect_latex_verbatim(
@@ -228,7 +229,7 @@ fn protect_latex_verbatim(
 
 /// Byte end of a `\verb` / `\lstinline` / `\spverb` / `\mintinline` /
 /// `\mint` / `\inputminted` / `\Verb` / `\SaveVerb` / `\piton` /
-/// `\lstinputlisting` /
+/// `\lstinputlisting` / `\tcbinputlisting` /
 /// extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
@@ -247,7 +248,9 @@ fn protect_latex_verbatim(
 /// delimiter so `\piton{...}` stays on the generic `\cmd{arg}` path.
 /// `\lstinputlisting` / `\lstinputlisting*` (listings.sty leftover;
 /// GitHub #391) take optional `[...]` then a required `{filename}`;
-/// no brace is not a span. Extra names are tokenized like `\verb`.
+/// no brace is not a span. `\tcbinputlisting` (tcolorbox leftover;
+/// GitHub #400) takes one keyval group; no brace is not a span.
+/// Extra names are tokenized like `\verb`.
 /// With no closer, the span runs to end of line so an inner `%` is
 /// not a comment.
 pub(crate) fn latex_verb_span_end_with(
@@ -281,6 +284,14 @@ pub(crate) fn latex_verb_span_end_with(
         (
             after_bs + "lstinputlisting".len(),
             VerbKind::Lstinputlisting,
+        )
+    } else if let Some(stripped) = tail.strip_prefix("tcbinputlisting") {
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (
+            after_bs + "tcbinputlisting".len(),
+            VerbKind::Tcbinputlisting,
         )
     } else if let Some(stripped) = tail.strip_prefix("lstinline") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
@@ -358,6 +369,16 @@ pub(crate) fn latex_verb_span_end_with(
         return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
     }
 
+    // tcolorbox `\tcbinputlisting{keyvals}` is one keyval group.
+    if kind == VerbKind::Tcbinputlisting {
+        i = skip_ascii_ws(text, i);
+        if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
+            return None;
+        }
+        i += 1;
+        return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
+    }
+
     if kind == VerbKind::Mint {
         if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
             return None;
@@ -414,6 +435,8 @@ enum VerbKind {
     Lstinline,
     /// `\lstinputlisting`: optional `[...]` then required `{filename}`.
     Lstinputlisting,
+    /// `\tcbinputlisting`: one required `{keyvals}` group.
+    Tcbinputlisting,
     /// `\mintinline` / `\mint` / `\inputminted`: optional `[...]`,
     /// `{lang}`, then body.
     Mint,
@@ -439,6 +462,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "verb"
             || name == "lstinline"
             || name == "lstinputlisting"
+            || name == "tcbinputlisting"
             || name == "spverb"
             || name == "mintinline"
             || name == "inputminted"
@@ -2333,6 +2357,50 @@ mod tests {
             latex_verb_span_end_with(r"\input{foo.py}", 0, &[]),
             None,
             "inputminted must not steal \\input"
+        );
+    }
+
+    /// Ticket fixture (GitHub #400): tcolorbox `\tcbinputlisting{keyvals}`
+    /// is one leftover command; following `After.` still splits.
+    #[test]
+    fn latex_tcbinputlisting_stays_atomic() {
+        let text = r"See \tcbinputlisting{listing file=foo.py} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders
+                .iter()
+                .any(|p| p == r"\tcbinputlisting{listing file=foo.py}"),
+            "tcbinputlisting span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\tcbinputlisting{listing file=foo.py}", 0, &[]),
+            Some(r"\tcbinputlisting{listing file=foo.py}".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \tcbinputlisting{listing file=foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\tcbinputlisting {listing file=foo.py}", 0, &[]),
+            Some(r"\tcbinputlisting {listing file=foo.py}".len())
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\tcbinputlisting foo.py", 0, &[]),
+            None,
+            "tcbinputlisting without a keyval group is not a verb span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\lstinputlisting{foo.py}", 0, &[]),
+            Some(r"\lstinputlisting{foo.py}".len()),
+            "tcbinputlisting must not steal lstinputlisting"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputminted{python}{foo.py}", 0, &[]),
+            Some(r"\inputminted{python}{foo.py}".len()),
+            "tcbinputlisting must not steal inputminted"
         );
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -3566,3 +3566,4 @@ fn piton_env_and_pipe_cmd_fixture_is_code_and_does_not_reflow() {
             "prose after inputminted must still split, got:\n{minted_in_out}"
         );
     }
+}

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -11,6 +11,8 @@
 //! GitHub #245: minted.sty \\mintinline / \\mint take {lang} then a FancyVerb body.
 //! GitHub #394: minted.sty \\inputminted is one leftover command;
 //! following flush prose stays on its own line.
+//! GitHub #400: tcolorbox \\tcbinputlisting is one leftover command
+//! (one keyval group); following flush prose stays on its own line.
 //! GitHub #273: minted.sty minted* is the starred twin of minted (same raw body).
 //! GitHub #275: fancyvrb \\SaveVerb{name}|body| is the same delimiter body as \\Verb.
 //! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
@@ -2960,6 +2962,115 @@ fn inputminted_fixture_does_not_join_following_prose() {
     assert!(
         minted_out.contains("After the block.\nNext."),
         "prose after minted must still split, got:\n{minted_out}"
+    );
+}
+
+/// Ticket fixture (GitHub #400): tcolorbox `\tcbinputlisting{keyvals}`
+/// stays one leftover command. Following flush `After.` does not join
+/// the command line. `After.` / `Next.` still split. tcboutputlisting /
+/// lstinputlisting / inputminted unchanged.
+#[test]
+fn tcbinputlisting_fixture_does_not_join_following_prose() {
+    let input = concat!(
+        "Before. Next.\n",
+        "\\tcbinputlisting{listing file=foo.py}\n",
+        "After. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\tcbinputlisting{listing file=foo.py}")
+        )),
+        "tcbinputlisting must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\tcbinputlisting{listing file=foo.py}")
+        )),
+        "tcbinputlisting must not leak into Prose, got: {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+        )),
+        "After. / Next. must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
+        "tcbinputlisting must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\tcbinputlisting{listing file=foo.py} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before tcbinputlisting must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after tcbinputlisting must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let tcboutput = concat!(
+        "\\begin{tcboutputlisting}\n",
+        "First line. Second line.\n",
+        "\\end{tcboutputlisting}\n",
+        "After the block. Next.\n",
+    );
+    let tcboutput_out = format_text(tcboutput, &latex_cfg()).unwrap();
+    assert!(
+        tcboutput_out.contains(
+            "\\begin{tcboutputlisting}\nFirst line. Second line.\n\\end{tcboutputlisting}"
+        ),
+        "tcboutputlisting must stay a code env, got:\n{tcboutput_out}"
+    );
+    assert!(
+        tcboutput_out.contains("After the block.\nNext."),
+        "prose after tcboutputlisting must still split, got:\n{tcboutput_out}"
+    );
+
+    let lstinput = concat!(
+        "Before. Next.\n",
+        "\\lstinputlisting{foo.py}\n",
+        "After. Next.\n",
+    );
+    let lstinput_out = format_text(lstinput, &latex_cfg()).unwrap();
+    assert!(
+        lstinput_out.contains("\\lstinputlisting{foo.py}\n"),
+        "lstinputlisting must stay one atomic command, got:\n{lstinput_out}"
+    );
+    assert!(
+        !lstinput_out.contains("\\lstinputlisting{foo.py} After."),
+        "lstinputlisting must not join following prose, got:\n{lstinput_out}"
+    );
+    assert!(
+        lstinput_out.contains("After.\nNext."),
+        "prose after lstinputlisting must still split, got:\n{lstinput_out}"
+    );
+
+    let minted_in = concat!(
+        "Before. Next.\n",
+        "\\inputminted{python}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let minted_in_out = format_text(minted_in, &latex_cfg()).unwrap();
+    assert!(
+        minted_in_out.contains("\\inputminted{python}{foo.py}\n"),
+        "inputminted must stay one atomic command, got:\n{minted_in_out}"
+    );
+    assert!(
+        !minted_in_out.contains("\\inputminted{python}{foo.py} After."),
+        "inputminted must not join following prose, got:\n{minted_in_out}"
+    );
+    assert!(
+        minted_in_out.contains("After.\nNext."),
+        "prose after inputminted must still split, got:\n{minted_in_out}"
     );
 }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -77,7 +77,7 @@
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
 use snapper_fmt::parser::{FormatParser, Region};
-use snapper_fmt::{format_text, FormatConfig};
+use snapper_fmt::{FormatConfig, format_text};
 
 fn latex_cfg() -> FormatConfig {
     FormatConfig {

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -3460,108 +3460,109 @@ fn piton_env_and_pipe_cmd_fixture_is_code_and_does_not_reflow() {
             "inputminted must not join following prose, got:\n{minted_out}"
         );
     }
-fn tcbinputlisting_fixture_does_not_join_following_prose() {
-    let input = concat!(
-        "Before. Next.\n",
-        "\\tcbinputlisting{listing file=foo.py}\n",
-        "After. Next.\n",
-    );
-    let regions = LatexParser::default().parse(input);
-    assert!(
-        regions.iter().any(|r| matches!(
-            r,
-            Region::Structure(s) if s.contains(r"\tcbinputlisting{listing file=foo.py}")
-        )),
-        "tcbinputlisting must stay one Structure command, got: {regions:?}"
-    );
-    assert!(
-        !regions.iter().any(|r| matches!(
-            r,
-            Region::Prose(p) if p.contains(r"\tcbinputlisting{listing file=foo.py}")
-        )),
-        "tcbinputlisting must not leak into Prose, got: {regions:?}"
-    );
-    assert!(
-        regions.iter().any(|r| matches!(
-            r,
-            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
-        )),
-        "After. / Next. must stay Prose, got: {regions:?}"
-    );
-    let out = format_text(input, &latex_cfg()).unwrap();
-    assert!(
-        out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
-        "tcbinputlisting must stay one atomic command, got:\n{out}"
-    );
-    assert!(
-        !out.contains("\\tcbinputlisting{listing file=foo.py} After."),
-        "following flush prose must not join the command line, got:\n{out}"
-    );
-    assert!(
-        out.contains("Before.\nNext."),
-        "prose before tcbinputlisting must still split, got:\n{out}"
-    );
-    assert!(
-        out.contains("After.\nNext."),
-        "prose after tcbinputlisting must still split, got:\n{out}"
-    );
-    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 
-    let tcboutput = concat!(
-        "\\begin{tcboutputlisting}\n",
-        "First line. Second line.\n",
-        "\\end{tcboutputlisting}\n",
-        "After the block. Next.\n",
-    );
-    let tcboutput_out = format_text(tcboutput, &latex_cfg()).unwrap();
-    assert!(
-        tcboutput_out.contains(
-            "\\begin{tcboutputlisting}\nFirst line. Second line.\n\\end{tcboutputlisting}"
-        ),
-        "tcboutputlisting must stay a code env, got:\n{tcboutput_out}"
-    );
-    assert!(
-        tcboutput_out.contains("After the block.\nNext."),
-        "prose after tcboutputlisting must still split, got:\n{tcboutput_out}"
-    );
+    /// Ticket fixture (GitHub #400): tcolorbox `\\tcbinputlisting`.
+    #[test]
+    fn tcbinputlisting_fixture_does_not_join_following_prose() {
+        let input = concat!(
+            "Before. Next.\n",
+            "\\tcbinputlisting{listing file=foo.py}\n",
+            "After. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\tcbinputlisting{listing file=foo.py}")
+            )),
+            "tcbinputlisting must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\tcbinputlisting{listing file=foo.py}")
+            )),
+            "tcbinputlisting must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+            )),
+            "After. / Next. must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
+            "tcbinputlisting must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\tcbinputlisting{listing file=foo.py} After."),
+            "following flush prose must not join the command line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before.\nNext."),
+            "prose before tcbinputlisting must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after tcbinputlisting must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 
-    let lstinput = concat!(
-        "Before. Next.\n",
-        "\\lstinputlisting{foo.py}\n",
-        "After. Next.\n",
-    );
-    let lstinput_out = format_text(lstinput, &latex_cfg()).unwrap();
-    assert!(
-        lstinput_out.contains("\\lstinputlisting{foo.py}\n"),
-        "lstinputlisting must stay one atomic command, got:\n{lstinput_out}"
-    );
-    assert!(
-        !lstinput_out.contains("\\lstinputlisting{foo.py} After."),
-        "lstinputlisting must not join following prose, got:\n{lstinput_out}"
-    );
-    assert!(
-        lstinput_out.contains("After.\nNext."),
-        "prose after lstinputlisting must still split, got:\n{lstinput_out}"
-    );
+        let tcboutput = concat!(
+            "\\begin{tcboutputlisting}\n",
+            "First line. Second line.\n",
+            "\\end{tcboutputlisting}\n",
+            "After the block. Next.\n",
+        );
+        let tcboutput_out = format_text(tcboutput, &latex_cfg()).unwrap();
+        assert!(
+            tcboutput_out.contains(
+                "\\begin{tcboutputlisting}\nFirst line. Second line.\n\\end{tcboutputlisting}"
+            ),
+            "tcboutputlisting must stay a code env, got:\n{tcboutput_out}"
+        );
+        assert!(
+            tcboutput_out.contains("After the block.\nNext."),
+            "prose after tcboutputlisting must still split, got:\n{tcboutput_out}"
+        );
 
-    let minted_in = concat!(
-        "Before. Next.\n",
-        "\\inputminted{python}{foo.py}\n",
-        "After. Next.\n",
-    );
-    let minted_in_out = format_text(minted_in, &latex_cfg()).unwrap();
-    assert!(
-        minted_in_out.contains("\\inputminted{python}{foo.py}\n"),
-        "inputminted must stay one atomic command, got:\n{minted_in_out}"
-    );
-    assert!(
-        !minted_in_out.contains("\\inputminted{python}{foo.py} After."),
-        "inputminted must not join following prose, got:\n{minted_in_out}"
-    );
-    assert!(
-        minted_in_out.contains("After.\nNext."),
-        "prose after inputminted must still split, got:\n{minted_in_out}"
-    );
-}
+        let lstinput = concat!(
+            "Before. Next.\n",
+            "\\lstinputlisting{foo.py}\n",
+            "After. Next.\n",
+        );
+        let lstinput_out = format_text(lstinput, &latex_cfg()).unwrap();
+        assert!(
+            lstinput_out.contains("\\lstinputlisting{foo.py}\n"),
+            "lstinputlisting must stay one atomic command, got:\n{lstinput_out}"
+        );
+        assert!(
+            !lstinput_out.contains("\\lstinputlisting{foo.py} After."),
+            "lstinputlisting must not join following prose, got:\n{lstinput_out}"
+        );
+        assert!(
+            lstinput_out.contains("After.\nNext."),
+            "prose after lstinputlisting must still split, got:\n{lstinput_out}"
+        );
 
-}
+        let minted_in = concat!(
+            "Before. Next.\n",
+            "\\inputminted{python}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let minted_in_out = format_text(minted_in, &latex_cfg()).unwrap();
+        assert!(
+            minted_in_out.contains("\\inputminted{python}{foo.py}\n"),
+            "inputminted must stay one atomic command, got:\n{minted_in_out}"
+        );
+        assert!(
+            !minted_in_out.contains("\\inputminted{python}{foo.py} After."),
+            "inputminted must not join following prose, got:\n{minted_in_out}"
+        );
+        assert!(
+            minted_in_out.contains("After.\nNext."),
+            "prose after inputminted must still split, got:\n{minted_in_out}"
+        );
+    }

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -3460,110 +3460,110 @@ fn piton_env_and_pipe_cmd_fixture_is_code_and_does_not_reflow() {
             "inputminted must not join following prose, got:\n{minted_out}"
         );
     }
+}
 
-    /// Ticket fixture (GitHub #400): tcolorbox `\\tcbinputlisting`.
-    #[test]
-    fn tcbinputlisting_fixture_does_not_join_following_prose() {
-        let input = concat!(
-            "Before. Next.\n",
-            "\\tcbinputlisting{listing file=foo.py}\n",
-            "After. Next.\n",
-        );
-        let regions = LatexParser::default().parse(input);
-        assert!(
-            regions.iter().any(|r| matches!(
-                r,
-                Region::Structure(s) if s.contains(r"\tcbinputlisting{listing file=foo.py}")
-            )),
-            "tcbinputlisting must stay one Structure command, got: {regions:?}"
-        );
-        assert!(
-            !regions.iter().any(|r| matches!(
-                r,
-                Region::Prose(p) if p.contains(r"\tcbinputlisting{listing file=foo.py}")
-            )),
-            "tcbinputlisting must not leak into Prose, got: {regions:?}"
-        );
-        assert!(
-            regions.iter().any(|r| matches!(
-                r,
-                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
-            )),
-            "After. / Next. must stay Prose, got: {regions:?}"
-        );
-        let out = format_text(input, &latex_cfg()).unwrap();
-        assert!(
-            out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
-            "tcbinputlisting must stay one atomic command, got:\n{out}"
-        );
-        assert!(
-            !out.contains("\\tcbinputlisting{listing file=foo.py} After."),
-            "following flush prose must not join the command line, got:\n{out}"
-        );
-        assert!(
-            out.contains("Before.\nNext."),
-            "prose before tcbinputlisting must still split, got:\n{out}"
-        );
-        assert!(
-            out.contains("After.\nNext."),
-            "prose after tcbinputlisting must still split, got:\n{out}"
-        );
-        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+/// Ticket fixture (GitHub #400): tcolorbox `\\tcbinputlisting`.
+#[test]
+fn tcbinputlisting_fixture_does_not_join_following_prose() {
+    let input = concat!(
+        "Before. Next.\n",
+        "\\tcbinputlisting{listing file=foo.py}\n",
+        "After. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\tcbinputlisting{listing file=foo.py}")
+        )),
+        "tcbinputlisting must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\tcbinputlisting{listing file=foo.py}")
+        )),
+        "tcbinputlisting must not leak into Prose, got: {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+        )),
+        "After. / Next. must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
+        "tcbinputlisting must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\tcbinputlisting{listing file=foo.py} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before tcbinputlisting must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after tcbinputlisting must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
 
-        let tcboutput = concat!(
-            "\\begin{tcboutputlisting}\n",
-            "First line. Second line.\n",
-            "\\end{tcboutputlisting}\n",
-            "After the block. Next.\n",
-        );
-        let tcboutput_out = format_text(tcboutput, &latex_cfg()).unwrap();
-        assert!(
-            tcboutput_out.contains(
-                "\\begin{tcboutputlisting}\nFirst line. Second line.\n\\end{tcboutputlisting}"
-            ),
-            "tcboutputlisting must stay a code env, got:\n{tcboutput_out}"
-        );
-        assert!(
-            tcboutput_out.contains("After the block.\nNext."),
-            "prose after tcboutputlisting must still split, got:\n{tcboutput_out}"
-        );
+    let tcboutput = concat!(
+        "\\begin{tcboutputlisting}\n",
+        "First line. Second line.\n",
+        "\\end{tcboutputlisting}\n",
+        "After the block. Next.\n",
+    );
+    let tcboutput_out = format_text(tcboutput, &latex_cfg()).unwrap();
+    assert!(
+        tcboutput_out.contains(
+            "\\begin{tcboutputlisting}\nFirst line. Second line.\n\\end{tcboutputlisting}"
+        ),
+        "tcboutputlisting must stay a code env, got:\n{tcboutput_out}"
+    );
+    assert!(
+        tcboutput_out.contains("After the block.\nNext."),
+        "prose after tcboutputlisting must still split, got:\n{tcboutput_out}"
+    );
 
-        let lstinput = concat!(
-            "Before. Next.\n",
-            "\\lstinputlisting{foo.py}\n",
-            "After. Next.\n",
-        );
-        let lstinput_out = format_text(lstinput, &latex_cfg()).unwrap();
-        assert!(
-            lstinput_out.contains("\\lstinputlisting{foo.py}\n"),
-            "lstinputlisting must stay one atomic command, got:\n{lstinput_out}"
-        );
-        assert!(
-            !lstinput_out.contains("\\lstinputlisting{foo.py} After."),
-            "lstinputlisting must not join following prose, got:\n{lstinput_out}"
-        );
-        assert!(
-            lstinput_out.contains("After.\nNext."),
-            "prose after lstinputlisting must still split, got:\n{lstinput_out}"
-        );
+    let lstinput = concat!(
+        "Before. Next.\n",
+        "\\lstinputlisting{foo.py}\n",
+        "After. Next.\n",
+    );
+    let lstinput_out = format_text(lstinput, &latex_cfg()).unwrap();
+    assert!(
+        lstinput_out.contains("\\lstinputlisting{foo.py}\n"),
+        "lstinputlisting must stay one atomic command, got:\n{lstinput_out}"
+    );
+    assert!(
+        !lstinput_out.contains("\\lstinputlisting{foo.py} After."),
+        "lstinputlisting must not join following prose, got:\n{lstinput_out}"
+    );
+    assert!(
+        lstinput_out.contains("After.\nNext."),
+        "prose after lstinputlisting must still split, got:\n{lstinput_out}"
+    );
 
-        let minted_in = concat!(
-            "Before. Next.\n",
-            "\\inputminted{python}{foo.py}\n",
-            "After. Next.\n",
-        );
-        let minted_in_out = format_text(minted_in, &latex_cfg()).unwrap();
-        assert!(
-            minted_in_out.contains("\\inputminted{python}{foo.py}\n"),
-            "inputminted must stay one atomic command, got:\n{minted_in_out}"
-        );
-        assert!(
-            !minted_in_out.contains("\\inputminted{python}{foo.py} After."),
-            "inputminted must not join following prose, got:\n{minted_in_out}"
-        );
-        assert!(
-            minted_in_out.contains("After.\nNext."),
-            "prose after inputminted must still split, got:\n{minted_in_out}"
-        );
-    }
+    let minted_in = concat!(
+        "Before. Next.\n",
+        "\\inputminted{python}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let minted_in_out = format_text(minted_in, &latex_cfg()).unwrap();
+    assert!(
+        minted_in_out.contains("\\inputminted{python}{foo.py}\n"),
+        "inputminted must stay one atomic command, got:\n{minted_in_out}"
+    );
+    assert!(
+        !minted_in_out.contains("\\inputminted{python}{foo.py} After."),
+        "inputminted must not join following prose, got:\n{minted_in_out}"
+    );
+    assert!(
+        minted_in_out.contains("After.\nNext."),
+        "prose after inputminted must still split, got:\n{minted_in_out}"
+    );
 }


### PR DESCRIPTION
tcolorbox `\tcbinputlisting{listing file=foo.py}`.

The command stays atomic. Following prose still splits. `tcboutputlisting` / `lstinputlisting` / `inputminted` unchanged.

Closes #400.

Do not hand-edit CHANGELOG.md.