### PR TITLE
fix(latex): tokenize piton PitonInputFile like lstinputlisting

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -8061,6 +8061,8 @@ Some text.
     /// atomic. Following flush `After.` does not join.
     #[test]
     fn pitoninputfile_does_not_join_following_prose() {
+        use crate::format_text;
+
         let input = concat!(
             "Before. Next.\n",
             "\\PitonInputFile{foo.py}\n",

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -963,7 +963,6 @@ fn tcbinputlisting_cs_at(line: &str, at: usize) -> bool {
     !after.starts_with(|c: char| c.is_ascii_alphabetic())
 }
 
-
 /// Leftover piton.sty `\PitonInputFile` (optional `<...>`, optional
 /// `[...]`, required `{file}`; `d < > O { } m`; GitHub #406). Other
 /// verb spans are skipped so `\verb|\PitonInputFile{x}|` is not
@@ -986,7 +985,6 @@ fn pitoninputfile_cs_at(line: &str, at: usize) -> bool {
     };
     !after.starts_with(|c: char| c.is_ascii_alphabetic())
 }
-
 
 fn find_leftover_cmd_at(
     line: &str,
@@ -8132,5 +8130,4 @@ Some text.
             "prose after d<> PitonInputFile must still split, got:\n{range_out}"
         );
     }
-
 }

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -963,6 +963,31 @@ fn tcbinputlisting_cs_at(line: &str, at: usize) -> bool {
     !after.starts_with(|c: char| c.is_ascii_alphabetic())
 }
 
+
+/// Leftover piton.sty `\PitonInputFile` (optional `<...>`, optional
+/// `[...]`, required `{file}`; `d < > O { } m`; GitHub #406). Other
+/// verb spans are skipped so `\verb|\PitonInputFile{x}|` is not
+/// stolen. Walk stops at an unescaped `%` so a comment is not a
+/// command tail.
+fn find_pitoninputfile_at(
+    line: &str,
+    from: usize,
+    extra_cmds: &[String],
+) -> Option<(usize, usize)> {
+    find_leftover_cmd_at(line, from, extra_cmds, pitoninputfile_cs_at)
+}
+
+fn pitoninputfile_cs_at(line: &str, at: usize) -> bool {
+    let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
+        return false;
+    };
+    let Some(after) = tail.strip_prefix("PitonInputFile") else {
+        return false;
+    };
+    !after.starts_with(|c: char| c.is_ascii_alphabetic())
+}
+
+
 fn find_leftover_cmd_at(
     line: &str,
     from: usize,
@@ -1728,6 +1753,9 @@ impl<'a> ParseState<'a> {
                     })
                     .or_else(|| {
                         find_tcbinputlisting_at(code, i, &self.parser.extra_verbatim_commands)
+                    })
+                    .or_else(|| {
+                        find_pitoninputfile_at(code, i, &self.parser.extra_verbatim_commands)
                     })
             {
                 self.append_item_or_prose(line.start + i, &code[i..start]);
@@ -8027,4 +8055,80 @@ Some text.
             "prose after inputminted must still split, got:\n{minted_in_out}"
         );
     }
+
+    /// Ticket fixture (GitHub #406): piton.sty `\PitonInputFile{file}`
+    /// stays one leftover command. Optional `[...]` and `<...>` stay
+    /// atomic. Following flush `After.` does not join.
+    #[test]
+    fn pitoninputfile_does_not_join_following_prose() {
+        let input = concat!(
+            "Before. Next.\n",
+            "\\PitonInputFile{foo.py}\n",
+            "After. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\PitonInputFile{foo.py}")
+            )),
+            "PitonInputFile must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\PitonInputFile{foo.py}")
+            )),
+            "PitonInputFile must not leak into Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\PitonInputFile{foo.py}\n"),
+            "PitonInputFile must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\PitonInputFile{foo.py} After."),
+            "following flush prose must not join the command line, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after PitonInputFile must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let opts = concat!(
+            "Before. Next.\n",
+            "\\PitonInputFile[language=python]{foo.py}\n",
+            "After. Next.\n",
+        );
+        let opts_out = format_text(opts, &latex_cfg()).unwrap();
+        assert!(
+            opts_out.contains("\\PitonInputFile[language=python]{foo.py}\n"),
+            "PitonInputFile optional args must stay atomic, got:\n{opts_out}"
+        );
+        assert!(
+            !opts_out.contains("\\PitonInputFile[language=python]{foo.py} After."),
+            "optional-arg PitonInputFile must not join following prose, got:\n{opts_out}"
+        );
+
+        let range = concat!(
+            "Before. Next.\n",
+            "\\PitonInputFile<1-10>[language=python]{foo.py}\n",
+            "After. Next.\n",
+        );
+        let range_out = format_text(range, &latex_cfg()).unwrap();
+        assert!(
+            range_out.contains("\\PitonInputFile<1-10>[language=python]{foo.py}\n"),
+            "PitonInputFile d<> plus optional args must stay atomic, got:\n{range_out}"
+        );
+        assert!(
+            !range_out.contains("\\PitonInputFile<1-10>[language=python]{foo.py} After."),
+            "d<> PitonInputFile must not join following prose, got:\n{range_out}"
+        );
+        assert!(
+            range_out.contains("After.\nNext."),
+            "prose after d<> PitonInputFile must still split, got:\n{range_out}"
+        );
+    }
+
 }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -2589,7 +2589,6 @@ mod tests {
                 "After.".to_string()
             ]
         );
