### PR TITLE
fix(latex): tokenize verbatim verbatiminput like lstinputlisting

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -187,12 +187,13 @@ Adding =algorithm= stops reflow of that environment.
 
 String array of extra command names tokenized like the built-in verb command before sentence split.
 The next character after the name is the delimiter.
-Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline=, =inputminted=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb=, and piton.sty =\piton=; =lstinline= still accepts optional =[...]= and ={...}=.
+Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline=, =inputminted=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb=, piton.sty =\piton=, and tools/verbatim.sty =\verbatiminput=; =lstinline= still accepts optional =[...]= and ={...}=.
 =mintinline= / =mint= take optional =[...]=, a ={lang}= argument, then a delimiter or ={...}= body.
 =\inputminted= takes the same optional =[...]= and ={lang}= then a required ={filename}=; following flush prose stays on its own line.
 =SaveVerb= takes optional =[...]=, a ={name}= argument, then the same delimiter body as =Verb=.
 =\piton|...|= is verb-like (interior =.!?%= stay one token); =\piton{...}= stays one token via the generic command argument.
 =\lstinputlisting= takes optional =[...]= then a required ={filename}=; following flush prose stays on its own line.
+=\verbatiminput= / =\verbatiminput*= take a required ={filename}=; following flush prose stays on its own line.
 Adding another name keeps that command's delimited body atomic and treats an inner =%= as content, not a comment.
 
 * Code-block sections (=[code.<lang>]=)

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -135,10 +135,11 @@ These tokens within prose are not split across lines:
 - piton.sty =Piton= is a built-in code region (verbatim listing env)
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= / =minted*= language arg, =lstlisting= / =lstlisting*= =language== option)
-- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= / piton.sty =\piton= / listings.sty =\lstinputlisting= / minted.sty =\inputminted= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment.
+- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= / piton.sty =\piton= / listings.sty =\lstinputlisting= / minted.sty =\inputminted= / tools/verbatim.sty =\verbatiminput= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment.
   =\piton|...|= is verb-like; =\piton{...}= stays one token via the generic command argument
   =\lstinputlisting= / =\lstinputlisting*= take optional =[...]= then a ={filename}=; a flush following sentence stays on its own line
   =\inputminted= / =\inputminted*= take optional =[...]=, ={lang}=, then a ={filename}=; a flush following sentence stays on its own line
