### PR TITLE
fix(rst): hang and split same-line substitution replace body

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -267,11 +267,15 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // container body is a new paragraph, not more note (GitHub #344).
         // Specific admonitions nested-parse same-line text after `::`
         // as the first body paragraph: marker Structure, body hung
-        // Prose that still splits (GitHub #349).
+        // Prose that still splits (GitHub #349). SubstitutionDef
+        // `.. |name| replace::` is the same leftover: the replace body
+        // is a nested-parsed paragraph (GitHub #417).
         let trimmed = line_text.trim_start();
         if trimmed.starts_with(".. ") && trimmed.contains("::") {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
-            if let Some(marker_len) = rst_admonition_marker_len(line_text) {
+            if let Some(marker_len) = rst_admonition_marker_len(line_text)
+                .or_else(|| rst_substitution_replace_marker_len(line_text))
+            {
                 if line_text.len() > marker_len && !line_text[marker_len..].trim().is_empty() {
                     list_hang = Some(marker_len);
                     in_container_body = true;
@@ -286,7 +290,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
                 }
             }
             regions.push(SpannedRegion::structure(input, line.span()));
-            if rst_directive_name(trimmed).is_some_and(|n| is_rst_container_directive(&n)) {
+            if rst_directive_name(trimmed).is_some_and(|n| is_rst_container_directive(&n))
+                || rst_substitution_replace_marker_len(line_text).is_some()
+            {
                 in_container_body = true;
                 i += 1;
                 continue;
@@ -837,6 +843,41 @@ pub(crate) fn rst_admonition_marker_len(line: &str) -> Option<usize> {
     let after_colons = &line[colons_at + 2..];
     let pad = after_colons.len() - after_colons.trim_start().len();
     Some(colons_at + 2 + pad)
+}
+
+/// Byte length of a Docutils SubstitutionDef `.. |name| replace::`
+/// opener (plus following whitespace, including leading indent).
+/// `None` when the line is not a replace substitution. Body text after
+/// the marker is not included, so `Some(s.len())` is the Structure
+/// prefix used for hang (GitHub #417).
+pub(crate) fn rst_substitution_replace_marker_len(line: &str) -> Option<usize> {
+    let indent = line.len() - line.trim_start().len();
+    let trimmed = &line[indent..];
+    let rest = trimmed.strip_prefix("..")?;
+    if !rest.starts_with([' ', '\t']) {
+        return None;
+    }
+    let ws_after_dots = rest.len() - rest.trim_start().len();
+    let after_ws = &rest[ws_after_dots..];
+    let after_open = after_ws.strip_prefix('|')?;
+    let name_end = after_open.find('|')?;
+    if name_end == 0 {
+        return None;
+    }
+    let after_close = &after_open[name_end + 1..];
+    let mid_ws = after_close.len() - after_close.trim_start().len();
+    if mid_ws == 0 {
+        return None;
+    }
+    let after_mid = &after_close[mid_ws..];
+    const REPLACE: &str = "replace::";
+    if after_mid.len() < REPLACE.len() || !after_mid[..REPLACE.len()].eq_ignore_ascii_case(REPLACE)
+    {
+        return None;
+    }
+    let after_colons = &after_mid[REPLACE.len()..];
+    let pad = after_colons.len() - after_colons.trim_start().len();
+    Some(indent + 2 + ws_after_dots + 1 + name_end + 1 + mid_ws + REPLACE.len() + pad)
 }
 
 /// True when `trimmed` is an RST comment opener, not a `.. name::`
@@ -2058,6 +2099,70 @@ mod tests {
                     if s.contains("|fig. 1|") && s.contains("Next sentence.")
             )),
             "|fig. 1| and the next sentence must stay Prose, got {regions:?}"
+        );
+    }
+
+    /// Ticket fixture (Format::Rst / GitHub #417): SubstitutionDef
+    /// `.. |name| replace::` same-line body is leftover Prose.
+    fn substitution_replace_fixture() -> &'static str {
+        concat!(
+            "See |v|. Next.\n",
+            "\n",
+            ".. |v| replace:: fig. 1 is here. After.\n",
+        )
+    }
+
+    #[test]
+    fn substitution_replace_marker_is_structure_body_is_hung_prose() {
+        let regions = RstParser.parse(substitution_replace_fixture());
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == ".. |v| replace:: ")),
+            "opener .. |v| replace:: must stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("fig. 1 is here.") && s.contains("After.")
+            )),
+            "same-line replace body must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("fig. 1 is here")
+            )),
+            "same-line replace body must not stay whole-line Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("See |v|.") && s.contains("Next.")
+            )),
+            "See |v|. / Next. must stay Prose, got {regions:?}"
+        );
+        assert_eq!(
+            rst_substitution_replace_marker_len(".. |v| replace:: "),
+            Some(".. |v| replace:: ".len())
+        );
+        assert_eq!(
+            rst_substitution_replace_marker_len(".. |v| replace:: fig. 1 is here. After."),
+            Some(".. |v| replace:: ".len())
+        );
+        assert_eq!(
+            rst_substitution_replace_marker_len(".. |v| image:: fig.png"),
+            None
+        );
+        assert_eq!(rst_substitution_replace_marker_len(".. note:: "), None);
+        assert_eq!(
+            rst_substitution_replace_marker_len(".. || replace:: x"),
+            None
+        );
+        assert_eq!(
+            rst_substitution_replace_marker_len(".. |v|replace:: x"),
+            None
         );
     }
 

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -1111,6 +1111,12 @@ fn hanging_indent_width(s: &str) -> usize {
     if crate::parser::rst::rst_admonition_marker_len(s) == Some(s.len()) {
         return s.chars().count();
     }
+    // RST SubstitutionDef (`.. |name| replace:: `): hang at marker
+    // width so the same-line replace body stays a hung paragraph
+    // (GitHub #417).
+    if crate::parser::rst::rst_substitution_replace_marker_len(s) == Some(s.len()) {
+        return s.chars().count();
+    }
     // RST field marker (`:Author: `, `:py:mod: `): hang at marker
     // width so the body stays a hung paragraph (GitHub #341).
     if crate::parser::rst::rst_field_marker_len(s) == Some(s.len()) {
@@ -1854,6 +1860,9 @@ They are endowed with reason and conscience and should act towards one another i
         assert_eq!(hanging_prefix(".. note:: "), "          ");
         assert_eq!(hanging_indent_width(".. warning:: "), 13);
         assert_eq!(hanging_indent_width(".. figure:: "), 0);
+        assert_eq!(hanging_indent_width(".. |v| replace:: "), 17);
+        assert_eq!(hanging_prefix(".. |v| replace:: "), "                 ");
+        assert_eq!(hanging_indent_width(".. |v| image:: "), 0);
         assert_eq!(hanging_indent_width("[fn:1] "), 7);
         assert_eq!(hanging_indent_width("[fn:note] "), 10);
         assert_eq!(hanging_prefix("[fn:1] "), "       ");
@@ -1926,6 +1935,26 @@ They are endowed with reason and conscience and should act towards one another i
         assert!(
             !result.contains("\nSecond sentence."),
             "second sentence must hang, got:\n{result}"
+        );
+    }
+
+    #[test]
+    fn rst_substitution_replace_hangs_second_sentence() {
+        let result = reflow_regions(vec![
+            Region::Structure(".. |v| replace:: ".to_string()),
+            Region::Prose("fig. 1 is here. After.".to_string()),
+            Region::Structure("\n".to_string()),
+        ]);
+        assert_eq!(
+            result,
+            concat!(
+                ".. |v| replace:: fig. 1 is here.\n",
+                "                 After.\n",
+            )
+        );
+        assert!(
+            !result.contains("\nAfter."),
+            "After. must hang inside the replace body, got:\n{result}"
         );
     }
 

--- a/tests/rst_substitution_replace.rs
+++ b/tests/rst_substitution_replace.rs
@@ -1,0 +1,168 @@
+//! snapper-nt0s / GitHub #417: RST SubstitutionDef
+//! `.. |name| replace::` same-line body is leftover Prose.
+//! Marker stays Structure; After. still splits. See |v|. / Next.
+//! unchanged. Isolate onto origin/main.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst / GitHub #417).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        "See |v|. Next.\n",
+        "\n",
+        ".. |v| replace:: fig. 1 is here. After.\n",
+    )
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        "See |v|.\n",
+        "Next.\n",
+        "\n",
+        ".. |v| replace:: fig. 1 is here.\n",
+        "                 After.\n",
+    )
+}
+
+#[test]
+fn substitution_replace_opener_is_structure_body_is_prose() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == ".. |v| replace:: ")),
+        "opener .. |v| replace:: must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("fig. 1 is here.") && s.contains("After.")
+        )),
+        "same-line replace body must be Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("fig. 1 is here")
+        )),
+        "same-line replace body must not stay whole-line Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_hangs_and_splits() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert!(
+        !out.contains(".. |v| replace:: fig. 1 is here. After."),
+        "same-line replace body must not stay one line, got:\n{out}"
+    );
+    assert!(
+        out.contains("See |v|.\nNext.\n"),
+        "See |v|. / Next. must stay split, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &rst_cfg()).unwrap(),
+        out,
+        "split replace body must be identity, got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn image_substitution_stays_opaque() {
+    let input = ".. |v| image:: fig.png\n";
+    let regions = RstParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(".. |v| image:: fig.png"))),
+        "image substitution must stay Structure, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(s) if s.contains("fig.png"))),
+        "image URI must not become Prose, got {regions:?}"
+    );
+    assert_eq!(format_text(input, &rst_cfg()).unwrap(), input);
+}
+
+#[test]
+fn indented_replace_body_still_hangs() {
+    let input = concat!(
+        ".. |v| replace::\n",
+        "\n",
+        "   fig. 1 is here. After.\n",
+        "\n",
+        "After markup. Next.\n",
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            ".. |v| replace::\n",
+            "\n",
+            "   fig. 1 is here.\n",
+            "   After.\n",
+            "\n",
+            "After markup.\n",
+            "Next.\n",
+        ),
+        "indented replace body must hang and split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn substitution_refs_still_split_as_prose() {
+    let input = concat!(
+        "|version| is the current release. Second sentence.\n",
+        "\n",
+        "The current release is\n",
+        "|version|. Next sentence.\n",
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            "|version| is the current release.\n",
+            "Second sentence.\n",
+            "\n",
+            "The current release is |version|.\n",
+            "Next sentence.\n",
+        ),
+        "substitution-ref prose from #233 must stay, got:\n{out}"
+    );
+}
+
+#[test]
+fn same_line_note_still_hangs() {
+    let input = ".. note:: This is a long note sentence that must reflow. Second sentence.\n";
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!(
+            ".. note:: This is a long note sentence that must reflow.\n",
+            "          Second sentence.\n",
+        ),
+        "same-line note leftover from #349 must stay, got:\n{out}"
+    );
+}


### PR DESCRIPTION
discovered-from: Docutils SubstitutionDef `.. |name| replace::`. GREEN snapper-nt0s (impl-A/B+rev-1/2, ljos consensus accept 1.000, unanimous-green-186 ok=true).

The replace opener is Structure. Same-line body is leftover Prose and hangs. Two sentences still split.

fixture:
See |v|. Next.

.. |v| replace:: fig. 1 is here. After.

verify (terra, format_text without_safety_backstops):
`See |v|.|Next.|` unchanged.
`.. |v| replace:: fig. 1 is here.|                 After.|`
After. does not stay on the definition line.

Do not hand-edit CHANGELOG.md.

Closes #417.
