### PR TITLE
fix(rst): hang and split same-line meta field body

### DIFF
--- a/src/parser/rst.rs
+++ b/src/parser/rst.rs
@@ -59,8 +59,9 @@ impl FormatParser for RstParser {
 /// block-quote hang spaces as structure regions. Docutils container
 /// directives (admonitions, figure, topic, sidebar, container, leftover
 /// body.py parsed-literal / epigraph / highlights / pull-quote / compound /
-/// header / footer / line-block) nested-parse their body: the opener and
-/// option fields stay Structure; the body hangs as Prose.
+/// header / footer / line-block / meta) nested-parse their body: the opener
+/// and option fields stay Structure; the body hangs as Prose. Meta field
+/// same-line values are leftover Prose (GitHub #434).
 fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     let mut regions = Vec::new();
     let mut current_prose = String::new();
@@ -83,6 +84,11 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
     // the body hangs as a block quote, so a column-0 line must close that
     // hang instead of joining After markup into the note Prose.
     let mut in_container_body = false;
+    // Docutils `meta` body is a field list whose values are paragraphs.
+    // Field markers stay Structure; same-line bodies hang as Prose
+    // (GitHub #434). Top-level `:Author:` and directive `:option:`
+    // fields stay whole-line Structure.
+    let mut in_meta = false;
     // Line-block hang (`| `): first flush line that is not `| ` and not
     // a hang is a new paragraph, not more line-block (GitHub #409).
     let mut in_line_block = false;
@@ -275,7 +281,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // argument; same-line text after `::` is leftover Prose
         // (GitHub #430). SubstitutionDef
         // `.. |name| replace::` is the same leftover: the replace body
-        // is a nested-parsed paragraph (GitHub #417).
+        // is a nested-parsed paragraph (GitHub #417). `meta` takes no
+        // argument; its body is a field list whose values are leftover
+        // paragraphs (GitHub #434).
         let trimmed = line_text.trim_start();
         if trimmed.starts_with(".. ") && trimmed.contains("::") {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
@@ -285,6 +293,7 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
                 if line_text.len() > marker_len && !line_text[marker_len..].trim().is_empty() {
                     list_hang = Some(marker_len);
                     in_container_body = true;
+                    in_meta = false;
                     regions.push(SpannedRegion::structure(
                         input,
                         ByteSpan::new(line.start, line.start + marker_len),
@@ -296,14 +305,19 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
                 }
             }
             regions.push(SpannedRegion::structure(input, line.span()));
-            if rst_directive_name(trimmed).is_some_and(|n| is_rst_container_directive(&n))
+            let dir_name = rst_directive_name(trimmed);
+            if dir_name
+                .as_deref()
+                .is_some_and(|n| is_rst_container_directive(n) || is_rst_meta_directive(n))
                 || rst_substitution_replace_marker_len(line_text).is_some()
             {
                 in_container_body = true;
+                in_meta = dir_name.as_deref().is_some_and(is_rst_meta_directive);
                 i += 1;
                 continue;
             }
             in_container_body = false;
+            in_meta = false;
             let leading = line_text.len() - trimmed.len();
             // Docutils accepts a two-space body; +3 is convention only.
             directive_indent = leading + 2;
@@ -421,7 +435,9 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
         // `:role:`text`` is interpreted text, not a field.
         // Empty `:name:` and simple `:Author:` stay whole-line
         // Structure (GitHub #330). Interior-colon names hang the body
-        // as Prose so SemBr still splits.
+        // as Prose so SemBr still splits. Meta field values are
+        // leftover paragraphs: marker Structure, same-line body Prose
+        // (GitHub #434). Directive `:option:` fields stay Structure.
         if let Some(marker_len) = rst_field_marker_len(line_text) {
             flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
             let body = &line_text[marker_len..];
@@ -430,7 +446,7 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
                 .strip_prefix(':')
                 .and_then(|s| s.strip_suffix(':'))
                 .is_some_and(|inner| inner.contains(':'));
-            if interior_colon && !body.trim().is_empty() {
+            if (interior_colon || in_meta) && !body.trim().is_empty() {
                 list_hang = Some(marker_len);
                 regions.push(SpannedRegion::structure(
                     input,
@@ -670,6 +686,7 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
             if (in_container_body || in_line_block) && leading == 0 {
                 flush_prose_spanned(&mut current_prose, &mut prose_span, &mut regions);
                 in_container_body = false;
+                in_meta = false;
                 in_line_block = false;
             }
         }
@@ -696,6 +713,7 @@ fn parse_line_based(input: &str) -> Vec<SpannedRegion> {
 
         // Regular prose
         in_container_body = false;
+        in_meta = false;
         in_line_block = false;
         push_prose_line(&mut current_prose, &mut prose_span, line, true, true);
         i += 1;
@@ -817,12 +835,20 @@ fn is_rst_specific_admonition(name: &str) -> bool {
 /// `is_rst_specific_admonition` (including parsed-literal / line-block)
 /// are the same class. Option fields stay Structure via the field-list
 /// arm. Other directive names stay opaque. GitHub #386 / #426 / #430.
+/// `meta` is a sibling leftover: its body is a field list, not a
+/// nested-parsed paragraph (GitHub #434).
 fn is_rst_container_directive(name: &str) -> bool {
     is_rst_specific_admonition(name)
         || matches!(
             name,
             "admonition" | "figure" | "topic" | "sidebar" | "container"
         )
+}
+
+/// Docutils `meta` directive. Takes no argument; the body is a field
+/// list whose values are paragraphs (GitHub #434).
+fn is_rst_meta_directive(name: &str) -> bool {
+    name == "meta"
 }
 
 /// Byte length of a specific-admonition opener (`.. note::` plus
@@ -2286,6 +2312,93 @@ mod tests {
             );
             assert_eq!(format_text(&out, &cfg).unwrap(), out);
         }
+    }
+
+    /// Ticket fixture (Format::Rst / GitHub #434): leftover `meta`
+    /// field same-line body is leftover Prose.
+    fn leftover_meta_fixture() -> &'static str {
+        concat!(
+            ".. meta::\n",
+            "   :description: fig. 1 is here. After.\n",
+            "After. Next.\n",
+        )
+    }
+
+    #[test]
+    fn leftover_meta_field_marker_is_structure_body_is_hung_prose() {
+        let input = leftover_meta_fixture();
+        let regions = RstParser.parse(input);
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains(".. meta::"))),
+            "opener .. meta:: must stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions
+                .iter()
+                .any(|r| matches!(r, Region::Structure(s) if s.contains(":description:"))),
+            "field marker :description: must stay Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("fig. 1 is here.") && s.contains("After.")
+            )),
+            "same-line meta field body must be Prose, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains("fig. 1 is here")
+            )),
+            "same-line meta field body must not stay whole-line Structure, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s)
+                    if s.contains("After.") && s.contains("Next.") && !s.contains("fig. 1")
+            )),
+            "flush After. / Next. must stay a separate Prose after meta, got {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(s) if s.contains("fig. 1 is here.") && s.contains("Next.")
+            )),
+            "flush After. / Next. must not join the meta field body, got {regions:?}"
+        );
+        assert!(is_rst_meta_directive("meta"));
+        assert!(!is_rst_meta_directive("note"));
+        assert!(!is_rst_container_directive("meta"));
+    }
+
+    #[test]
+    fn leftover_meta_fixture_hangs_and_splits() {
+        use crate::format::Format;
+        use crate::{FormatConfig, format_text};
+
+        let cfg = FormatConfig {
+            format: Format::Rst,
+            max_width: 0,
+            ..Default::default()
+        }
+        .without_safety_backstops();
+        let input = leftover_meta_fixture();
+        let marker = "   :description: ";
+        let hang = " ".repeat(marker.len());
+        let out = format_text(input, &cfg).unwrap();
+        assert_eq!(
+            out,
+            format!(".. meta::\n{marker}fig. 1 is here.\n{hang}After.\nAfter.\nNext.\n"),
+            "meta field same-line body must hang and split; flush After. / Next. stay flush, got:\n{out}"
+        );
+        assert!(
+            !out.contains(":description: fig. 1 is here. After."),
+            "same-line meta field body must not stay one line, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &cfg).unwrap(), out);
     }
 
     #[test]

--- a/tests/rst_meta.rs
+++ b/tests/rst_meta.rs
@@ -1,0 +1,167 @@
+//! snapper-10kg / GitHub #434: leftover Docutils `meta` field
+//! `:description: fig. 1 is here. After.` same-line body is leftover
+//! Prose. Field marker stays Structure; After. still splits and hangs.
+//! Flush After. / Next. still split. `.. meta::` stays Structure.
+//! Top-level `:Author:` and note `:option:` stay whole-line Structure.
+
+use snapper_fmt::format::Format;
+use snapper_fmt::parser::rst::RstParser;
+use snapper_fmt::parser::{FormatParser, Region};
+use snapper_fmt::{FormatConfig, format_text};
+
+fn rst_cfg() -> FormatConfig {
+    FormatConfig {
+        format: Format::Rst,
+        max_width: 0,
+        ..Default::default()
+    }
+    .without_safety_backstops()
+}
+
+/// Ticket fixture (Format::Rst / GitHub #434).
+fn ticket_fixture() -> &'static str {
+    concat!(
+        ".. meta::\n",
+        "   :description: fig. 1 is here. After.\n",
+        "After. Next.\n",
+    )
+}
+
+fn expected_ticket() -> &'static str {
+    concat!(
+        ".. meta::\n",
+        "   :description: fig. 1 is here.\n",
+        "                 After.\n",
+        "After.\n",
+        "Next.\n",
+    )
+}
+
+#[test]
+fn meta_opener_and_field_marker_are_structure_body_is_prose() {
+    let regions = RstParser.parse(ticket_fixture());
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(".. meta::"))),
+        "opener .. meta:: must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(":description:"))),
+        "field marker :description: must stay Structure, got {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(s) if s.contains("fig. 1 is here.") && s.contains("After.")
+        )),
+        "same-line meta field body must be Prose, got {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains("fig. 1 is here")
+        )),
+        "same-line meta field body must not stay whole-line Structure, got {regions:?}"
+    );
+}
+
+#[test]
+fn ticket_fixture_hangs_and_splits() {
+    let input = ticket_fixture();
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, expected_ticket(), "got:\n{out}");
+    assert!(
+        !out.contains(":description: fig. 1 is here. After."),
+        "same-line meta field body must not stay one line, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext.\n"),
+        "flush After. / Next. must stay split, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\n                 After.\n                 Next."),
+        "flush After. must not inherit the meta field hang, got:\n{out}"
+    );
+    assert_eq!(
+        format_text(&out, &rst_cfg()).unwrap(),
+        out,
+        "split meta field body must be identity, got:\n{out}"
+    );
+    assert!(
+        snapper_fmt::oracle::matches(Format::Rst, input, &out),
+        "oracle mismatch\n in={input:?}\n out={out:?}"
+    );
+}
+
+#[test]
+fn author_field_stays_whole_line_structure() {
+    let input = ":Author: Someone\n";
+    let regions = RstParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(":Author: Someone"))),
+        "top-level :Author: must stay whole-line Structure, got {regions:?}"
+    );
+    assert!(
+        !regions
+            .iter()
+            .any(|r| matches!(r, Region::Prose(s) if s.contains("Someone"))),
+        "top-level :Author: body must not become Prose, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert_eq!(out, input, "valued field must hang as today, got:\n{out}");
+}
+
+#[test]
+fn note_option_field_stays_structure() {
+    let input = concat!(".. note::\n", "   :class: test\n", "\n", "   Body.\n",);
+    let regions = RstParser.parse(input);
+    assert!(
+        regions
+            .iter()
+            .any(|r| matches!(r, Region::Structure(s) if s.contains(":class: test"))),
+        "note option field must stay Structure, got {regions:?}"
+    );
+    let out = format_text(input, &rst_cfg()).unwrap();
+    assert!(
+        out.contains("   :class: test\n"),
+        "note option field must stay one line, got:\n{out}"
+    );
+}
+
+#[test]
+fn header_footer_replace_unchanged() {
+    for name in ["header", "footer"] {
+        let opener = format!(".. {name}:: ");
+        let hang = " ".repeat(opener.len());
+        let input = format!(".. {name}:: fig. 1 is here. After.\nAfter. Next.\n");
+        let out = format_text(&input, &rst_cfg()).unwrap();
+        assert_eq!(
+            out,
+            format!("{opener}fig. 1 is here.\n{hang}After.\nAfter.\nNext.\n"),
+            "{name} same-line leftover must stay, got:\n{out}"
+        );
+    }
+
+    let replace = concat!(
+        "See |v|. Next.\n",
+        "\n",
+        ".. |v| replace:: fig. 1 is here. After.\n",
+    );
+    let replace_out = format_text(replace, &rst_cfg()).unwrap();
+    assert_eq!(
+        replace_out,
+        concat!(
+            "See |v|.\n",
+            "Next.\n",
+            "\n",
+            ".. |v| replace:: fig. 1 is here.\n",
+            "                 After.\n",
+        ),
+        "replace:: leftover walker must stay, got:\n{replace_out}"
+    );
+}


### PR DESCRIPTION
discovered-from: Docutils meta field body. GREEN snapper-10kg (impl-A/B+rev-1/2, ljos consensus accept 1.000, children gaxz/omso DONE).

A meta field value is leftover Prose and hangs. Two sentences still split.

fixture:
.. meta::
   :description: fig. 1 is here. After.
After. Next.

verify (terra, format_text without_safety_backstops):
`:description: fig. 1 is here.|               After.|`
Flush After. / Next. still split. `.. meta::` stays Structure. Top-level `:Author:` unchanged.

Do not hand-edit CHANGELOG.md.

Closes #434.
