### PR TITLE
fix(latex): tokenize pythontex inputpylab inputsympy like inputpy

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -503,7 +503,8 @@ impl LatexParser {
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
     /// `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
     /// `\inputminted` / `\verbatiminput` / `\VerbatimInput` / `\tcbinputlisting` /
-    /// `\listinginput` / `\inputpy` / `\inputpycon` / `\sageinput` /
+    /// `\listinginput` / `\inputpy` / `\inputpycon` / `\inputpylab` /
+    /// `\inputpylabcon` / `\inputsympy` / `\inputsympycon` / `\sageinput` /
     /// configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
@@ -879,6 +880,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 /// `\spverb` / `\mintinline` / `\mint` / `\inputminted` / `\Verb` /
 /// `\SaveVerb` / `\piton` / `\lstinputlisting` / `\verbatiminput` /
 /// `\VerbatimInput` / `\listinginput` / `\inputpy` / `\inputpycon` /
+/// `\inputpylab` / `\inputpylabcon` / `\inputsympy` / `\inputsympycon` /
 /// `\sageinput` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
@@ -988,11 +990,14 @@ fn pitoninputfile_cs_at(line: &str, at: usize) -> bool {
     !after.starts_with(|c: char| c.is_ascii_alphabetic())
 }
 
-/// Leftover pythontex.sty `\inputpy` / `\inputpycon` (optional `[...]`,
-/// required `{file}`; GitHub #419). One leftover walker for both names.
-/// Other verb spans are skipped so `\verb|\inputpy{x}|` is not stolen.
-/// Walk stops at an unescaped `%` so a comment is not a command tail.
-/// `\inputpygments` is not a span (`inputpy` + alphabetic leftover).
+/// Leftover pythontex.sty default-family file-input (optional `[...]`,
+/// required `{file}`; GitHub #419 / #433). One leftover walker for
+/// `\inputpy` / `\inputpycon` / `\inputpylab` / `\inputpylabcon` /
+/// `\inputsympy` / `\inputsympycon`. Longer names first so
+/// `\inputpylab` is not `\inputpy` + leftover. Other verb spans are
+/// skipped so `\verb|\inputpy{x}|` is not stolen. Walk stops at an
+/// unescaped `%` so a comment is not a command tail. `\inputpygments`
+/// is not a span (`inputpy` + alphabetic leftover).
 fn find_inputpy_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<(usize, usize)> {
     find_leftover_cmd_at(line, from, extra_cmds, inputpy_cs_at)
 }
@@ -1001,7 +1006,14 @@ fn inputpy_cs_at(line: &str, at: usize) -> bool {
     let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
         return false;
     };
-    for name in ["inputpycon", "inputpy"] {
+    for name in [
+        "inputpylabcon",
+        "inputsympycon",
+        "inputpylab",
+        "inputpycon",
+        "inputsympy",
+        "inputpy",
+    ] {
         if let Some(after) = tail.strip_prefix(name) {
             return !after.starts_with(|c: char| c.is_ascii_alphabetic());
         }
@@ -8355,6 +8367,112 @@ Some text.
         assert!(
             !piton_out.contains("\\PitonInputFile{foo.py} After."),
             "PitonInputFile must not join following prose, got:\n{piton_out}"
+        );
+    }
+
+    /// Ticket fixture (GitHub #433): pythontex.sty `\inputpylab{file}` /
+    /// `\inputsympy{file}` and con twins stay one leftover command.
+    /// Following flush `After.` does not join. inputpy / listinginput /
+    /// sageinput unchanged.
+    #[test]
+    fn inputpylab_inputsympy_does_not_join_following_prose() {
+        use crate::format_text;
+
+        for name in ["inputpylab", "inputpylabcon", "inputsympy", "inputsympycon"] {
+            let cmd = format!("\\{name}{{foo.py}}");
+            let input = format!("Before. Next.\n{cmd}\nAfter. Next.\n");
+            let regions = LatexParser::default().parse(&input);
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Structure(s) if s.contains(cmd.as_str())
+                )),
+                "{name} must stay one Structure command, got: {regions:?}"
+            );
+            assert!(
+                !regions.iter().any(|r| matches!(
+                    r,
+                    Region::Prose(p) if p.contains(cmd.as_str())
+                )),
+                "{name} must not leak into Prose, got: {regions:?}"
+            );
+            assert!(
+                regions.iter().any(|r| matches!(
+                    r,
+                    Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+                )),
+                "After. / Next. must stay Prose after {name}, got: {regions:?}"
+            );
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&format!("{cmd}\n")),
+                "{name} must stay one atomic command, got:\n{out}"
+            );
+            assert!(
+                !out.contains(&format!("{cmd} After.")),
+                "following flush prose must not join the {name} line, got:\n{out}"
+            );
+            assert!(
+                out.contains("Before.\nNext."),
+                "prose before {name} must still split, got:\n{out}"
+            );
+            assert!(
+                out.contains("After.\nNext."),
+                "prose after {name} must still split, got:\n{out}"
+            );
+            assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+            let opts = format!("Before. Next.\n\\{name}[sess]{{foo.py}}\nAfter. Next.\n");
+            let opts_out = format_text(&opts, &latex_cfg()).unwrap();
+            assert!(
+                opts_out.contains(&format!("\\{name}[sess]{{foo.py}}\n")),
+                "{name} optional args must stay atomic, got:\n{opts_out}"
+            );
+            assert!(
+                !opts_out.contains(&format!("\\{name}[sess]{{foo.py}} After.")),
+                "optional-arg {name} must not join following prose, got:\n{opts_out}"
+            );
+        }
+
+        let py = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+        let py_out = format_text(py, &latex_cfg()).unwrap();
+        assert!(
+            py_out.contains("\\inputpy{foo.py}\n"),
+            "inputpy must stay unchanged, got:\n{py_out}"
+        );
+        assert!(
+            !py_out.contains("\\inputpy{foo.py} After."),
+            "inputpy must not join following prose, got:\n{py_out}"
+        );
+
+        let listing = concat!(
+            "Before. Next.\n",
+            "\\listinginput{1}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let listing_out = format_text(listing, &latex_cfg()).unwrap();
+        assert!(
+            listing_out.contains("\\listinginput{1}{foo.py}\n"),
+            "listinginput must stay unchanged, got:\n{listing_out}"
+        );
+        assert!(
+            !listing_out.contains("\\listinginput{1}{foo.py} After."),
+            "listinginput must not join following prose, got:\n{listing_out}"
+        );
+
+        let sage = concat!(
+            "Before. Next.\n",
+            "\\sageinput{foo.sage}\n",
+            "After. Next.\n",
+        );
+        let sage_out = format_text(sage, &latex_cfg()).unwrap();
+        assert!(
+            sage_out.contains("\\sageinput{foo.sage}\n"),
+            "sageinput must stay unchanged, got:\n{sage_out}"
+        );
+        assert!(
+            !sage_out.contains("\\sageinput{foo.sage} After."),
+            "sageinput must not join following prose, got:\n{sage_out}"
         );
     }
 

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -204,6 +204,8 @@ pub fn protect_inline_tokens_with(
 /// `\verbatiminput{file}` / `\VerbatimInput[...]{file}` /
 /// `\listinginput[interval]{start}{file}` /
 /// `\inputpy[...]{file}` / `\inputpycon[...]{file}` /
+/// `\inputpylab[...]{file}` / `\inputpylabcon[...]{file}` /
+/// `\inputsympy[...]{file}` / `\inputsympycon[...]{file}` /
 /// `\sageinput{file}` so inner `.!?%` cannot
 /// split or comment. `\piton{...}` stays on the generic `\cmd{arg}`
 /// path (piton.sty brace syntax is not verbatim; GitHub #305).
@@ -234,6 +236,7 @@ fn protect_latex_verbatim(
 /// `\mint` / `\inputminted` / `\Verb` / `\SaveVerb` / `\piton` /
 /// `\lstinputlisting` / `\VerbatimInput` / `\BVerbatimInput` /
 /// `\LVerbatimInput` / `\listinginput` / `\inputpy` / `\inputpycon` /
+/// `\inputpylab` / `\inputpylabcon` / `\inputsympy` / `\inputsympycon` /
 /// `\sageinput` / extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
@@ -256,10 +259,11 @@ fn protect_latex_verbatim(
 /// `\LVerbatimInput` (fancyvrb.sty leftover; GitHub #399) use the same
 /// optional `[...]` then `{filename}` walk. Matched before `\Verb` so
 /// `\VerbatimInput` is not `\Verb` plus leftover letters. `\inputpy` /
-/// `\inputpycon` (pythontex.sty leftover; GitHub #419) take optional
-/// `[...]` then a required `{filename}`; no brace is not a span.
-/// `inputpycon` is matched before `inputpy` so the longer name is not
-/// `\inputpy` + leftover. `\inputpygments` is not a span (`inputpy` +
+/// `\inputpycon` / `\inputpylab` / `\inputpylabcon` / `\inputsympy` /
+/// `\inputsympycon` (pythontex.sty leftover; GitHub #419 / #433) take
+/// optional `[...]` then a required `{filename}`; no brace is not a
+/// span. Longer names first so `\inputpylab` is not `\inputpy` +
+/// leftover. `\inputpygments` is not a span (`inputpy` +
 /// alphabetic leftover). `\listinginput` (moreverb leftover; GitHub
 /// #424) takes optional `[interval]` then required `{start-line}` and
 /// `{filename}`; no second brace is not a span. There is no `*` form.
@@ -294,8 +298,8 @@ pub(crate) fn latex_verb_span_end_with(
         }
         (after_bs + "inputminted".len(), VerbKind::Mint)
     } else if let Some(name_len) = inputpy_cmd_len(tail) {
-        // pythontex.sty leftover file-input (GitHub #419). `inputpycon`
-        // before `inputpy`; `\inputpygments` is not a span.
+        // pythontex.sty leftover file-input (GitHub #419 / #433).
+        // Longer names first; `\inputpygments` is not a span.
         (after_bs + name_len, VerbKind::Lstinputlisting)
     } else if let Some(stripped) = tail.strip_prefix("listinginput") {
         // moreverb leftover file-input (GitHub #424). No `*` form;
@@ -540,7 +544,8 @@ enum VerbKind {
     /// `\lstinline`: optional `[...]` then delimiter or `{...}`.
     Lstinline,
     /// `\lstinputlisting` / `\VerbatimInput` / `\BVerbatimInput` /
-    /// `\LVerbatimInput` / `\inputpy` / `\inputpycon`: optional `[...]`
+    /// `\LVerbatimInput` / `\inputpy` / `\inputpycon` / `\inputpylab` /
+    /// `\inputpylabcon` / `\inputsympy` / `\inputsympycon`: optional `[...]`
     /// then required `{filename}`.
     Lstinputlisting,
     /// `\\verbatiminput`: required `{filename}` (verbatim.sty leftover).
@@ -585,12 +590,19 @@ fn verbatiminput_cs_name(tail: &str) -> Option<&'static str> {
     None
 }
 
-/// pythontex.sty leftover `\inputpycon` / `\inputpy` (optional `[...]`,
-/// required `{file}`; GitHub #419). Longer name first so `\inputpycon`
-/// is not `\inputpy` + leftover. `\inputpygments` is rejected as
-/// `inputpy` + alphabetic leftover.
+/// pythontex.sty leftover default-family file-input (optional `[...]`,
+/// required `{file}`; GitHub #419 / #433). Longer names first so
+/// `\inputpylab` / `\inputpycon` are not `\inputpy` + leftover.
+/// `\inputpygments` is rejected as `inputpy` + alphabetic leftover.
 fn inputpy_cmd_len(tail: &str) -> Option<usize> {
-    for name in ["inputpycon", "inputpy"] {
+    for name in [
+        "inputpylabcon",
+        "inputsympycon",
+        "inputpylab",
+        "inputpycon",
+        "inputsympy",
+        "inputpy",
+    ] {
         if let Some(stripped) = tail.strip_prefix(name) {
             if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
                 return None;
@@ -615,6 +627,10 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "inputminted"
             || name == "inputpy"
             || name == "inputpycon"
+            || name == "inputpylab"
+            || name == "inputpylabcon"
+            || name == "inputsympy"
+            || name == "inputsympycon"
             || name == "verbatiminput"
             || name == "tcbinputlisting"
             || name == "listinginput"
@@ -2771,6 +2787,77 @@ mod tests {
             latex_verb_span_end_with(r"\PitonInputFile{foo.py}", 0, &[]),
             Some(r"\PitonInputFile{foo.py}".len()),
             "inputpy must not steal PitonInputFile"
+        );
+    }
+
+    /// Ticket fixture (GitHub #433): pythontex.sty `\inputpylab{file}` /
+    /// `\inputsympy{file}` and con twins are the same leftover family
+    /// as `\inputpy`. Following `After.` still splits. inputpy /
+    /// listinginput / sageinput unchanged. A configured extra of the
+    /// same name must not re-tokenize the no-brace form as Delim.
+    #[test]
+    fn latex_inputpylab_inputsympy_stays_atomic() {
+        for name in ["inputpylab", "inputpylabcon", "inputsympy", "inputsympycon"] {
+            let cmd = format!("\\{name}{{foo.py}}");
+            let text = format!("See {cmd} here. After.");
+            let (_, placeholders) = protect_inline_tokens(&text);
+            assert!(
+                placeholders.iter().any(|p| p == &cmd),
+                "{name} span must be protected, got {placeholders:?}"
+            );
+            assert_eq!(latex_verb_span_end_with(&cmd, 0, &[]), Some(cmd.len()));
+            assert_eq!(
+                split(&text),
+                vec![format!("See {cmd} here."), "After.".to_string()]
+            );
+            let opts = format!("\\{name}[sess]{{foo.py}}");
+            assert_eq!(
+                latex_verb_span_end_with(&opts, 0, &[]),
+                Some(opts.len()),
+                "{name} optional session must stay in the span"
+            );
+            let no_brace = format!("\\{name} foo.py");
+            assert_eq!(
+                latex_verb_span_end_with(&no_brace, 0, &[]),
+                None,
+                "{name} without a brace file arg is not a verb span"
+            );
+            let extras = [name.to_string()];
+            assert_eq!(
+                latex_verb_span_end_with(&no_brace, 0, &extras),
+                None,
+                "configured extra {name} must not re-tokenize the no-brace form as Delim"
+            );
+            assert_eq!(
+                latex_verb_span_end_with(&cmd, 0, &extras),
+                Some(cmd.len()),
+                "configured extra {name} must keep the brace form as leftover"
+            );
+        }
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpy{foo.py}", 0, &[]),
+            Some(r"\inputpy{foo.py}".len()),
+            "inputpy must stay a span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpycon{foo.py}", 0, &[]),
+            Some(r"\inputpycon{foo.py}".len()),
+            "inputpycon must stay a span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\listinginput{1}{foo.py}", 0, &[]),
+            Some(r"\listinginput{1}{foo.py}".len()),
+            "listinginput must stay a span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\sageinput{foo.sage}", 0, &[]),
+            Some(r"\sageinput{foo.sage}".len()),
+            "sageinput must stay a span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpygments{python}{foo.py}", 0, &[]),
+            None,
+            "inputpylab must not steal inputpygments"
         );
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -76,6 +76,8 @@
 //! following flush prose does not join the command line.
 //! GitHub #419: pythontex.sty \\inputpy / \\inputpycon is one leftover
 //! command; following flush prose does not join the command line.
+//! GitHub #433: pythontex.sty \\inputpylab / \\inputsympy (and con
+//! twins) are the same leftover family as \\inputpy.
 //! GitHub #424: moreverb.sty \\listinginput is one leftover command;
 //! following flush prose does not join the command line.
 //! GitHub #428: sagetex.sty \\sageinput is one leftover command;
@@ -3793,6 +3795,100 @@ fn inputpy_fixture_does_not_join_following_prose() {
     assert!(
         !piton_out.contains("\\PitonInputFile{foo.py} After."),
         "PitonInputFile must not join following prose, got:\n{piton_out}"
+    );
+}
+
+/// Ticket fixture (GitHub #433): pythontex.sty `\inputpylab{file}` /
+/// `\inputsympy{file}` and con twins stay one atomic command.
+/// Following flush `After.` does not join the command line.
+/// `After.` / `Next.` still split. inputpy / listinginput / sageinput
+/// unchanged.
+#[test]
+fn inputpylab_inputsympy_fixture_does_not_join_following_prose() {
+    for name in ["inputpylab", "inputpylabcon", "inputsympy", "inputsympycon"] {
+        let cmd = format!("\\{name}{{foo.py}}");
+        let input = format!("Before. Next.\n{cmd}\nAfter. Next.\n");
+        let regions = LatexParser::default().parse(&input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(cmd.as_str())
+            )),
+            "{name} must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(cmd.as_str())
+            )),
+            "{name} must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+            )),
+            "After. / Next. must stay Prose after {name}, got: {regions:?}"
+        );
+        let out = format_text(&input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains(&format!("{cmd}\n")),
+            "{name} must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains(&format!("{cmd} After.")),
+            "following flush prose must not join the {name} line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before.\nNext."),
+            "prose before {name} must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after {name} must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+    }
+
+    let py = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+    let py_out = format_text(py, &latex_cfg()).unwrap();
+    assert!(
+        py_out.contains("\\inputpy{foo.py}\n"),
+        "inputpy must stay unchanged, got:\n{py_out}"
+    );
+    assert!(
+        !py_out.contains("\\inputpy{foo.py} After."),
+        "inputpy must not join following prose, got:\n{py_out}"
+    );
+
+    let listing = concat!(
+        "Before. Next.\n",
+        "\\listinginput{1}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let listing_out = format_text(listing, &latex_cfg()).unwrap();
+    assert!(
+        listing_out.contains("\\listinginput{1}{foo.py}\n"),
+        "listinginput must stay unchanged, got:\n{listing_out}"
+    );
+    assert!(
+        !listing_out.contains("\\listinginput{1}{foo.py} After."),
+        "listinginput must not join following prose, got:\n{listing_out}"
+    );
+
+    let sage = concat!(
+        "Before. Next.\n",
+        "\\sageinput{foo.sage}\n",
+        "After. Next.\n",
+    );
+    let sage_out = format_text(sage, &latex_cfg()).unwrap();
+    assert!(
+        sage_out.contains("\\sageinput{foo.sage}\n"),
+        "sageinput must stay unchanged, got:\n{sage_out}"
+    );
+    assert!(
+        !sage_out.contains("\\sageinput{foo.sage} After."),
+        "sageinput must not join following prose, got:\n{sage_out}"
     );
 }
 


### PR DESCRIPTION
discovered-from: pythontex.sty default-family file-input after `\inputpy`. GREEN snapper-l39b (impl-A/B+rev-1/2, ljos consensus accept 1.000, child t1eb DONE).

`\inputpylab` / `\inputsympy` and con twins are the same leftover class as `\inputpy`. Following flush prose does not join.

fixture:
Before. Next.
\inputpylab{foo.py}
After. Next.

verify (terra, format_text without_safety_backstops):
`\inputpylab{foo.py}` / `\inputsympy{foo.py}` stay one line. After. / Next. still split.
inputpy / listinginput / sageinput unchanged.

Do not hand-edit CHANGELOG.md.

Closes #433.
