### PR TITLE
fix(rst): hang and split same-line line-block body

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -2,8 +2,8 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::parser::{
-    flush_prose_spanned, iter_lines, join_prose_gap, push_prose_line, ByteSpan, FormatParser, Line,
-    Region, SpannedRegion,
+    ByteSpan, FormatParser, Line, Region, SpannedRegion, flush_prose_spanned, iter_lines,
+    join_prose_gap, push_prose_line,
 };
 
 /// Match `.. code-block:: LANG` or `.. sourcecode:: LANG` (or `.. code:: LANG`).

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -261,7 +261,7 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // figure, topic, sidebar, container, leftover body.py
         // parsed-literal / epigraph / highlights / pull-quote / compound /
         // header / footer / line-block) nested-parse their body: the opener
-        // and `:option:` fields stay Structure; the body hangs and reflows
+        // `:option:` fields stay Structure; the body hangs and reflows
         // like a block quote.
         // Opaque names keep the old freeze (GitHub #54 / #351 / #386).
         // A flush paragraph after a compact
@@ -1375,11 +1375,7 @@ fn rst_grid_table_end(lines: &[Line<'_>], start: usize) -> usize {
             last_top = j;
         }
     }
-    if last_top > start {
-        last_top
-    } else {
-        last
-    }
+    if last_top > start { last_top } else { last }
 }
 
 #[cfg(test)]
@@ -1391,9 +1387,11 @@ mod tests {
     fn simple_prose() {
         let input = "Hello world. This is a test.\nAnother line here.";
         let regions = RstParser.parse(input);
-        assert!(regions
-            .iter()
-            .any(|r| matches!(r, Region::Prose(s) if s.contains("Hello world."))));
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Prose(s) if s.contains("Hello world.")))
+        );
     }
 
     #[test]
@@ -1419,12 +1417,16 @@ mod tests {
     fn section_title_preserved() {
         let input = "My Title\n========\n\nSome text here.";
         let regions = RstParser.parse(input);
-        assert!(regions
-            .iter()
-            .any(|r| matches!(r, Region::Structure(s) if s.contains("My Title"))));
-        assert!(regions
-            .iter()
-            .any(|r| matches!(r, Region::Structure(s) if s.contains("===="))));
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains("My Title")))
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains("====")))
+        );
     }
 
     #[test]
@@ -1655,9 +1657,11 @@ mod tests {
     fn field_list_preserved() {
         let input = ":Author: Someone\n:Date: 2026\n\nParagraph text.";
         let regions = RstParser.parse(input);
-        assert!(regions
-            .iter()
-            .any(|r| matches!(r, Region::Structure(s) if s.contains("Author"))));
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains("Author")))
+        );
     }
 
     #[test]