-        let opts = r"See \PitonInputFile[language=python]{foo.py} here. After.";
         assert_eq!(
             latex_verb_span_end_with(r"\PitonInputFile[language=python]{foo.py}", 0, &[]),
             Some(r"\PitonInputFile[language=python]{foo.py}".len())

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -400,7 +400,6 @@ pub(crate) fn latex_verb_span_end_with(
         return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
     }
 
-
     // piton.sty `\PitonInputFile<spec>[opts]{file}` (`d < > O { } m`;
     // GitHub #406). Optional angle then optional brackets, then a
     // required brace file arg. No brace is not a span.
@@ -424,7 +423,6 @@ pub(crate) fn latex_verb_span_end_with(
         i += 1;
         return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
     }
-
 
     if kind == VerbKind::Mint {
         if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
@@ -583,8 +581,6 @@ fn skip_angle_group(text: &str, open_at: usize) -> Option<usize> {
     }
     None
 }
-
-
 
 fn skip_bracket_group(text: &str, open_at: usize) -> Option<usize> {
     let bytes = text.as_bytes();
@@ -2615,8 +2611,6 @@ mod tests {
             "PitonInputFile must not steal tcbinputlisting"
         );
     }
-
-
 
     /// Ticket fixture (GitHub #275): fancyvrb `\SaveVerb{name}|body|`
     /// is one token; following `After.` still splits.

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -301,6 +301,13 @@ pub(crate) fn latex_verb_span_end_with(
             after_bs + "tcbinputlisting".len(),
             VerbKind::Tcbinputlisting,
         )
+    } else if let Some(stripped) = tail.strip_prefix("PitonInputFile") {
+        // Before `piton` so the longer leftover name is not `\piton`
+        // + alphabetic leftover (GitHub #406).
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (after_bs + "PitonInputFile".len(), VerbKind::PitonInputFile)
     } else if let Some(stripped) = tail.strip_prefix("lstinline") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -393,6 +400,32 @@ pub(crate) fn latex_verb_span_end_with(
         return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
     }
 