+  =\verbatiminput= / =\verbatiminput*= take a ={filename}=; a flush following sentence stays on its own line
 
 *** Prose regions (reflowed)
 :PROPERTIES:

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub struct FormatOverrides {
     pub structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
     /// Meaningful under `[latex]` only. Missing or empty keeps
-    /// verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/piton.
+    /// verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/piton/verbatiminput.
     pub verbatim_commands: Vec<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub struct FormatConfig {
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.
     pub latex_structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
-    /// Empty keeps verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/piton.
+    /// Empty keeps verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/piton/verbatiminput.
     pub latex_verbatim_commands: Vec<String>,
 }
 

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -502,7 +502,7 @@ impl LatexParser {
     /// Byte offset of the first `%` that is not escaped as `\%` and is not
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
     /// `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
-    /// `\inputminted` / configured verbatim commands.
+    /// `\inputminted` / `\verbatiminput` / configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -875,7 +875,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 
 /// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` /
 /// `\spverb` / `\mintinline` / `\mint` / `\inputminted` / `\Verb` /
-/// `\SaveVerb` / `\piton` / `\lstinputlisting` spans.
+/// `\SaveVerb` / `\piton` / `\lstinputlisting` / `\verbatiminput` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -915,6 +915,14 @@ fn find_lstinputlisting_at(
 /// stops at an unescaped `%` so a comment is not a command tail.
 fn find_inputminted_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<(usize, usize)> {
     find_leftover_cmd_at(line, from, extra_cmds, inputminted_cs_at)
+}
+
+/// Leftover tools/verbatim.sty `\verbatiminput` / `\verbatiminput*`
+/// (required `{file}`; GitHub #398). Other verb spans are skipped so
+/// `\verb|\verbatiminput{x}|` is not stolen. Walk stops at an
+/// unescaped `%` so a comment is not a command tail.
+fn find_verbatiminput_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<(usize, usize)> {
+    find_leftover_cmd_at(line, from, extra_cmds, verbatiminput_cs_at)
 }
 
 fn find_leftover_cmd_at(
@@ -962,6 +970,16 @@ fn inputminted_cs_at(line: &str, at: usize) -> bool {
         return false;
     };
     let Some(after) = tail.strip_prefix("inputminted") else {
+        return false;
+    };
+    !after.starts_with(|c: char| c.is_ascii_alphabetic())
+}
+
+fn verbatiminput_cs_at(line: &str, at: usize) -> bool {
+    let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
+        return false;
+    };
+    let Some(after) = tail.strip_prefix("verbatiminput") else {
         return false;
     };
     !after.starts_with(|c: char| c.is_ascii_alphabetic())
@@ -1652,6 +1670,9 @@ impl<'a> ParseState<'a> {
             if let Some((start, end)) =
                 find_lstinputlisting_at(code, i, &self.parser.extra_verbatim_commands)
                     .or_else(|| find_inputminted_at(code, i, &self.parser.extra_verbatim_commands))
+                    .or_else(|| {
+                        find_verbatiminput_at(code, i, &self.parser.extra_verbatim_commands)
+                    })
             {
                 self.append_item_or_prose(line.start + i, &code[i..start]);
                 self.push_structure(ByteSpan::new(
@@ -2576,6 +2597,119 @@ Some text.
         assert!(
             minted_out.contains("After the block.\nNext."),
             "prose after minted must still split, got:\n{minted_out}"
+        );
+        assert_eq!(format_text(&minted_out, &latex_cfg()).unwrap(), minted_out);
+    }
+
+    /// Ticket fixture (GitHub #398): tools/verbatim.sty `\verbatiminput{file}`
+    /// is one leftover command. Following flush prose does not join the
+    /// command line. `After.` / `Next.` still split. `lstinputlisting` /
+    /// `inputminted` unchanged.
+    #[test]
+    fn verbatiminput_does_not_join_following_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "Before. Next.\n",
+            "\\verbatiminput{foo.py}\n",
+            "After. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\verbatiminput{foo.py}")
+            )),
+            "verbatiminput must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\verbatiminput{foo.py}")
+            )),
+            "verbatiminput must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+            )),
+            "After. / Next. must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\verbatiminput{foo.py}\n"),
+            "verbatiminput must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\verbatiminput{foo.py} After."),
+            "following flush prose must not join the command line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before.\nNext."),
+            "prose before verbatiminput must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after verbatiminput must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let star = concat!(
+            "Before. Next.\n",
+            "\\verbatiminput*{foo.py}\n",
+            "After. Next.\n",
+        );
+        let star_out = format_text(star, &latex_cfg()).unwrap();
+        assert!(
+            star_out.contains("\\verbatiminput*{foo.py}\n"),
+            "verbatiminput* must stay one atomic command, got:\n{star_out}"
+        );
+        assert!(
+            !star_out.contains("\\verbatiminput*{foo.py} After."),
+            "starred verbatiminput must not join following prose, got:\n{star_out}"
+        );
+        assert!(
+            star_out.contains("After.\nNext."),
+            "prose after starred verbatiminput must still split, got:\n{star_out}"
+        );
+
+        let lst = concat!(
+            "Before. Next.\n",
+            "\\lstinputlisting{foo.py}\n",
+            "After. Next.\n",
+        );
+        let lst_out = format_text(lst, &latex_cfg()).unwrap();
+        assert!(
+            lst_out.contains("\\lstinputlisting{foo.py}\n"),
+            "lstinputlisting must stay unchanged, got:\n{lst_out}"
+        );
+        assert!(
+            !lst_out.contains("\\lstinputlisting{foo.py} After."),
+            "lstinputlisting must not join following prose, got:\n{lst_out}"
+        );
+        assert!(
+            lst_out.contains("After.\nNext."),
+            "prose after lstinputlisting must still split, got:\n{lst_out}"
+        );
+
+        let minted = concat!(
+            "Before. Next.\n",
+            "\\inputminted{python}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let minted_out = format_text(minted, &latex_cfg()).unwrap();
+        assert!(
+            minted_out.contains("\\inputminted{python}{foo.py}\n"),
+            "inputminted must stay unchanged, got:\n{minted_out}"
+        );
+        assert!(
+            !minted_out.contains("\\inputminted{python}{foo.py} After."),
+            "inputminted must not join following prose, got:\n{minted_out}"
+        );
+        assert!(
+            minted_out.contains("After.\nNext."),
+            "prose after inputminted must still split, got:\n{minted_out}"
         );
         assert_eq!(format_text(&minted_out, &latex_cfg()).unwrap(), minted_out);
     }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -200,7 +200,7 @@ pub fn protect_inline_tokens_with(
 /// `\mintinline{lang}|...|` / `\mint{lang}{...}` /
 /// `\inputminted{lang}{file}` / `\Verb|...|` /
 /// `\SaveVerb{name}|...|` / `\piton|...|` /
-/// `\lstinputlisting[...]{file}` so inner `.!?%` cannot
+/// `\lstinputlisting[...]{file}` / `\verbatiminput{file}` so inner `.!?%` cannot
 /// split or comment. `\piton{...}` stays on the generic `\cmd{arg}`
 /// path (piton.sty brace syntax is not verbatim; GitHub #305).
 fn protect_latex_verbatim(
@@ -228,7 +228,7 @@ fn protect_latex_verbatim(
 
 /// Byte end of a `\verb` / `\lstinline` / `\spverb` / `\mintinline` /
 /// `\mint` / `\inputminted` / `\Verb` / `\SaveVerb` / `\piton` /
-/// `\lstinputlisting` /
+/// `\lstinputlisting` / `\verbatiminput` /
 /// extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
@@ -247,9 +247,11 @@ fn protect_latex_verbatim(
 /// delimiter so `\piton{...}` stays on the generic `\cmd{arg}` path.
 /// `\lstinputlisting` / `\lstinputlisting*` (listings.sty leftover;
 /// GitHub #391) take optional `[...]` then a required `{filename}`;
-/// no brace is not a span. Extra names are tokenized like `\verb`.
-/// With no closer, the span runs to end of line so an inner `%` is
-/// not a comment.
+/// no brace is not a span. `\verbatiminput` / `\verbatiminput*`
+/// (tools/verbatim.sty leftover; GitHub #398) take a required
+/// `{filename}`; no brace is not a span. Extra names are tokenized
+/// like `\verb`. With no closer, the span runs to end of line so an
+/// inner `%` is not a comment.
 pub(crate) fn latex_verb_span_end_with(
     text: &str,
     at: usize,
@@ -282,6 +284,12 @@ pub(crate) fn latex_verb_span_end_with(
             after_bs + "lstinputlisting".len(),
             VerbKind::Lstinputlisting,
         )
+    } else if let Some(stripped) = tail.strip_prefix("verbatiminput") {
+        // Before `verb` so `\verbatiminput` is not `\verb` + leftover.
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (after_bs + "verbatiminput".len(), VerbKind::Verbatiminput)
     } else if let Some(stripped) = tail.strip_prefix("lstinline") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -350,7 +358,12 @@ pub(crate) fn latex_verb_span_end_with(
     }
 
     // listings.sty `\lstinputlisting[opts]{file}` is brace-only.
-    if kind == VerbKind::Lstinputlisting {
+    // tools/verbatim.sty `\verbatiminput{file}` is the same brace file
+    // arg (no optional `[...]`; GitHub #398).
+    if matches!(kind, VerbKind::Lstinputlisting | VerbKind::Verbatiminput) {
+        if kind == VerbKind::Verbatiminput {
+            i = skip_ascii_ws(text, i);
+        }
         if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
             return None;
         }
@@ -414,6 +427,8 @@ enum VerbKind {
     Lstinline,
     /// `\lstinputlisting`: optional `[...]` then required `{filename}`.
     Lstinputlisting,
+    /// `\verbatiminput`: required `{filename}` (verbatim.sty leftover).
+    Verbatiminput,
     /// `\mintinline` / `\mint` / `\inputminted`: optional `[...]`,
     /// `{lang}`, then body.
     Mint,
@@ -442,6 +457,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "spverb"
             || name == "mintinline"
             || name == "inputminted"
+            || name == "verbatiminput"
             || name == "mint"
             || name == "Verb"
             || name == "SaveVerb"
@@ -2333,6 +2349,61 @@ mod tests {
             latex_verb_span_end_with(r"\input{foo.py}", 0, &[]),
             None,
             "inputminted must not steal \\input"
+        );
+    }
+
+    /// Ticket fixture (GitHub #398): tools/verbatim.sty `\verbatiminput{file}`
+    /// is one token; following `After.` still splits.
+    #[test]
+    fn latex_verbatiminput_stays_atomic() {
+        let text = r"See \verbatiminput{foo.py} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == r"\verbatiminput{foo.py}"),
+            "verbatiminput span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\verbatiminput{foo.py}", 0, &[]),
+            Some(r"\verbatiminput{foo.py}".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \verbatiminput{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\verbatiminput*{foo.py}", 0, &[]),
+            Some(r"\verbatiminput*{foo.py}".len())
+        );
+        let star = r"See \verbatiminput*{foo.py} here. After.";
+        assert_eq!(
+            split(star),
+            vec![
+                r"See \verbatiminput*{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\verbatiminput foo.py", 0, &[]),
+            None,
+            "verbatiminput without a brace file arg is not a verb span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\verb|a.b! c|", 0, &[]),
+            Some(r"\verb|a.b! c|".len()),
+            "verbatiminput must not steal verb"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\lstinputlisting{foo.py}", 0, &[]),
+            Some(r"\lstinputlisting{foo.py}".len()),
+            "verbatiminput must not steal lstinputlisting"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputminted{python}{foo.py}", 0, &[]),
+            Some(r"\inputminted{python}{foo.py}".len()),
+            "verbatiminput must not steal inputminted"
         );
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -11,6 +11,8 @@
 //! GitHub #245: minted.sty \\mintinline / \\mint take {lang} then a FancyVerb body.
 //! GitHub #394: minted.sty \\inputminted is one leftover command;
 //! following flush prose stays on its own line.
+//! GitHub #398: tools/verbatim.sty \\verbatiminput / \\verbatiminput*
+//! is one leftover command; following flush prose stays on its own line.
 //! GitHub #273: minted.sty minted* is the starred twin of minted (same raw body).
 //! GitHub #275: fancyvrb \\SaveVerb{name}|body| is the same delimiter body as \\Verb.
 //! GitHub #246: tcolorbox listings tcblisting* is the starred twin of tcblisting.
@@ -2960,6 +2962,108 @@ fn inputminted_fixture_does_not_join_following_prose() {
     assert!(
         minted_out.contains("After the block.\nNext."),
         "prose after minted must still split, got:\n{minted_out}"
+    );
+}
+
+/// Ticket fixture (GitHub #398): tools/verbatim.sty `\verbatiminput{file}`
+/// stays one atomic command. Following flush `After.` does not join
+/// the command line. `After.` / `Next.` still split. lstinputlisting /
+/// inputminted unchanged.
+#[test]
+fn verbatiminput_fixture_does_not_join_following_prose() {
+    let input = concat!(
+        "Before. Next.\n",
+        "\\verbatiminput{foo.py}\n",
+        "After. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\verbatiminput{foo.py}")
+        )),
+        "verbatiminput must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\verbatiminput{foo.py}")
+        )),
+        "verbatiminput must not leak into Prose, got: {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+        )),
+        "After. / Next. must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\verbatiminput{foo.py}\n"),
+        "verbatiminput must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\verbatiminput{foo.py} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before verbatiminput must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after verbatiminput must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let star = concat!(
+        "Before. Next.\n",
+        "\\verbatiminput*{foo.py}\n",
+        "After. Next.\n",
+    );
+    let star_out = format_text(star, &latex_cfg()).unwrap();
+    assert!(
+        star_out.contains("\\verbatiminput*{foo.py}\n"),
+        "verbatiminput* must stay one atomic command, got:\n{star_out}"
+    );
+    assert!(
+        !star_out.contains("\\verbatiminput*{foo.py} After."),
+        "starred verbatiminput must not join following prose, got:\n{star_out}"
+    );
+    assert!(
+        star_out.contains("After.\nNext."),
+        "prose after starred verbatiminput must still split, got:\n{star_out}"
+    );
+
+    let lst = concat!(
+        "Before. Next.\n",
+        "\\lstinputlisting{foo.py}\n",
+        "After. Next.\n",
+    );
+    let lst_out = format_text(lst, &latex_cfg()).unwrap();
+    assert!(
+        lst_out.contains("\\lstinputlisting{foo.py}\n"),
+        "lstinputlisting must stay unchanged, got:\n{lst_out}"
+    );
+    assert!(
+        !lst_out.contains("\\lstinputlisting{foo.py} After."),
+        "lstinputlisting must not join following prose, got:\n{lst_out}"
+    );
+
+    let minted = concat!(
+        "Before. Next.\n",
+        "\\inputminted{python}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let minted_out = format_text(minted, &latex_cfg()).unwrap();
+    assert!(
+        minted_out.contains("\\inputminted{python}{foo.py}\n"),
+        "inputminted must stay unchanged, got:\n{minted_out}"
+    );
+    assert!(
+        !minted_out.contains("\\inputminted{python}{foo.py} After."),
+        "inputminted must not join following prose, got:\n{minted_out}"
     );
 }
 


### PR DESCRIPTION
tools/verbatim.sty `\verbatiminput{file}` / `\verbatiminput*{file}`.

The command stays atomic. Following prose still splits. `lstinputlisting` / `inputminted` unchanged.

Closes #398.

Do not hand-edit CHANGELOG.md.