@@ -3550,7 +3554,6 @@ mod tests {
             "compound",
             "header",
             "footer",
-            "line-block",
         ] {
             let arg = if matches!(name, "figure" | "admonition" | "sidebar" | "topic") {
                 " Title"
@@ -3772,93 +3775,6 @@ mod tests {
         assert!(
             !out.contains(".. parsed-literal:: fig. 1 is here. After."),
             "same-line parsed-literal body must not stay one line, got:\n{out}"
-        );
-        assert_eq!(format_text(&out, &cfg).unwrap(), out);
-    }
-
-    /// Ticket fixture (Format::Rst / GitHub #430): leftover body.py
-    /// `line-block` same-line body is leftover Prose.
-    fn leftover_line_block_same_line_fixture() -> &'static str {
-        concat!(".. line-block:: fig. 1 is here. After.\n", "After. Next.\n",)
-    }
-
-    #[test]
-    fn leftover_line_block_same_line_marker_is_structure_body_is_hung_prose() {
-        let input = leftover_line_block_same_line_fixture();
-        let regions = RstParser.parse(input);
-        assert!(
-            regions
-                .iter()
-                .any(|r| matches!(r, Region::Structure(s) if s == ".. line-block:: ")),
-            "opener .. line-block:: must stay Structure, got {regions:?}"
-        );
-        assert!(
-            regions.iter().any(|r| matches!(
-                r,
-                Region::Prose(s) if s.contains("fig. 1 is here.") && s.contains("After.")
-            )),
-            "same-line line-block body must be Prose, got {regions:?}"
-        );
-        assert!(
-            !regions.iter().any(|r| matches!(
-                r,
-                Region::Structure(s) if s.contains("fig. 1 is here")
-            )),
-            "same-line line-block body must not stay whole-line Structure, got {regions:?}"
-        );
-        assert!(
-            regions.iter().any(|r| matches!(
-                r,
-                Region::Prose(s)
-                    if s.contains("After.") && s.contains("Next.") && !s.contains("fig. 1")
-            )),
-            "flush After. / Next. must stay a separate Prose after line-block, got {regions:?}"
-        );
-        assert!(
-            !regions.iter().any(|r| matches!(
-                r,
-                Region::Prose(s) if s.contains("fig. 1 is here.") && s.contains("Next.")
-            )),
-            "flush After. / Next. must not join the line-block body, got {regions:?}"
-        );
-        assert_eq!(
-            rst_admonition_marker_len(".. line-block:: "),
-            Some(".. line-block:: ".len())
-        );
-        assert_eq!(
-            rst_admonition_marker_len(".. line-block:: fig. 1 is here. After."),
-            Some(".. line-block:: ".len())
-        );
-        assert_eq!(rst_admonition_marker_len(".. figure:: image.png"), None);
-        assert_eq!(
-            rst_substitution_replace_marker_len(".. line-block:: fig. 1 is here. After."),
-            None
-        );
-    }
-
-    #[test]
-    fn leftover_line_block_same_line_fixture_hangs_and_splits() {
-        use crate::format::Format;
-        use crate::{FormatConfig, format_text};
-
-        let cfg = FormatConfig {
-            format: Format::Rst,
-            max_width: 0,
-            ..Default::default()
-        }
-        .without_safety_backstops();
-        let input = leftover_line_block_same_line_fixture();
-        let opener = ".. line-block:: ";
-        let hang = " ".repeat(opener.len());
-        let out = format_text(input, &cfg).unwrap();
-        assert_eq!(
-            out,
-            format!("{opener}fig. 1 is here.\n{hang}After.\nAfter.\nNext.\n"),
-            "line-block same-line body must hang and split; flush After. / Next. stay flush, got:\n{out}"
-        );
-        assert!(
-            !out.contains(".. line-block:: fig. 1 is here. After."),
-            "same-line line-block body must not stay one line, got:\n{out}"
         );
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -1454,7 +1454,7 @@ mod tests {
     #[test]
     fn reporter_section_adornments_are_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1522,7 +1522,7 @@ mod tests {
     #[test]
     fn colon_section_fixture_is_identity_and_prose_still_splits() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1625,7 +1625,7 @@ mod tests {
     #[test]
     fn reporter_quoted_literal_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1725,7 +1725,7 @@ mod tests {
     fn reporter_role_continuation_second_sentence_hangs() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1813,7 +1813,7 @@ mod tests {
     #[test]
     fn reporter_simple_table_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1871,7 +1871,7 @@ mod tests {
     #[test]
     fn simple_table_interior_blank_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1964,7 +1964,7 @@ mod tests {
     #[test]
     fn line_block_does_not_swallow_following_flush_prose() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = line_block_flush_prose_fixture();
         let regions = RstParser.parse(input);
@@ -2257,7 +2257,7 @@ mod tests {
     #[test]
     fn leftover_header_footer_fixture_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2329,7 +2329,7 @@ mod tests {
     #[test]
     fn reporter_definition_list_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2430,7 +2430,7 @@ mod tests {
     fn compact_listlike_prose_does_not_invent_a_list() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2519,7 +2519,7 @@ mod tests {
     #[test]
     fn adjacent_rst_lists_are_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2709,7 +2709,7 @@ mod tests {
     fn reporter_open_quote_list_continuation_keeps_two_space_hang() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2746,7 +2746,7 @@ mod tests {
     fn reporter_open_literal_list_continuation_keeps_two_space_hang() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2795,7 +2795,7 @@ mod tests {
     fn reporter_open_paren_list_continuation_keeps_two_space_hang() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2836,7 +2836,7 @@ mod tests {
     fn reporter_abbrev_list_continuation_keeps_two_space_hang() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2877,7 +2877,7 @@ mod tests {
     fn starred_quote_list_item_is_idempotent_and_oracle() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2905,7 +2905,7 @@ mod tests {
     #[test]
     fn reporter_list_continuation_paragraph_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2928,7 +2928,7 @@ mod tests {
     fn reporter_enumerated_item_second_sentence_hangs_at_marker_width() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3069,7 +3069,7 @@ mod tests {
     #[test]
     fn reporter_comment_body_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3149,7 +3149,7 @@ mod tests {
     #[test]
     fn recognized_comment_line_keeps_indented_body() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3221,7 +3221,7 @@ mod tests {
     #[test]
     fn comment_blank_then_quote_splits_and_hangs() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3323,7 +3323,7 @@ mod tests {
     #[test]
     fn reporter_two_space_container_option_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3349,7 +3349,7 @@ mod tests {
     #[test]
     fn note_container_fixture_body_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = note_container_fixture();
         let regions = RstParser.parse(input);
@@ -3420,7 +3420,7 @@ mod tests {
     #[test]
     fn compact_note_flush_paragraph_stays_unindented() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = compact_note_flush_fixture();
         let regions = RstParser.parse(input);
@@ -3521,7 +3521,7 @@ mod tests {
     #[test]
     fn leftover_container_names_reflow_like_note() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3606,7 +3606,7 @@ mod tests {
     #[test]
     fn leftover_parsed_literal_fixture_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let input = leftover_parsed_literal_fixture();
         let regions = RstParser.parse(input);
@@ -3752,7 +3752,7 @@ mod tests {
     #[test]
     fn leftover_parsed_literal_same_line_fixture_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3839,7 +3839,7 @@ mod tests {
     #[test]
     fn leftover_line_block_same_line_fixture_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3866,7 +3866,7 @@ mod tests {
     #[test]
     fn leftover_header_footer_replace_epigraph_stay_unchanged() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3949,7 +3949,7 @@ mod tests {
     #[test]
     fn reporter_two_space_code_block_body_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4004,7 +4004,7 @@ mod tests {
     #[test]
     fn reporter_block_quote_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4030,7 +4030,7 @@ mod tests {
     #[test]
     fn surrounding_unquoted_paragraphs_still_reflow() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4060,7 +4060,7 @@ mod tests {
     #[test]
     fn compact_block_quote_reflows_with_hang() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4153,7 +4153,7 @@ mod tests {
     #[test]
     fn reporter_doctest_block_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4191,7 +4191,7 @@ mod tests {
     #[test]
     fn surrounding_prose_still_reflows_around_doctest() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4256,7 +4256,7 @@ mod tests {
     #[test]
     fn prompt_only_doctest_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4288,7 +4288,7 @@ mod tests {
     #[test]
     fn prompt_only_doctest_does_not_steal_preceding_prose_as_title() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4314,7 +4314,7 @@ mod tests {
     #[test]
     fn empty_doctest_opener_does_not_swallow_following_prose() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4366,7 +4366,7 @@ mod tests {
     #[test]
     fn same_line_doctest_command_still_takes_the_block() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4400,7 +4400,7 @@ mod tests {
     #[test]
     fn five_gt_adornment_stays_a_section_underline() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4432,7 +4432,7 @@ mod tests {
     #[test]
     fn rst_role_closer_keeps_two_sentence_lines() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4577,7 +4577,7 @@ mod tests {
     fn reporter_alpha_roman_paren_enumerators_hang_at_marker_width() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4676,7 +4676,7 @@ mod tests {
     fn reporter_option_list_keeps_alignment_and_hangs_description() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4874,7 +4874,7 @@ mod tests {
     #[test]
     fn reporter_anonymous_target_is_identity_and_prose_still_splits() {
         use crate::format::Format;
-        use crate::{format_text, FormatConfig};
+        use crate::{FormatConfig, format_text};
 
         let cfg = FormatConfig {
             format: Format::Rst,

--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -2,8 +2,8 @@ use regex::Regex;
 use std::sync::LazyLock;
 
 use crate::parser::{
-    ByteSpan, FormatParser, Line, Region, SpannedRegion, flush_prose_spanned, iter_lines,
-    join_prose_gap, push_prose_line,
+    flush_prose_spanned, iter_lines, join_prose_gap, push_prose_line, ByteSpan, FormatParser, Line,
+    Region, SpannedRegion,
 };
 
 /// Match `.. code-block:: LANG` or `.. sourcecode:: LANG` (or `.. code:: LANG`).
@@ -59,8 +59,8 @@ impl FormatParser for RstParser {
 /// block-quote hang spaces as structure regions. Docutils container
 /// directives (admonitions, figure, topic, sidebar, container, leftover
 /// body.py parsed-literal / epigraph / highlights / pull-quote / compound /
-/// header / footer) nested-parse their body: the opener and option fields
-/// stay Structure; the body hangs as Prose.
+/// header / footer / line-block) nested-parse their body: the opener and
+/// option fields stay Structure; the body hangs as Prose.
 fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut regions = Vec::new();
     let mut current_prose = String::new();
@@ -260,8 +260,8 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // RST directive (`.. name::`). Container directives (admonitions,
         // figure, topic, sidebar, container, leftover body.py
         // parsed-literal / epigraph / highlights / pull-quote / compound /
-        // header / footer) nested-parse their body: the opener and
-        // `:option:` fields stay Structure; the body hangs and reflows
+        // header / footer / line-block) nested-parse their body: the opener
+        // and `:option:` fields stay Structure; the body hangs and reflows
         // like a block quote.
         // Opaque names keep the old freeze (GitHub #54 / #351 / #386).
         // A flush paragraph after a compact
@@ -271,7 +271,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // Prose that still splits (GitHub #349). leftover body.py
         // `header` / `footer` is the same no-argument class (GitHub #422).
         // `parsed-literal` takes no argument; same-line text after `::`
-        // is leftover Prose (GitHub #426). SubstitutionDef
+        // is leftover Prose (GitHub #426). `line-block` takes no
+        // argument; same-line text after `::` is leftover Prose
+        // (GitHub #430). SubstitutionDef
         // `.. |name| replace::` is the same leftover: the replace body
         // is a nested-parsed paragraph (GitHub #417).
         let trimmed = line_text.trim_start();
@@ -784,8 +786,9 @@ fn rst_directive_name(trimmed: &str) -> Option<String> {
 
 /// Docutils specific admonitions plus leftover body.py names with no
 /// arguments (epigraph / highlights / pull-quote / compound / header /
-/// footer / parsed-literal): same-line text after `::` is the first
-/// nested-parsed body paragraph (GitHub #349 / #351 / #422 / #426).
+/// footer / parsed-literal / line-block): same-line text after `::` is
+/// the first nested-parsed body paragraph (GitHub #349 / #351 / #422 /
+/// #426 / #430).
 fn is_rst_specific_admonition(name: &str) -> bool {
     matches!(
         name,
@@ -805,14 +808,15 @@ fn is_rst_specific_admonition(name: &str) -> bool {
             | "header"
             | "footer"
             | "parsed-literal"
+            | "line-block"
     )
 }
 
 /// Docutils admonitions plus figure/topic/sidebar/container: bodies
 /// nested-parse, so hang + reflow. Leftover body.py names in
-/// `is_rst_specific_admonition` (including parsed-literal) are the
-/// same class. Option fields stay Structure via the field-list arm.
-/// Other directive names stay opaque. GitHub #386 / #426.
+/// `is_rst_specific_admonition` (including parsed-literal / line-block)
+/// are the same class. Option fields stay Structure via the field-list
+/// arm. Other directive names stay opaque. GitHub #386 / #426 / #430.
 fn is_rst_container_directive(name: &str) -> bool {
     is_rst_specific_admonition(name)
         || matches!(
@@ -1371,7 +1375,11 @@ fn rst_grid_table_end(lines: &[Line<'_>], start: usize) -> usize {
             last_top = j;
         }
     }
-    if last_top > start { last_top } else { last }
+    if last_top > start {
+        last_top
+    } else {
+        last
+    }
 }
 
 #[cfg(test)]
@@ -1383,11 +1391,9 @@ mod tests {
     fn simple_prose() {
         let input = "Hello world. This is a test.\nAnother line here.";
         let regions = RstParser.parse(input);
-        assert!(
-            regions
-                .iter()
-                .any(|r| matches!(r, Region::Prose(s) if s.contains("Hello world.")))
-        );
+        assert!(regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(s) if s.contains("Hello world."))));
     }
 
     #[test]
@@ -1413,16 +1419,12 @@ mod tests {
     fn section_title_preserved() {
         let input = "My Title\n========\n\nSome text here.";
         let regions = RstParser.parse(input);
-        assert!(
-            regions
-                .iter()
-                .any(|r| matches!(r, Region::Structure(s) if s.contains("My Title")))
-        );
-        assert!(
-            regions
-                .iter()
-                .any(|r| matches!(r, Region::Structure(s) if s.contains("====")))
-        );
+        assert!(regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains("My Title"))));
+        assert!(regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains("===="))));
     }
 
     #[test]
@@ -1452,7 +1454,7 @@ mod tests {
     #[test]
     fn reporter_section_adornments_are_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1520,7 +1522,7 @@ mod tests {
     #[test]
     fn colon_section_fixture_is_identity_and_prose_still_splits() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1623,7 +1625,7 @@ mod tests {
     #[test]
     fn reporter_quoted_literal_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1653,11 +1655,9 @@ mod tests {
     fn field_list_preserved() {
         let input = ":Author: Someone\n:Date: 2026\n\nParagraph text.";
         let regions = RstParser.parse(input);
-        assert!(
-            regions
-                .iter()
-                .any(|r| matches!(r, Region::Structure(s) if s.contains("Author")))
-        );
+        assert!(regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains("Author"))));
     }
 
     #[test]
@@ -1725,7 +1725,7 @@ mod tests {
     fn reporter_role_continuation_second_sentence_hangs() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1813,7 +1813,7 @@ mod tests {
     #[test]
     fn reporter_simple_table_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1871,7 +1871,7 @@ mod tests {
     #[test]
     fn simple_table_interior_blank_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -1964,7 +1964,7 @@ mod tests {
     #[test]
     fn line_block_does_not_swallow_following_flush_prose() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = line_block_flush_prose_fixture();
         let regions = RstParser.parse(input);
@@ -2257,7 +2257,7 @@ mod tests {
     #[test]
     fn leftover_header_footer_fixture_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2329,7 +2329,7 @@ mod tests {
     #[test]
     fn reporter_definition_list_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2430,7 +2430,7 @@ mod tests {
     fn compact_listlike_prose_does_not_invent_a_list() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2519,7 +2519,7 @@ mod tests {
     #[test]
     fn adjacent_rst_lists_are_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2709,7 +2709,7 @@ mod tests {
     fn reporter_open_quote_list_continuation_keeps_two_space_hang() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2746,7 +2746,7 @@ mod tests {
     fn reporter_open_literal_list_continuation_keeps_two_space_hang() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2795,7 +2795,7 @@ mod tests {
     fn reporter_open_paren_list_continuation_keeps_two_space_hang() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2836,7 +2836,7 @@ mod tests {
     fn reporter_abbrev_list_continuation_keeps_two_space_hang() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2877,7 +2877,7 @@ mod tests {
     fn starred_quote_list_item_is_idempotent_and_oracle() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2905,7 +2905,7 @@ mod tests {
     #[test]
     fn reporter_list_continuation_paragraph_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -2928,7 +2928,7 @@ mod tests {
     fn reporter_enumerated_item_second_sentence_hangs_at_marker_width() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3069,7 +3069,7 @@ mod tests {
     #[test]
     fn reporter_comment_body_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3149,7 +3149,7 @@ mod tests {
     #[test]
     fn recognized_comment_line_keeps_indented_body() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3221,7 +3221,7 @@ mod tests {
     #[test]
     fn comment_blank_then_quote_splits_and_hangs() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3323,7 +3323,7 @@ mod tests {
     #[test]
     fn reporter_two_space_container_option_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3349,7 +3349,7 @@ mod tests {
     #[test]
     fn note_container_fixture_body_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = note_container_fixture();
         let regions = RstParser.parse(input);
@@ -3420,7 +3420,7 @@ mod tests {
     #[test]
     fn compact_note_flush_paragraph_stays_unindented() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = compact_note_flush_fixture();
         let regions = RstParser.parse(input);
@@ -3521,7 +3521,7 @@ mod tests {
     #[test]
     fn leftover_container_names_reflow_like_note() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3550,6 +3550,7 @@ mod tests {
             "compound",
             "header",
             "footer",
+            "line-block",
         ] {
             let arg = if matches!(name, "figure" | "admonition" | "sidebar" | "topic") {
                 " Title"
@@ -3605,7 +3606,7 @@ mod tests {
     #[test]
     fn leftover_parsed_literal_fixture_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let input = leftover_parsed_literal_fixture();
         let regions = RstParser.parse(input);
@@ -3751,7 +3752,7 @@ mod tests {
     #[test]
     fn leftover_parsed_literal_same_line_fixture_hangs_and_splits() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3775,10 +3776,97 @@ mod tests {
         assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 
+    /// Ticket fixture (Format::Rst / GitHub #430): leftover body.py
+    /// `line-block` same-line body is leftover Prose.
+    fn leftover_line_block_same_line_fixture() -> &'static str {
+        concat!(".. line-block:: fig. 1 is here. After.\n", "After. Next.\n",)
+    }
+
+    #[test]
+    fn leftover_line_block_same_line_marker_is_structure_body_is_hung_prose() {
+        let input = leftover_line_block_same_line_fixture();
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s == ".. line-block:: ")),
+            "opener .. line-block:: must stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("fig. 1 is here.") && s.contains("After.")
+            )),
+            "same-line line-block body must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("fig. 1 is here")
+            )),
+            "same-line line-block body must not stay whole-line Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("After.") && s.contains("Next.") && !s.contains("fig. 1")
+            )),
+            "flush After. / Next. must stay a separate Prose after line-block, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("fig. 1 is here.") && s.contains("Next.")
+            )),
+            "flush After. / Next. must not join the line-block body, got {regions:?}"
+        );
+        assert_eq!(
+            rst_admonition_marker_len(".. line-block:: "),
+            Some(".. line-block:: ".len())
+        );
+        assert_eq!(
+            rst_admonition_marker_len(".. line-block:: fig. 1 is here. After."),
+            Some(".. line-block:: ".len())
+        );
+        assert_eq!(rst_admonition_marker_len(".. figure:: image.png"), None);
+        assert_eq!(
+            rst_substitution_replace_marker_len(".. line-block:: fig. 1 is here. After."),
+            None
+        );
+    }
+
+    #[test]
+    fn leftover_line_block_same_line_fixture_hangs_and_splits() {
+        use crate::format::Format;
+        use crate::{format_text, FormatConfig};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let input = leftover_line_block_same_line_fixture();
+        let opener = ".. line-block:: ";
+        let hang = " ".repeat(opener.len());
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out,
+            format!("{opener}fig. 1 is here.\n{hang}After.\nAfter.\nNext.\n"),
+            "line-block same-line body must hang and split; flush After. / Next. stay flush, got:\n{out}"
+        );
+        assert!(
+            !out.contains(".. line-block:: fig. 1 is here. After."),
+            "same-line line-block body must not stay one line, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
+    }
+
     #[test]
     fn leftover_header_footer_replace_epigraph_stay_unchanged() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3861,7 +3949,7 @@ mod tests {
     #[test]
     fn reporter_two_space_code_block_body_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3916,7 +4004,7 @@ mod tests {
     #[test]
     fn reporter_block_quote_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3942,7 +4030,7 @@ mod tests {
     #[test]
     fn surrounding_unquoted_paragraphs_still_reflow() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -3972,7 +4060,7 @@ mod tests {
     #[test]
     fn compact_block_quote_reflows_with_hang() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4065,7 +4153,7 @@ mod tests {
     #[test]
     fn reporter_doctest_block_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4103,7 +4191,7 @@ mod tests {
     #[test]
     fn surrounding_prose_still_reflows_around_doctest() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4168,7 +4256,7 @@ mod tests {
     #[test]
     fn prompt_only_doctest_is_identity_under_format() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4200,7 +4288,7 @@ mod tests {
     #[test]
     fn prompt_only_doctest_does_not_steal_preceding_prose_as_title() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4226,7 +4314,7 @@ mod tests {
     #[test]
     fn empty_doctest_opener_does_not_swallow_following_prose() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4278,7 +4366,7 @@ mod tests {
     #[test]
     fn same_line_doctest_command_still_takes_the_block() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4312,7 +4400,7 @@ mod tests {
     #[test]
     fn five_gt_adornment_stays_a_section_underline() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4344,7 +4432,7 @@ mod tests {
     #[test]
     fn rst_role_closer_keeps_two_sentence_lines() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4489,7 +4577,7 @@ mod tests {
     fn reporter_alpha_roman_paren_enumerators_hang_at_marker_width() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4588,7 +4676,7 @@ mod tests {
     fn reporter_option_list_keeps_alignment_and_hangs_description() {
         use crate::format::Format;
         use crate::oracle;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,
@@ -4786,7 +4874,7 @@ mod tests {
     #[test]
     fn reporter_anonymous_target_is_identity_and_prose_still_splits() {
         use crate::format::Format;
-        use crate::{FormatConfig, format_text};
+        use crate::{format_text, FormatConfig};
 
         let cfg = FormatConfig {
             format: Format::Rst,

--- a/tests/rst_line_block_directive.rs
+++ b/tests/rst_line_block_directive.rs
@@ -1,0 +1,134 @@
+//! snapper-awlr / GitHub #430: leftover body.py `line-block` same-line
+//! body is leftover Prose. Marker stays Structure; After. still splits
+//! and hangs. Flush After. / Next. still split. `| ` line-blocks already
+//! end at flush. parsed-literal / header / footer unchanged.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{format_text, FormatConfig};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst / GitHub #430).
+fn ticket_fixture() -> &'static str {
+    concat!(".. line-block:: fig. 1 is here. After.\n", "After. Next.\n",)
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        ".. line-block:: fig. 1 is here.\n",
+        "                After.\n",
+        "After.\n",
+        "Next.\n",
+    )
+}
+
+#[test]
+fn line_block_directive_opener_is_structure_body_is_prose() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s == ".. line-block:: ")),
+        "opener .. line-block:: must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s)
+                if s.contains("fig. 1 is here.") && s.contains("After.")
+        )),
+        "same-line line-block body must be Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("fig. 1 is here")
+        )),
+        "same-line line-block body must not stay whole-line Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_hangs_and_splits() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert!(
+        !out.contains(".. line-block:: fig. 1 is here. After."),
+        "same-line line-block body must not stay one line, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext.\n"),
+        "flush After. / Next. must stay split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\n                After.\n                After."),
+        "flush After. must not inherit the line-block hang, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &rst_cfg()).unwrap(),
+        out,
+        "split line-block body must be identity, got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn pipe_line_blocks_still_end_at_flush() {
+    let input = concat!("| First line. Second line.\n", "After. Next.\n",);
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(
+        out,
+        concat!("| First line.\n", "  Second line.\n", "After.\n", "Next.\n",),
+        "| line-blocks already end at flush; After. / Next. still split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\n  After."),
+        "After. must not inherit the | hang, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+}
+
+#[test]
+fn parsed_literal_header_footer_unchanged() {
+    let parsed = concat!(
+        ".. parsed-literal:: fig. 1 is here. After.\n",
+        "After. Next.\n",
+    );
+    let parsed_out = format_text(parsed, &rst_cfg()).unwrap();
+    assert_eq!(
+        parsed_out,
+        concat!(
+            ".. parsed-literal:: fig. 1 is here.\n",
+            "                    After.\n",
+            "After.\n",
+            "Next.\n",
+        ),
+        "parsed-literal leftover from #426 must stay, got:\n{parsed_out}"
+    );
+
+    for name in ["header", "footer"] {
+        let opener = format!(".. {name}:: ");
+        let hang = " ".repeat(opener.len());
+        let input = format!(".. {name}:: fig. 1 is here. After.\nAfter. Next.\n");
+        let out = format_text(&input, &rst_cfg()).unwrap();
+        assert_eq!(
+            out,
+            format!("{opener}fig. 1 is here.\n{hang}After.\nAfter.\nNext.\n"),
+            "{name} same-line leftover must stay, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &rst_cfg()).unwrap(), out);
+    }
+}

--- a/tests/rst_line_block_directive.rs
+++ b/tests/rst_line_block_directive.rs
@@ -6,7 +6,7 @@
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::rst::RstParser;
 use snapper_fmt::parser::{FormatParser, Region};
-use snapper_fmt::{format_text, FormatConfig};
+use snapper_fmt::{FormatConfig, format_text};
 
 fn rst_cfg() -> FormatConfig {
     FormatConfig {


### PR DESCRIPTION
discovered-from: Docutils `line_block` directive. GREEN snapper-awlr (impl-A/B+rev-1/2, ljos consensus accept 1.000).

`.. line-block::` takes no argument. Same-line text after `::` is leftover Prose and hangs. Two sentences still split. `| ` line-blocks already end at flush prose.

fixture:
.. line-block:: fig. 1 is here. After.
After. Next.

verify (terra, format_text without_safety_backstops):
`.. line-block:: fig. 1 is here.|                After.|`
Flush After. / Next. still split.
`| ` line-blocks / parsed-literal / header / footer unchanged.

Do not hand-edit CHANGELOG.md.

Closes #430.
