### PR TITLE
fix(latex): tokenize pythontex inputpy like lstinputlisting

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -503,7 +503,7 @@ impl LatexParser {
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
     /// `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
     /// `\inputminted` / `\verbatiminput` / `\VerbatimInput` / `\tcbinputlisting` /
-    /// configured verbatim commands.
+    /// `\inputpy` / `\inputpycon` / configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -877,7 +877,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 /// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` /
 /// `\spverb` / `\mintinline` / `\mint` / `\inputminted` / `\Verb` /
 /// `\SaveVerb` / `\piton` / `\lstinputlisting` / `\verbatiminput` /
-/// `\VerbatimInput` spans.
+/// `\VerbatimInput` / `\inputpy` / `\inputpycon` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -984,6 +984,27 @@ fn pitoninputfile_cs_at(line: &str, at: usize) -> bool {
         return false;
     };
     !after.starts_with(|c: char| c.is_ascii_alphabetic())
+}
+
+/// Leftover pythontex.sty `\inputpy` / `\inputpycon` (optional `[...]`,
+/// required `{file}`; GitHub #419). One leftover walker for both names.
+/// Other verb spans are skipped so `\verb|\inputpy{x}|` is not stolen.
+/// Walk stops at an unescaped `%` so a comment is not a command tail.
+/// `\inputpygments` is not a span (`inputpy` + alphabetic leftover).
+fn find_inputpy_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<(usize, usize)> {
+    find_leftover_cmd_at(line, from, extra_cmds, inputpy_cs_at)
+}
+
+fn inputpy_cs_at(line: &str, at: usize) -> bool {
+    let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
+        return false;
+    };
+    for name in ["inputpycon", "inputpy"] {
+        if let Some(after) = tail.strip_prefix(name) {
+            return !after.starts_with(|c: char| c.is_ascii_alphabetic());
+        }
+    }
+    false
 }
 
 fn find_leftover_cmd_at(
@@ -1755,6 +1776,7 @@ impl<'a> ParseState<'a> {
                     .or_else(|| {
                         find_pitoninputfile_at(code, i, &self.parser.extra_verbatim_commands)
                     })
+                    .or_else(|| find_inputpy_at(code, i, &self.parser.extra_verbatim_commands))
             {
                 self.append_item_or_prose(line.start + i, &code[i..start]);
                 self.push_structure(ByteSpan::new(
@@ -8128,6 +8150,169 @@ Some text.
         assert!(
             range_out.contains("After.\nNext."),
             "prose after d<> PitonInputFile must still split, got:\n{range_out}"
+        );
+    }
+
+    /// Ticket fixture (GitHub #419): pythontex.sty `\inputpy{file}` /
+    /// `\inputpycon{file}` stay one leftover command. Following flush
+    /// `After.` does not join. pycode / pyconsole / inputminted /
+    /// lstinputlisting / tcbinputlisting / PitonInputFile unchanged.
+    #[test]
+    fn inputpy_does_not_join_following_prose() {
+        use crate::format_text;
+
+        let input = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\inputpy{foo.py}")
+            )),
+            "inputpy must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\inputpy{foo.py}")
+            )),
+            "inputpy must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+            )),
+            "After. / Next. must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\inputpy{foo.py}\n"),
+            "inputpy must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\inputpy{foo.py} After."),
+            "following flush prose must not join the command line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before.\nNext."),
+            "prose before inputpy must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after inputpy must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let con = concat!(
+            "Before. Next.\n",
+            "\\inputpycon{foo.py}\n",
+            "After. Next.\n",
+        );
+        let con_out = format_text(con, &latex_cfg()).unwrap();
+        assert!(
+            con_out.contains("\\inputpycon{foo.py}\n"),
+            "inputpycon must stay one atomic command, got:\n{con_out}"
+        );
+        assert!(
+            !con_out.contains("\\inputpycon{foo.py} After."),
+            "inputpycon must not join following prose, got:\n{con_out}"
+        );
+        assert!(
+            con_out.contains("After.\nNext."),
+            "prose after inputpycon must still split, got:\n{con_out}"
+        );
+
+        let pycode = concat!(
+            "\\begin{pycode}\n",
+            "First line. Second line.\n",
+            "\\end{pycode}\n",
+            "After the block. Next.\n",
+        );
+        let pycode_out = format_text(pycode, &latex_cfg()).unwrap();
+        assert!(
+            pycode_out.contains("\\begin{pycode}\nFirst line. Second line.\n\\end{pycode}"),
+            "pycode must stay a code env, got:\n{pycode_out}"
+        );
+        assert!(
+            pycode_out.contains("After the block.\nNext."),
+            "prose after pycode must still split, got:\n{pycode_out}"
+        );
+
+        let pyconsole = concat!(
+            "\\begin{pyconsole}\n",
+            "First line. Second line.\n",
+            "\\end{pyconsole}\n",
+            "After the block. Next.\n",
+        );
+        let pyconsole_out = format_text(pyconsole, &latex_cfg()).unwrap();
+        assert!(
+            pyconsole_out
+                .contains("\\begin{pyconsole}\nFirst line. Second line.\n\\end{pyconsole}"),
+            "pyconsole must stay a code env, got:\n{pyconsole_out}"
+        );
+        assert!(
+            pyconsole_out.contains("After the block.\nNext."),
+            "prose after pyconsole must still split, got:\n{pyconsole_out}"
+        );
+
+        let minted = concat!(
+            "Before. Next.\n",
+            "\\inputminted{python}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let minted_out = format_text(minted, &latex_cfg()).unwrap();
+        assert!(
+            minted_out.contains("\\inputminted{python}{foo.py}\n"),
+            "inputminted must stay unchanged, got:\n{minted_out}"
+        );
+        assert!(
+            !minted_out.contains("\\inputminted{python}{foo.py} After."),
+            "inputminted must not join following prose, got:\n{minted_out}"
+        );
+
+        let lst = concat!(
+            "Before. Next.\n",
+            "\\lstinputlisting{foo.py}\n",
+            "After. Next.\n",
+        );
+        let lst_out = format_text(lst, &latex_cfg()).unwrap();
+        assert!(
+            lst_out.contains("\\lstinputlisting{foo.py}\n"),
+            "lstinputlisting must stay unchanged, got:\n{lst_out}"
+        );
+        assert!(
+            !lst_out.contains("\\lstinputlisting{foo.py} After."),
+            "lstinputlisting must not join following prose, got:\n{lst_out}"
+        );
+
+        let tcb = concat!(
+            "Before. Next.\n",
+            "\\tcbinputlisting{listing file=foo.py}\n",
+            "After. Next.\n",
+        );
+        let tcb_out = format_text(tcb, &latex_cfg()).unwrap();
+        assert!(
+            tcb_out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
+            "tcbinputlisting must stay unchanged, got:\n{tcb_out}"
+        );
+        assert!(
+            !tcb_out.contains("\\tcbinputlisting{listing file=foo.py} After."),
+            "tcbinputlisting must not join following prose, got:\n{tcb_out}"
+        );
+
+        let piton = concat!(
+            "Before. Next.\n",
+            "\\PitonInputFile{foo.py}\n",
+            "After. Next.\n",
+        );
+        let piton_out = format_text(piton, &latex_cfg()).unwrap();
+        assert!(
+            piton_out.contains("\\PitonInputFile{foo.py}\n"),
+            "PitonInputFile must stay unchanged, got:\n{piton_out}"
+        );
+        assert!(
+            !piton_out.contains("\\PitonInputFile{foo.py} After."),
+            "PitonInputFile must not join following prose, got:\n{piton_out}"
         );
     }
 }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -201,7 +201,8 @@ pub fn protect_inline_tokens_with(
 /// `\inputminted{lang}{file}` / `\Verb|...|` /
 /// `\SaveVerb{name}|...|` / `\piton|...|` /
 /// `\lstinputlisting[...]{file}` /
-/// `\verbatiminput{file}` / `\VerbatimInput[...]{file}` so inner `.!?%` cannot
+/// `\verbatiminput{file}` / `\VerbatimInput[...]{file}` /
+/// `\inputpy[...]{file}` / `\inputpycon[...]{file}` so inner `.!?%` cannot
 /// split or comment. `\piton{...}` stays on the generic `\cmd{arg}`
 /// path (piton.sty brace syntax is not verbatim; GitHub #305).
 fn protect_latex_verbatim(
@@ -230,7 +231,7 @@ fn protect_latex_verbatim(
 /// Byte end of a `\verb` / `\lstinline` / `\spverb` / `\mintinline` /
 /// `\mint` / `\inputminted` / `\Verb` / `\SaveVerb` / `\piton` /
 /// `\lstinputlisting` / `\VerbatimInput` / `\BVerbatimInput` /
-/// `\LVerbatimInput` /
+/// `\LVerbatimInput` / `\inputpy` / `\inputpycon` /
 /// extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
@@ -252,9 +253,14 @@ fn protect_latex_verbatim(
 /// no brace is not a span. `\VerbatimInput` / `\BVerbatimInput` /
 /// `\LVerbatimInput` (fancyvrb.sty leftover; GitHub #399) use the same
 /// optional `[...]` then `{filename}` walk. Matched before `\Verb` so
-/// `\VerbatimInput` is not `\Verb` plus leftover letters. Extra names
-/// are tokenized like `\verb`. With no closer, the span runs to end of
-/// line so an inner `%` is not a comment.
+/// `\VerbatimInput` is not `\Verb` plus leftover letters. `\inputpy` /
+/// `\inputpycon` (pythontex.sty leftover; GitHub #419) take optional
+/// `[...]` then a required `{filename}`; no brace is not a span.
+/// `inputpycon` is matched before `inputpy` so the longer name is not
+/// `\inputpy` + leftover. `\inputpygments` is not a span (`inputpy` +
+/// alphabetic leftover). Extra names are tokenized like `\verb`. With
+/// no closer, the span runs to end of line so an inner `%` is not a
+/// comment.
 pub(crate) fn latex_verb_span_end_with(
     text: &str,
     at: usize,
@@ -279,6 +285,10 @@ pub(crate) fn latex_verb_span_end_with(
             return None;
         }
         (after_bs + "inputminted".len(), VerbKind::Mint)
+    } else if let Some(name_len) = inputpy_cmd_len(tail) {
+        // pythontex.sty leftover file-input (GitHub #419). `inputpycon`
+        // before `inputpy`; `\inputpygments` is not a span.
+        (after_bs + name_len, VerbKind::Lstinputlisting)
     } else if let Some(stripped) = tail.strip_prefix("lstinputlisting") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -479,7 +489,8 @@ enum VerbKind {
     /// `\lstinline`: optional `[...]` then delimiter or `{...}`.
     Lstinline,
     /// `\lstinputlisting` / `\VerbatimInput` / `\BVerbatimInput` /
-    /// `\LVerbatimInput`: optional `[...]` then required `{filename}`.
+    /// `\LVerbatimInput` / `\inputpy` / `\inputpycon`: optional `[...]`
+    /// then required `{filename}`.
     Lstinputlisting,
     /// `\\verbatiminput`: required `{filename}` (verbatim.sty leftover).
     Verbatiminput,
@@ -518,6 +529,22 @@ fn verbatiminput_cs_name(tail: &str) -> Option<&'static str> {
     None
 }
 
+/// pythontex.sty leftover `\inputpycon` / `\inputpy` (optional `[...]`,
+/// required `{file}`; GitHub #419). Longer name first so `\inputpycon`
+/// is not `\inputpy` + leftover. `\inputpygments` is rejected as
+/// `inputpy` + alphabetic leftover.
+fn inputpy_cmd_len(tail: &str) -> Option<usize> {
+    for name in ["inputpycon", "inputpy"] {
+        if let Some(stripped) = tail.strip_prefix(name) {
+            if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+                return None;
+            }
+            return Some(name.len());
+        }
+    }
+    None
+}
+
 /// Longest extra command name that is a prefix of `tail` and is not
 /// followed by an ASCII letter (`\Verb` must not steal `\Verbatim`).
 fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&'a str> {
@@ -530,6 +557,8 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "spverb"
             || name == "mintinline"
             || name == "inputminted"
+            || name == "inputpy"
+            || name == "inputpycon"
             || name == "verbatiminput"
             || name == "tcbinputlisting"
             || name == "PitonInputFile"
@@ -2609,6 +2638,82 @@ mod tests {
             latex_verb_span_end_with(r"\tcbinputlisting{listing file=foo.py}", 0, &[]),
             Some(r"\tcbinputlisting{listing file=foo.py}".len()),
             "PitonInputFile must not steal tcbinputlisting"
+        );
+    }
+
+    /// Ticket fixture (GitHub #419): pythontex.sty `\inputpy{file}` /
+    /// `\inputpycon{file}` are leftover file-input commands; following
+    /// `After.` still splits. `\inputpygments` is not stolen.
+    #[test]
+    fn latex_inputpy_stays_atomic() {
+        let text = r"See \inputpy{foo.py} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == r"\inputpy{foo.py}"),
+            "inputpy span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpy{foo.py}", 0, &[]),
+            Some(r"\inputpy{foo.py}".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \inputpy{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        let con = r"See \inputpycon{foo.py} here. After.";
+        let (_, con_ph) = protect_inline_tokens(con);
+        assert!(
+            con_ph.iter().any(|p| p == r"\inputpycon{foo.py}"),
+            "inputpycon span must be protected, got {con_ph:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpycon{foo.py}", 0, &[]),
+            Some(r"\inputpycon{foo.py}".len())
+        );
+        assert_eq!(
+            split(con),
+            vec![
+                r"See \inputpycon{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpy[firstline=1]{foo.py}", 0, &[]),
+            Some(r"\inputpy[firstline=1]{foo.py}".len()),
+            "inputpy optional args must stay in the span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpy foo.py", 0, &[]),
+            None,
+            "inputpy without a brace file arg is not a verb span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpygments{python}{foo.py}", 0, &[]),
+            None,
+            "inputpy must not steal inputpygments"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputminted{python}{foo.py}", 0, &[]),
+            Some(r"\inputminted{python}{foo.py}".len()),
+            "inputpy must not steal inputminted"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\lstinputlisting{foo.py}", 0, &[]),
+            Some(r"\lstinputlisting{foo.py}".len()),
+            "inputpy must not steal lstinputlisting"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\tcbinputlisting{listing file=foo.py}", 0, &[]),
+            Some(r"\tcbinputlisting{listing file=foo.py}".len()),
+            "inputpy must not steal tcbinputlisting"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFile{foo.py}", 0, &[]),
+            Some(r"\PitonInputFile{foo.py}".len()),
+            "inputpy must not steal PitonInputFile"
         );
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -74,6 +74,8 @@
 //! VerbatimEnvironment plus VerbatimOut.
 //! GitHub #391: listings.sty \\lstinputlisting is one atomic command;
 //! following flush prose does not join the command line.
+//! GitHub #419: pythontex.sty \\inputpy / \\inputpycon is one leftover
+//! command; following flush prose does not join the command line.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -3626,5 +3628,166 @@ fn pitoninputfile_fixture_does_not_join_following_prose() {
     assert!(
         !tcb_out.contains("\\tcbinputlisting{listing file=foo.py} After."),
         "tcbinputlisting must not join following prose, got:\n{tcb_out}"
+    );
+}
+
+/// Ticket fixture (GitHub #419): pythontex.sty `\inputpy{file}` /
+/// `\inputpycon{file}` stay one atomic command. Following flush
+/// `After.` does not join the command line. `After.` / `Next.` still
+/// split. pycode / pyconsole / inputminted / lstinputlisting /
+/// tcbinputlisting / PitonInputFile unchanged.
+#[test]
+fn inputpy_fixture_does_not_join_following_prose() {
+    let input = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\inputpy{foo.py}")
+        )),
+        "inputpy must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\inputpy{foo.py}")
+        )),
+        "inputpy must not leak into Prose, got: {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+        )),
+        "After. / Next. must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\inputpy{foo.py}\n"),
+        "inputpy must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\inputpy{foo.py} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before inputpy must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after inputpy must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let con = concat!(
+        "Before. Next.\n",
+        "\\inputpycon{foo.py}\n",
+        "After. Next.\n",
+    );
+    let con_out = format_text(con, &latex_cfg()).unwrap();
+    assert!(
+        con_out.contains("\\inputpycon{foo.py}\n"),
+        "inputpycon must stay one atomic command, got:\n{con_out}"
+    );
+    assert!(
+        !con_out.contains("\\inputpycon{foo.py} After."),
+        "inputpycon must not join following prose, got:\n{con_out}"
+    );
+    assert!(
+        con_out.contains("After.\nNext."),
+        "prose after inputpycon must still split, got:\n{con_out}"
+    );
+
+    let pycode = concat!(
+        "\\begin{pycode}\n",
+        "First line. Second line.\n",
+        "\\end{pycode}\n",
+        "After the block. Next.\n",
+    );
+    let pycode_out = format_text(pycode, &latex_cfg()).unwrap();
+    assert!(
+        pycode_out.contains("\\begin{pycode}\nFirst line. Second line.\n\\end{pycode}"),
+        "pycode must stay a code env, got:\n{pycode_out}"
+    );
+    assert!(
+        pycode_out.contains("After the block.\nNext."),
+        "prose after pycode must still split, got:\n{pycode_out}"
+    );
+
+    let pyconsole = concat!(
+        "\\begin{pyconsole}\n",
+        "First line. Second line.\n",
+        "\\end{pyconsole}\n",
+        "After the block. Next.\n",
+    );
+    let pyconsole_out = format_text(pyconsole, &latex_cfg()).unwrap();
+    assert!(
+        pyconsole_out.contains("\\begin{pyconsole}\nFirst line. Second line.\n\\end{pyconsole}"),
+        "pyconsole must stay a code env, got:\n{pyconsole_out}"
+    );
+    assert!(
+        pyconsole_out.contains("After the block.\nNext."),
+        "prose after pyconsole must still split, got:\n{pyconsole_out}"
+    );
+
+    let minted = concat!(
+        "Before. Next.\n",
+        "\\inputminted{python}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let minted_out = format_text(minted, &latex_cfg()).unwrap();
+    assert!(
+        minted_out.contains("\\inputminted{python}{foo.py}\n"),
+        "inputminted must stay unchanged, got:\n{minted_out}"
+    );
+    assert!(
+        !minted_out.contains("\\inputminted{python}{foo.py} After."),
+        "inputminted must not join following prose, got:\n{minted_out}"
+    );
+
+    let lst = concat!(
+        "Before. Next.\n",
+        "\\lstinputlisting{foo.py}\n",
+        "After. Next.\n",
+    );
+    let lst_out = format_text(lst, &latex_cfg()).unwrap();
+    assert!(
+        lst_out.contains("\\lstinputlisting{foo.py}\n"),
+        "lstinputlisting must stay unchanged, got:\n{lst_out}"
+    );
+    assert!(
+        !lst_out.contains("\\lstinputlisting{foo.py} After."),
+        "lstinputlisting must not join following prose, got:\n{lst_out}"
+    );
+
+    let tcb = concat!(
+        "Before. Next.\n",
+        "\\tcbinputlisting{listing file=foo.py}\n",
+        "After. Next.\n",
+    );
+    let tcb_out = format_text(tcb, &latex_cfg()).unwrap();
+    assert!(
+        tcb_out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
+        "tcbinputlisting must stay unchanged, got:\n{tcb_out}"
+    );
+    assert!(
+        !tcb_out.contains("\\tcbinputlisting{listing file=foo.py} After."),
+        "tcbinputlisting must not join following prose, got:\n{tcb_out}"
+    );
+
+    let piton = concat!(
+        "Before. Next.\n",
+        "\\PitonInputFile{foo.py}\n",
+        "After. Next.\n",
+    );
+    let piton_out = format_text(piton, &latex_cfg()).unwrap();
+    assert!(
+        piton_out.contains("\\PitonInputFile{foo.py}\n"),
+        "PitonInputFile must stay unchanged, got:\n{piton_out}"
+    );
+    assert!(
+        !piton_out.contains("\\PitonInputFile{foo.py} After."),
+        "PitonInputFile must not join following prose, got:\n{piton_out}"
     );
 }


### PR DESCRIPTION
discovered-from: pythontex.sty `\inputpy` / `\inputpycon`. GREEN snapper-yg4k (impl-A/B+rev-1/2, ljos consensus accept 1.000, unanimous-green-187 ok=true).

The command is one leftover token (optional `[...]`, required `{file}`). Following flush prose does not join. `inputpycon` before `inputpy` so the longer name is not stolen. `\inputpygments` is not a span.

fixture:
Before. Next.
\inputpy{foo.py}
After. Next.

verify (terra, format_text without_safety_backstops):
`\inputpy{foo.py}` stays one line. After. / Next. still split.
Same for `\inputpycon{foo.py}`.
tcbinputlisting / PitonInputFile / inputminted / lstinputlisting / pycode unchanged.

Do not hand-edit CHANGELOG.md.

Closes #419.