+
+    // piton.sty `\PitonInputFile<spec>[opts]{file}` (`d < > O { } m`;
+    // GitHub #406). Optional angle then optional brackets, then a
+    // required brace file arg. No brace is not a span.
+    if kind == VerbKind::PitonInputFile {
+        i = skip_ascii_ws(text, i);
+        if text.get(i..).is_some_and(|s| s.starts_with('<')) {
+            match skip_angle_group(text, i) {
+                Some(end) => i = skip_ascii_ws(text, end),
+                None => return Some(line_end(text, i)),
+            }
+        }
+        if text.get(i..).is_some_and(|s| s.starts_with('[')) {
+            match skip_bracket_group(text, i) {
+                Some(end) => i = skip_ascii_ws(text, end),
+                None => return Some(line_end(text, i)),
+            }
+        }
+        if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
+            return None;
+        }
+        i += 1;
+        return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
+    }
+
+
     if kind == VerbKind::Mint {
         if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
             return None;
@@ -454,6 +487,9 @@ enum VerbKind {
     Verbatiminput,
     /// `\tcbinputlisting`: one required `{keyvals}` group.
     Tcbinputlisting,
+    /// `\PitonInputFile`: optional `<...>`, optional `[...]`, required
+    /// `{filename}` (piton.sty leftover; GitHub #406).
+    PitonInputFile,
     /// `\mintinline` / `\mint` / `\inputminted`: optional `[...]`,
     /// `{lang}`, then body.
     Mint,
@@ -498,6 +534,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "inputminted"
             || name == "verbatiminput"
             || name == "tcbinputlisting"
+            || name == "PitonInputFile"
             || name == "mint"
             || name == "Verb"
             || name == "SaveVerb"
@@ -527,6 +564,27 @@ fn skip_ascii_ws(text: &str, mut i: usize) -> usize {
     }
     i
 }
+
+/// xparse `d < >` optional delimited argument (piton.sty
+/// `\PitonInputFile`; GitHub #406). Not a nested group: first `>` on
+/// the same line closes it.
+fn skip_angle_group(text: &str, open_at: usize) -> Option<usize> {
+    let bytes = text.as_bytes();
+    if bytes.get(open_at) != Some(&b'<') {
+        return None;
+    }
+    let mut i = open_at + 1;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\n' => return None,
+            b'>' => return Some(i + 1),
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+
 
 fn skip_bracket_group(text: &str, open_at: usize) -> Option<usize> {
     let bytes = text.as_bytes();
@@ -2509,6 +2567,57 @@ mod tests {
             "tcbinputlisting must not steal inputminted"
         );
     }
+
+    /// Ticket fixture (GitHub #406): piton.sty `\PitonInputFile{file}`
+    /// is one leftover command; following `After.` still splits.
+    #[test]
+    fn latex_pitoninputfile_stays_atomic() {
+        let text = r"See \PitonInputFile{foo.py} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == r"\PitonInputFile{foo.py}"),
+            "PitonInputFile span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFile{foo.py}", 0, &[]),
+            Some(r"\PitonInputFile{foo.py}".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \PitonInputFile{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        let opts = r"See \PitonInputFile[language=python]{foo.py} here. After.";
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFile[language=python]{foo.py}", 0, &[]),
+            Some(r"\PitonInputFile[language=python]{foo.py}".len())
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFile<python>{foo.py}", 0, &[]),
+            Some(r"\PitonInputFile<python>{foo.py}".len()),
+            "PitonInputFile optional angle spec must stay in the span"
+        );
+        let range = r"\PitonInputFile<1-10>[language=python]{foo.py}";
+        assert_eq!(
+            latex_verb_span_end_with(range, 0, &[]),
+            Some(range.len()),
+            "PitonInputFile d<> plus optional args must stay one span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFile foo.py", 0, &[]),
+            None,
+            "PitonInputFile without a brace file arg is not a verb span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\tcbinputlisting{listing file=foo.py}", 0, &[]),
+            Some(r"\tcbinputlisting{listing file=foo.py}".len()),
+            "PitonInputFile must not steal tcbinputlisting"
+        );
+    }
+
+
 
     /// Ticket fixture (GitHub #275): fancyvrb `\SaveVerb{name}|body|`
     /// is one token; following `After.` still splits.

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -3567,3 +3567,64 @@ fn tcbinputlisting_fixture_does_not_join_following_prose() {
         "prose after inputminted must still split, got:\n{minted_in_out}"
     );
 }
+
+/// Ticket fixture (GitHub #406): piton.sty `\PitonInputFile{file}`
+/// stays one atomic command. Following flush `After.` does not join
+/// the command line. Optional `[...]` / `<...>` stay atomic.
+/// tcbinputlisting / verbatiminput / VerbatimInput unchanged.
+#[test]
+fn pitoninputfile_fixture_does_not_join_following_prose() {
+    let input = concat!(
+        "Before. Next.\n",
+        "\\PitonInputFile{foo.py}\n",
+        "After. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\PitonInputFile{foo.py}")
+        )),
+        "PitonInputFile must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\PitonInputFile{foo.py}")
+        )),
+        "PitonInputFile must not leak into Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\PitonInputFile{foo.py}\n"),
+        "PitonInputFile must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\PitonInputFile{foo.py} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before PitonInputFile must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after PitonInputFile must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let tcb = concat!(
+        "Before. Next.\n",
+        "\\tcbinputlisting{listing file=foo.py}\n",
+        "After. Next.\n",
+    );
+    let tcb_out = format_text(tcb, &latex_cfg()).unwrap();
+    assert!(
+        tcb_out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
+        "tcbinputlisting must stay unchanged, got:\n{tcb_out}"
+    );
+    assert!(
+        !tcb_out.contains("\\tcbinputlisting{listing file=foo.py} After."),
+        "tcbinputlisting must not join following prose, got:\n{tcb_out}"
+    );
+}


### PR DESCRIPTION
discovered-from: piton.sty `\PitonInputFile`. GREEN snapper-e0x2 (impl-A/B+rev-1/2, ljos consensus accept 1.000, unanimous-green-182 ok=true).

The command is one leftover token (optional `<...>`, optional `[...]`, required `{file}`). Following flush prose does not join.

fixture:
Before. Next.
\PitonInputFile{foo.py}
After. Next.

verify (terra, format_text without_safety_backstops):
`\PitonInputFile{foo.py}` stays one line. After. / Next. still split.
Optional `[language=python]` and `<1-10>` stay atomic.
Piton env, `\piton`, verbatiminput, VerbatimInput, tcbinputlisting unchanged.

Do not hand-edit CHANGELOG.md.

Closes #406.
