### PR TITLE
fix(latex): tokenize moreverb listinginput like lstinputlisting

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -2024,7 +2024,7 @@ mod tests {
     #[test]
     fn multi_sentence_section_title_stays_one_line() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "\\begin{document}\n\\section{A long title. With two sentences.}\nBody text here. More body.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -2081,7 +2081,7 @@ mod tests {
     fn section_optional_short_title_stays_one_line() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input =
             "\\section[Short. Title.]{A long title. With two sentences.}\nBody. More body.\n";
@@ -2113,7 +2113,7 @@ mod tests {
     #[test]
     fn koma_addsec_addchap_addpart_optional_short_title_is_structure() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Latex,
@@ -2157,7 +2157,7 @@ mod tests {
     #[test]
     fn fragment_without_begin_document_is_prose() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "This sentence is a test. This sentence is also a test.\n";
         let cfg = FormatConfig {
@@ -2175,7 +2175,7 @@ mod tests {
     #[test]
     fn no_preamble_pragma_formats_body() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input =
             "% snapper:no-preamble\nThis sentence is a test. This sentence is also a test.\n";
@@ -2198,7 +2198,7 @@ mod tests {
     #[test]
     fn documentclass_without_begin_stays_preamble() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input =
             "\\documentclass{article}\nThis sentence is a test. This sentence is also a test.\n";
@@ -2266,7 +2266,7 @@ Some text.
     #[test]
     fn trailing_percent_is_nospace_join() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "\\begin{document}\nfoo%\nbar. Next sentence.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -2290,7 +2290,7 @@ Some text.
     #[test]
     fn escaped_percent_is_not_a_comment() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "\\begin{document}\n50\\% of cases. More text.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -2309,7 +2309,7 @@ Some text.
     #[test]
     fn mid_line_percent_comment_is_structure() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "\\begin{document}\nSee Fig. 1. % TODO cite\nNext sentence.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -6452,7 +6452,7 @@ Some text.
     fn enumerate_item_hangs_next_sentence() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Latex,

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::parser::{
-    flush_prose_spanned, iter_lines, join_prose_gap, ByteSpan, FormatParser, Line, SpannedRegion,
+    ByteSpan, FormatParser, Line, SpannedRegion, flush_prose_spanned, iter_lines, join_prose_gap,
 };
 use crate::sentence::unicode::latex_verb_span_end_with;
 

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -2,7 +2,7 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::parser::{
-    ByteSpan, FormatParser, Line, SpannedRegion, flush_prose_spanned, iter_lines, join_prose_gap,
+    flush_prose_spanned, iter_lines, join_prose_gap, ByteSpan, FormatParser, Line, SpannedRegion,
 };
 use crate::sentence::unicode::latex_verb_span_end_with;
 
@@ -503,7 +503,7 @@ impl LatexParser {
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
     /// `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
     /// `\inputminted` / `\verbatiminput` / `\VerbatimInput` / `\tcbinputlisting` /
-    /// `\inputpy` / `\inputpycon` / configured verbatim commands.
+    /// `\listinginput` / `\inputpy` / `\inputpycon` / configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -877,7 +877,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 /// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` /
 /// `\spverb` / `\mintinline` / `\mint` / `\inputminted` / `\Verb` /
 /// `\SaveVerb` / `\piton` / `\lstinputlisting` / `\verbatiminput` /
-/// `\VerbatimInput` / `\inputpy` / `\inputpycon` spans.
+/// `\VerbatimInput` / `\listinginput` / `\inputpy` / `\inputpycon` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -1005,6 +1005,25 @@ fn inputpy_cs_at(line: &str, at: usize) -> bool {
         }
     }
     false
+}
+
+/// Leftover moreverb `\listinginput` (optional `[interval]`, required
+/// `{start-line}`, required `{filename}`; GitHub #424). Other verb
+/// spans are skipped so `\verb|\listinginput{1}{x}|` is not stolen.
+/// Walk stops at an unescaped `%` so a comment is not a command tail.
+/// There is no `*` form.
+fn find_listinginput_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<(usize, usize)> {
+    find_leftover_cmd_at(line, from, extra_cmds, listinginput_cs_at)
+}
+
+fn listinginput_cs_at(line: &str, at: usize) -> bool {
+    let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
+        return false;
+    };
+    let Some(after) = tail.strip_prefix("listinginput") else {
+        return false;
+    };
+    !after.starts_with(|c: char| c.is_ascii_alphabetic() || c == '*')
 }
 
 fn find_leftover_cmd_at(
@@ -1777,6 +1796,7 @@ impl<'a> ParseState<'a> {
                         find_pitoninputfile_at(code, i, &self.parser.extra_verbatim_commands)
                     })
                     .or_else(|| find_inputpy_at(code, i, &self.parser.extra_verbatim_commands))
+                    .or_else(|| find_listinginput_at(code, i, &self.parser.extra_verbatim_commands))
             {
                 self.append_item_or_prose(line.start + i, &code[i..start]);
                 self.push_structure(ByteSpan::new(
@@ -2004,7 +2024,7 @@ mod tests {
     #[test]
     fn multi_sentence_section_title_stays_one_line() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = "\\begin{document}\n\\section{A long title. With two sentences.}\nBody text here. More body.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -2061,7 +2081,7 @@ mod tests {
     fn section_optional_short_title_stays_one_line() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input =
             "\\section[Short. Title.]{A long title. With two sentences.}\nBody. More body.\n";
@@ -2093,7 +2113,7 @@ mod tests {
     #[test]
     fn koma_addsec_addchap_addpart_optional_short_title_is_structure() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Latex,
@@ -2137,7 +2157,7 @@ mod tests {
     #[test]
     fn fragment_without_begin_document_is_prose() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = "This sentence is a test. This sentence is also a test.\n";
         let cfg = FormatConfig {
@@ -2155,7 +2175,7 @@ mod tests {
     #[test]
     fn no_preamble_pragma_formats_body() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input =
             "% snapper:no-preamble\nThis sentence is a test. This sentence is also a test.\n";
@@ -2178,7 +2198,7 @@ mod tests {
     #[test]
     fn documentclass_without_begin_stays_preamble() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input =
             "\\documentclass{article}\nThis sentence is a test. This sentence is also a test.\n";
@@ -2246,7 +2266,7 @@ Some text.
     #[test]
     fn trailing_percent_is_nospace_join() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = "\\begin{document}\nfoo%\nbar. Next sentence.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -2270,7 +2290,7 @@ Some text.
     #[test]
     fn escaped_percent_is_not_a_comment() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = "\\begin{document}\n50\\% of cases. More text.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -2289,7 +2309,7 @@ Some text.
     #[test]
     fn mid_line_percent_comment_is_structure() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = "\\begin{document}\nSee Fig. 1. % TODO cite\nNext sentence.\n\\end{document}\n";
         let cfg = FormatConfig {
@@ -6432,7 +6452,7 @@ Some text.
     fn enumerate_item_hangs_next_sentence() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Latex,
@@ -8283,6 +8303,166 @@ Some text.
         assert!(
             !lst_out.contains("\\lstinputlisting{foo.py} After."),
             "lstinputlisting must not join following prose, got:\n{lst_out}"
+        );
+
+        let tcb = concat!(
+            "Before. Next.\n",
+            "\\tcbinputlisting{listing file=foo.py}\n",
+            "After. Next.\n",
+        );
+        let tcb_out = format_text(tcb, &latex_cfg()).unwrap();
+        assert!(
+            tcb_out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
+            "tcbinputlisting must stay unchanged, got:\n{tcb_out}"
+        );
+        assert!(
+            !tcb_out.contains("\\tcbinputlisting{listing file=foo.py} After."),
+            "tcbinputlisting must not join following prose, got:\n{tcb_out}"
+        );
+
+        let piton = concat!(
+            "Before. Next.\n",
+            "\\PitonInputFile{foo.py}\n",
+            "After. Next.\n",
+        );
+        let piton_out = format_text(piton, &latex_cfg()).unwrap();
+        assert!(
+            piton_out.contains("\\PitonInputFile{foo.py}\n"),
+            "PitonInputFile must stay unchanged, got:\n{piton_out}"
+        );
+        assert!(
+            !piton_out.contains("\\PitonInputFile{foo.py} After."),
+            "PitonInputFile must not join following prose, got:\n{piton_out}"
+        );
+    }
+
+    /// Ticket fixture (GitHub #424): moreverb `\listinginput{start}{file}`
+    /// stays one leftover command. Optional `[interval]` stays atomic.
+    /// Following flush `After.` does not join. listing / listingcont /
+    /// verbatiminput / inputpy / tcbinputlisting / PitonInputFile
+    /// unchanged.
+    #[test]
+    fn listinginput_does_not_join_following_prose() {
+        use crate::format_text;
+
+        let input = concat!(
+            "Before. Next.\n",
+            "\\listinginput{1}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\listinginput{1}{foo.py}")
+            )),
+            "listinginput must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\listinginput{1}{foo.py}")
+            )),
+            "listinginput must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+            )),
+            "After. / Next. must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\listinginput{1}{foo.py}\n"),
+            "listinginput must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\listinginput{1}{foo.py} After."),
+            "following flush prose must not join the command line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before.\nNext."),
+            "prose before listinginput must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after listinginput must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let opts = concat!(
+            "Before. Next.\n",
+            "\\listinginput[2]{1}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let opts_out = format_text(opts, &latex_cfg()).unwrap();
+        assert!(
+            opts_out.contains("\\listinginput[2]{1}{foo.py}\n"),
+            "listinginput optional interval must stay atomic, got:\n{opts_out}"
+        );
+        assert!(
+            !opts_out.contains("\\listinginput[2]{1}{foo.py} After."),
+            "optional-interval listinginput must not join following prose, got:\n{opts_out}"
+        );
+
+        let listing = concat!(
+            "\\begin{listing}{1}\n",
+            "First line. Second line.\n",
+            "\\end{listing}\n",
+            "After the block. Next.\n",
+        );
+        let listing_out = format_text(listing, &latex_cfg()).unwrap();
+        assert!(
+            listing_out.contains("\\begin{listing}{1}\nFirst line. Second line.\n\\end{listing}"),
+            "listing must stay a code env, got:\n{listing_out}"
+        );
+        assert!(
+            listing_out.contains("After the block.\nNext."),
+            "prose after listing must still split, got:\n{listing_out}"
+        );
+
+        let listingcont = concat!(
+            "\\begin{listingcont}\n",
+            "First line. Second line.\n",
+            "\\end{listingcont}\n",
+            "After the block. Next.\n",
+        );
+        let listingcont_out = format_text(listingcont, &latex_cfg()).unwrap();
+        assert!(
+            listingcont_out
+                .contains("\\begin{listingcont}\nFirst line. Second line.\n\\end{listingcont}"),
+            "listingcont must stay a code env, got:\n{listingcont_out}"
+        );
+        assert!(
+            listingcont_out.contains("After the block.\nNext."),
+            "prose after listingcont must still split, got:\n{listingcont_out}"
+        );
+
+        let verb = concat!(
+            "Before. Next.\n",
+            "\\verbatiminput{foo.py}\n",
+            "After. Next.\n",
+        );
+        let verb_out = format_text(verb, &latex_cfg()).unwrap();
+        assert!(
+            verb_out.contains("\\verbatiminput{foo.py}\n"),
+            "verbatiminput must stay unchanged, got:\n{verb_out}"
+        );
+        assert!(
+            !verb_out.contains("\\verbatiminput{foo.py} After."),
+            "verbatiminput must not join following prose, got:\n{verb_out}"
+        );
+
+        let py = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+        let py_out = format_text(py, &latex_cfg()).unwrap();
+        assert!(
+            py_out.contains("\\inputpy{foo.py}\n"),
+            "inputpy must stay unchanged, got:\n{py_out}"
+        );
+        assert!(
+            !py_out.contains("\\inputpy{foo.py} After."),
+            "inputpy must not join following prose, got:\n{py_out}"
         );
 
         let tcb = concat!(

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -202,6 +202,7 @@ pub fn protect_inline_tokens_with(
 /// `\SaveVerb{name}|...|` / `\piton|...|` /
 /// `\lstinputlisting[...]{file}` /
 /// `\verbatiminput{file}` / `\VerbatimInput[...]{file}` /
+/// `\listinginput[interval]{start}{file}` /
 /// `\inputpy[...]{file}` / `\inputpycon[...]{file}` so inner `.!?%` cannot
 /// split or comment. `\piton{...}` stays on the generic `\cmd{arg}`
 /// path (piton.sty brace syntax is not verbatim; GitHub #305).
@@ -231,7 +232,7 @@ fn protect_latex_verbatim(
 /// Byte end of a `\verb` / `\lstinline` / `\spverb` / `\mintinline` /
 /// `\mint` / `\inputminted` / `\Verb` / `\SaveVerb` / `\piton` /
 /// `\lstinputlisting` / `\VerbatimInput` / `\BVerbatimInput` /
-/// `\LVerbatimInput` / `\inputpy` / `\inputpycon` /
+/// `\LVerbatimInput` / `\listinginput` / `\inputpy` / `\inputpycon` /
 /// extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
@@ -258,7 +259,10 @@ fn protect_latex_verbatim(
 /// `[...]` then a required `{filename}`; no brace is not a span.
 /// `inputpycon` is matched before `inputpy` so the longer name is not
 /// `\inputpy` + leftover. `\inputpygments` is not a span (`inputpy` +
-/// alphabetic leftover). Extra names are tokenized like `\verb`. With
+/// alphabetic leftover). `\listinginput` (moreverb leftover; GitHub
+/// #424) takes optional `[interval]` then required `{start-line}` and
+/// `{filename}`; no second brace is not a span. There is no `*` form.
+/// Extra names are tokenized like `\verb`. With
 /// no closer, the span runs to end of line so an inner `%` is not a
 /// comment.
 pub(crate) fn latex_verb_span_end_with(
@@ -289,6 +293,13 @@ pub(crate) fn latex_verb_span_end_with(
         // pythontex.sty leftover file-input (GitHub #419). `inputpycon`
         // before `inputpy`; `\inputpygments` is not a span.
         (after_bs + name_len, VerbKind::Lstinputlisting)
+    } else if let Some(stripped) = tail.strip_prefix("listinginput") {
+        // moreverb leftover file-input (GitHub #424). No `*` form;
+        // alphabetic tail rejects a longer name.
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic() || c == '*') {
+            return None;
+        }
+        (after_bs + "listinginput".len(), VerbKind::Listinginput)
     } else if let Some(stripped) = tail.strip_prefix("lstinputlisting") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -410,6 +421,32 @@ pub(crate) fn latex_verb_span_end_with(
         return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
     }
 
+    // moreverb `\listinginput[interval]{start-line}{filename}` (GitHub
+    // #424). Optional interval, then two required brace groups. No
+    // second brace is not a span. There is no `*` form.
+    if kind == VerbKind::Listinginput {
+        i = skip_ascii_ws(text, i);
+        if text.get(i..).is_some_and(|s| s.starts_with('[')) {
+            match skip_bracket_group(text, i) {
+                Some(end) => i = skip_ascii_ws(text, end),
+                None => return Some(line_end(text, i)),
+            }
+        }
+        if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
+            return None;
+        }
+        i += 1;
+        match find_unescaped_brace_close(text, i) {
+            Some(end) => i = skip_ascii_ws(text, end),
+            None => return Some(line_end(text, i)),
+        }
+        if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
+            return None;
+        }
+        i += 1;
+        return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
+    }
+
     // piton.sty `\PitonInputFile<spec>[opts]{file}` (`d < > O { } m`;
     // GitHub #406). Optional angle then optional brackets, then a
     // required brace file arg. No brace is not a span.
@@ -496,6 +533,9 @@ enum VerbKind {
     Verbatiminput,
     /// `\tcbinputlisting`: one required `{keyvals}` group.
     Tcbinputlisting,
+    /// `\listinginput`: optional `[interval]`, required `{start-line}`,
+    /// required `{filename}` (moreverb leftover; GitHub #424).
+    Listinginput,
     /// `\PitonInputFile`: optional `<...>`, optional `[...]`, required
     /// `{filename}` (piton.sty leftover; GitHub #406).
     PitonInputFile,
@@ -561,6 +601,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "inputpycon"
             || name == "verbatiminput"
             || name == "tcbinputlisting"
+            || name == "listinginput"
             || name == "PitonInputFile"
             || name == "mint"
             || name == "Verb"
@@ -2717,6 +2758,83 @@ mod tests {
         );
     }
 
+    /// Ticket fixture (GitHub #424): moreverb `\listinginput{start}{file}`
+    /// is one leftover file-input command; following `After.` still
+    /// splits. Optional `[interval]` stays in the span. No `*` form.
+    /// listing / listingcont / verbatiminput / inputpy unchanged.
+    #[test]
+    fn latex_listinginput_stays_atomic() {
+        let text = r"See \listinginput{1}{foo.py} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders
+                .iter()
+                .any(|p| p == r"\listinginput{1}{foo.py}"),
+            "listinginput span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\listinginput{1}{foo.py}", 0, &[]),
+            Some(r"\listinginput{1}{foo.py}".len())
+        );
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \listinginput{1}{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\listinginput[2]{1}{foo.py}", 0, &[]),
+            Some(r"\listinginput[2]{1}{foo.py}".len()),
+            "listinginput optional interval must stay in the span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\listinginput {1} {foo.py}", 0, &[]),
+            Some(r"\listinginput {1} {foo.py}".len()),
+            "listinginput may skip space between brace groups"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\listinginput{1}", 0, &[]),
+            None,
+            "listinginput without a filename brace is not a verb span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\listinginput foo.py", 0, &[]),
+            None,
+            "listinginput without brace args is not a verb span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\listinginput*{1}{foo.py}", 0, &[]),
+            None,
+            "listinginput has no star form"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\verbatiminput{foo.py}", 0, &[]),
+            Some(r"\verbatiminput{foo.py}".len()),
+            "listinginput must not steal verbatiminput"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpy{foo.py}", 0, &[]),
+            Some(r"\inputpy{foo.py}".len()),
+            "listinginput must not steal inputpy"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\tcbinputlisting{listing file=foo.py}", 0, &[]),
+            Some(r"\tcbinputlisting{listing file=foo.py}".len()),
+            "listinginput must not steal tcbinputlisting"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFile{foo.py}", 0, &[]),
+            Some(r"\PitonInputFile{foo.py}".len()),
+            "listinginput must not steal PitonInputFile"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\lstinputlisting{foo.py}", 0, &[]),
+            Some(r"\lstinputlisting{foo.py}".len()),
+            "listinginput must not steal lstinputlisting"
+        );
+    }
+
     /// Ticket fixture (GitHub #275): fancyvrb `\SaveVerb{name}|body|`
     /// is one token; following `After.` still splits.
     #[test]
@@ -4183,7 +4301,7 @@ mod tests {
     #[test]
     fn plaintext_format_keeps_dialogue_quote_together() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = "He said \"Hello world. How are you?\" Then he left.\n";
         let cfg = FormatConfig {
@@ -4300,7 +4418,7 @@ mod tests {
     #[test]
     fn newlines_invariant_holds_on_dialogue_output() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let samples = [
             "He said \"Hello world. How are you?\" Then he left.\n",
@@ -4548,7 +4666,7 @@ mod tests {
     #[test]
     fn markdown_period_inside_closers_survives_format_roundtrip() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Markdown,
@@ -4562,7 +4680,7 @@ mod tests {
     #[test]
     fn org_markdown_style_bold_period_splits_without_headline() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Org,
@@ -4623,7 +4741,7 @@ mod tests {
     #[test]
     fn markdown_emphasis_format_text_does_not_break_inside_span() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Markdown,
@@ -4671,7 +4789,7 @@ mod tests {
     #[test]
     fn plaintext_bang_inside_code_span_stays_atomic_after_keep_break() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = "?=\"`=!a`\n";
         let cfg = FormatConfig {
@@ -4691,7 +4809,7 @@ mod tests {
     #[test]
     fn keeps_break_before_lowercase_proper_noun() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = "First sentence.\niCloud starts the second sentence.\n";
         for format in [
@@ -4718,7 +4836,7 @@ mod tests {
     #[test]
     fn splits_same_line_lowercase_proper_noun() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         assert_eq!(
             split("First sentence. iCloud starts the second sentence."),

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -4301,7 +4301,7 @@ mod tests {
     #[test]
     fn plaintext_format_keeps_dialogue_quote_together() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "He said \"Hello world. How are you?\" Then he left.\n";
         let cfg = FormatConfig {
@@ -4418,7 +4418,7 @@ mod tests {
     #[test]
     fn newlines_invariant_holds_on_dialogue_output() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let samples = [
             "He said \"Hello world. How are you?\" Then he left.\n",
@@ -4666,7 +4666,7 @@ mod tests {
     #[test]
     fn markdown_period_inside_closers_survives_format_roundtrip() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Markdown,
@@ -4680,7 +4680,7 @@ mod tests {
     #[test]
     fn org_markdown_style_bold_period_splits_without_headline() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Org,
@@ -4741,7 +4741,7 @@ mod tests {
     #[test]
     fn markdown_emphasis_format_text_does_not_break_inside_span() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Markdown,
@@ -4789,7 +4789,7 @@ mod tests {
     #[test]
     fn plaintext_bang_inside_code_span_stays_atomic_after_keep_break() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "?=\"`=!a`\n";
         let cfg = FormatConfig {
@@ -4809,7 +4809,7 @@ mod tests {
     #[test]
     fn keeps_break_before_lowercase_proper_noun() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = "First sentence.\niCloud starts the second sentence.\n";
         for format in [
@@ -4836,7 +4836,7 @@ mod tests {
     #[test]
     fn splits_same_line_lowercase_proper_noun() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         assert_eq!(
             split("First sentence. iCloud starts the second sentence."),

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -76,11 +76,13 @@
 //! following flush prose does not join the command line.
 //! GitHub #419: pythontex.sty \\inputpy / \\inputpycon is one leftover
 //! command; following flush prose does not join the command line.
+//! GitHub #424: moreverb.sty \\listinginput is one leftover command;
+//! following flush prose does not join the command line.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
 use snapper_fmt::parser::{FormatParser, Region};
-use snapper_fmt::{FormatConfig, format_text};
+use snapper_fmt::{format_text, FormatConfig};
 
 fn latex_cfg() -> FormatConfig {
     FormatConfig {
@@ -3759,6 +3761,168 @@ fn inputpy_fixture_does_not_join_following_prose() {
     assert!(
         !lst_out.contains("\\lstinputlisting{foo.py} After."),
         "lstinputlisting must not join following prose, got:\n{lst_out}"
+    );
+
+    let tcb = concat!(
+        "Before. Next.\n",
+        "\\tcbinputlisting{listing file=foo.py}\n",
+        "After. Next.\n",
+    );
+    let tcb_out = format_text(tcb, &latex_cfg()).unwrap();
+    assert!(
+        tcb_out.contains("\\tcbinputlisting{listing file=foo.py}\n"),
+        "tcbinputlisting must stay unchanged, got:\n{tcb_out}"
+    );
+    assert!(
+        !tcb_out.contains("\\tcbinputlisting{listing file=foo.py} After."),
+        "tcbinputlisting must not join following prose, got:\n{tcb_out}"
+    );
+
+    let piton = concat!(
+        "Before. Next.\n",
+        "\\PitonInputFile{foo.py}\n",
+        "After. Next.\n",
+    );
+    let piton_out = format_text(piton, &latex_cfg()).unwrap();
+    assert!(
+        piton_out.contains("\\PitonInputFile{foo.py}\n"),
+        "PitonInputFile must stay unchanged, got:\n{piton_out}"
+    );
+    assert!(
+        !piton_out.contains("\\PitonInputFile{foo.py} After."),
+        "PitonInputFile must not join following prose, got:\n{piton_out}"
+    );
+}
+
+/// Ticket fixture (GitHub #424): moreverb.sty `\listinginput{start}{file}`
+/// stays one atomic command. Following flush `After.` does not join
+/// the command line. `After.` / `Next.` still split. listing /
+/// listingcont / verbatiminput / inputpy / tcbinputlisting /
+/// PitonInputFile unchanged.
+#[test]
+fn listinginput_fixture_does_not_join_following_prose() {
+    let input = concat!(
+        "Before. Next.\n",
+        "\\listinginput{1}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\listinginput{1}{foo.py}")
+        )),
+        "listinginput must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\listinginput{1}{foo.py}")
+        )),
+        "listinginput must not leak into Prose, got: {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+        )),
+        "After. / Next. must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\listinginput{1}{foo.py}\n"),
+        "listinginput must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\listinginput{1}{foo.py} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before listinginput must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after listinginput must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let opts = concat!(
+        "Before. Next.\n",
+        "\\listinginput[2]{1}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let opts_out = format_text(opts, &latex_cfg()).unwrap();
+    assert!(
+        opts_out.contains("\\listinginput[2]{1}{foo.py}\n"),
+        "listinginput optional interval must stay atomic, got:\n{opts_out}"
+    );
+    assert!(
+        !opts_out.contains("\\listinginput[2]{1}{foo.py} After."),
+        "optional-interval listinginput must not join following prose, got:\n{opts_out}"
+    );
+    assert!(
+        opts_out.contains("After.\nNext."),
+        "prose after optional-interval listinginput must still split, got:\n{opts_out}"
+    );
+
+    let listing = concat!(
+        "\\begin{listing}{1}\n",
+        "First line. Second line.\n",
+        "\\end{listing}\n",
+        "After the block. Next.\n",
+    );
+    let listing_out = format_text(listing, &latex_cfg()).unwrap();
+    assert!(
+        listing_out.contains("\\begin{listing}{1}\nFirst line. Second line.\n\\end{listing}"),
+        "listing must stay a code env, got:\n{listing_out}"
+    );
+    assert!(
+        listing_out.contains("After the block.\nNext."),
+        "prose after listing must still split, got:\n{listing_out}"
+    );
+
+    let listingcont = concat!(
+        "\\begin{listingcont}\n",
+        "First line. Second line.\n",
+        "\\end{listingcont}\n",
+        "After the block. Next.\n",
+    );
+    let listingcont_out = format_text(listingcont, &latex_cfg()).unwrap();
+    assert!(
+        listingcont_out
+            .contains("\\begin{listingcont}\nFirst line. Second line.\n\\end{listingcont}"),
+        "listingcont must stay a code env, got:\n{listingcont_out}"
+    );
+    assert!(
+        listingcont_out.contains("After the block.\nNext."),
+        "prose after listingcont must still split, got:\n{listingcont_out}"
+    );
+
+    let verb = concat!(
+        "Before. Next.\n",
+        "\\verbatiminput{foo.py}\n",
+        "After. Next.\n",
+    );
+    let verb_out = format_text(verb, &latex_cfg()).unwrap();
+    assert!(
+        verb_out.contains("\\verbatiminput{foo.py}\n"),
+        "verbatiminput must stay unchanged, got:\n{verb_out}"
+    );
+    assert!(
+        !verb_out.contains("\\verbatiminput{foo.py} After."),
+        "verbatiminput must not join following prose, got:\n{verb_out}"
+    );
+
+    let py = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+    let py_out = format_text(py, &latex_cfg()).unwrap();
+    assert!(
+        py_out.contains("\\inputpy{foo.py}\n"),
+        "inputpy must stay unchanged, got:\n{py_out}"
+    );
+    assert!(
+        !py_out.contains("\\inputpy{foo.py} After."),
+        "inputpy must not join following prose, got:\n{py_out}"
     );
 
     let tcb = concat!(

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -82,7 +82,7 @@
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
 use snapper_fmt::parser::{FormatParser, Region};
-use snapper_fmt::{format_text, FormatConfig};
+use snapper_fmt::{FormatConfig, format_text};
 
 fn latex_cfg() -> FormatConfig {
     FormatConfig {


### PR DESCRIPTION
discovered-from: moreverb.sty `\listinginput`. GREEN snapper-6g9n (impl-A/B+rev-1/2, ljos consensus accept 1.000, unanimous-green-189 ok=true).

The command is one leftover token (optional interval, required start-line, required `{file}`). Following flush prose does not join.

fixture:
Before. Next.
\listinginput{1}{foo.py}
After. Next.

verify (terra, format_text without_safety_backstops):
`\listinginput{1}{foo.py}` stays one line. After. / Next. still split.
listing / listingcont / verbatiminput / inputpy unchanged.

Do not hand-edit CHANGELOG.md.

Closes #424.
