### PR TITLE
fix(latex): tokenize scontents inputsc like lstinputlisting

### DIFF
--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -505,7 +505,7 @@ impl LatexParser {
     /// `\inputminted` / `\verbatiminput` / `\VerbatimInput` / `\tcbinputlisting` /
     /// `\listinginput` / `\inputpy` / `\inputpycon` / `\inputpylab` /
     /// `\inputpylabcon` / `\inputsympy` / `\inputsympycon` / `\sageinput` /
-    /// configured verbatim commands.
+    /// `\inputsc` / configured verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -881,7 +881,7 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 /// `\SaveVerb` / `\piton` / `\lstinputlisting` / `\verbatiminput` /
 /// `\VerbatimInput` / `\listinginput` / `\inputpy` / `\inputpycon` /
 /// `\inputpylab` / `\inputpylabcon` / `\inputsympy` / `\inputsympycon` /
-/// `\sageinput` spans.
+/// `\sageinput` / `\inputsc` spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -1054,6 +1054,25 @@ fn sageinput_cs_at(line: &str, at: usize) -> bool {
         return false;
     };
     let Some(after) = tail.strip_prefix("sageinput") else {
+        return false;
+    };
+    !after.starts_with(|c: char| c.is_ascii_alphabetic() || c == '*')
+}
+
+/// Leftover scontents.sty `\inputsc` (optional `[keys]`, required
+/// `{name}`; GitHub #437). Other verb spans are skipped so
+/// `\verb|\inputsc{x}|` is not stolen. Walk stops at an unescaped `%`
+/// so a comment is not a command tail. `\input` / `\inputpy` are not
+/// this name. There is no `*` form.
+fn find_inputsc_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<(usize, usize)> {
+    find_leftover_cmd_at(line, from, extra_cmds, inputsc_cs_at)
+}
+
+fn inputsc_cs_at(line: &str, at: usize) -> bool {
+    let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
+        return false;
+    };
+    let Some(after) = tail.strip_prefix("inputsc") else {
         return false;
     };
     !after.starts_with(|c: char| c.is_ascii_alphabetic() || c == '*')
@@ -1831,6 +1850,7 @@ impl<'a> ParseState<'a> {
                     .or_else(|| find_inputpy_at(code, i, &self.parser.extra_verbatim_commands))
                     .or_else(|| find_listinginput_at(code, i, &self.parser.extra_verbatim_commands))
                     .or_else(|| find_sageinput_at(code, i, &self.parser.extra_verbatim_commands))
+                    .or_else(|| find_inputsc_at(code, i, &self.parser.extra_verbatim_commands))
             {
                 self.append_item_or_prose(line.start + i, &code[i..start]);
                 self.push_structure(ByteSpan::new(
@@ -8761,6 +8781,129 @@ Some text.
         assert!(
             !piton_out.contains("\\PitonInputFile{foo.py} After."),
             "PitonInputFile must not join following prose, got:\n{piton_out}"
+        );
+    }
+
+    /// Ticket fixture (GitHub #437): scontents.sty `\inputsc{name}`
+    /// stays one leftover command. Following flush `After.` does not
+    /// join. scontents env / inputpy / sageinput / listinginput
+    /// unchanged.
+    #[test]
+    fn inputsc_does_not_join_following_prose() {
+        use crate::format_text;
+
+        let input = concat!("Before. Next.\n", "\\inputsc{foo}\n", "After. Next.\n",);
+        let regions = LatexParser::default().parse(input);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\inputsc{foo}")
+            )),
+            "inputsc must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\inputsc{foo}")
+            )),
+            "inputsc must not leak into Prose, got: {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+            )),
+            "After. / Next. must stay Prose, got: {regions:?}"
+        );
+        let out = format_text(input, &latex_cfg()).unwrap();
+        assert!(
+            out.contains("\\inputsc{foo}\n"),
+            "inputsc must stay one atomic command, got:\n{out}"
+        );
+        assert!(
+            !out.contains("\\inputsc{foo} After."),
+            "following flush prose must not join the command line, got:\n{out}"
+        );
+        assert!(
+            out.contains("Before.\nNext."),
+            "prose before inputsc must still split, got:\n{out}"
+        );
+        assert!(
+            out.contains("After.\nNext."),
+            "prose after inputsc must still split, got:\n{out}"
+        );
+        assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+        let opts = concat!(
+            "Before. Next.\n",
+            "\\inputsc[print-env=verbatim]{foo}\n",
+            "After. Next.\n",
+        );
+        let opts_out = format_text(opts, &latex_cfg()).unwrap();
+        assert!(
+            opts_out.contains("\\inputsc[print-env=verbatim]{foo}\n"),
+            "inputsc optional keys must stay atomic, got:\n{opts_out}"
+        );
+        assert!(
+            !opts_out.contains("\\inputsc[print-env=verbatim]{foo} After."),
+            "optional-key inputsc must not join following prose, got:\n{opts_out}"
+        );
+
+        let sc = concat!(
+            "\\begin{scontents}\n",
+            "First line. Second line.\n",
+            "\\end{scontents}\n",
+            "After the block. Next.\n",
+        );
+        let sc_out = format_text(sc, &latex_cfg()).unwrap();
+        assert!(
+            sc_out.contains("\\begin{scontents}\nFirst line. Second line.\n\\end{scontents}"),
+            "scontents env must stay a code env, got:\n{sc_out}"
+        );
+        assert!(
+            sc_out.contains("After the block.\nNext."),
+            "prose after scontents env must still split, got:\n{sc_out}"
+        );
+
+        let py = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+        let py_out = format_text(py, &latex_cfg()).unwrap();
+        assert!(
+            py_out.contains("\\inputpy{foo.py}\n"),
+            "inputpy must stay unchanged, got:\n{py_out}"
+        );
+        assert!(
+            !py_out.contains("\\inputpy{foo.py} After."),
+            "inputpy must not join following prose, got:\n{py_out}"
+        );
+
+        let sage = concat!(
+            "Before. Next.\n",
+            "\\sageinput{foo.sage}\n",
+            "After. Next.\n",
+        );
+        let sage_out = format_text(sage, &latex_cfg()).unwrap();
+        assert!(
+            sage_out.contains("\\sageinput{foo.sage}\n"),
+            "sageinput must stay unchanged, got:\n{sage_out}"
+        );
+        assert!(
+            !sage_out.contains("\\sageinput{foo.sage} After."),
+            "sageinput must not join following prose, got:\n{sage_out}"
+        );
+
+        let listing = concat!(
+            "Before. Next.\n",
+            "\\listinginput{1}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let listing_out = format_text(listing, &latex_cfg()).unwrap();
+        assert!(
+            listing_out.contains("\\listinginput{1}{foo.py}\n"),
+            "listinginput must stay unchanged, got:\n{listing_out}"
+        );
+        assert!(
+            !listing_out.contains("\\listinginput{1}{foo.py} After."),
+            "listinginput must not join following prose, got:\n{listing_out}"
         );
     }
 }

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -206,7 +206,7 @@ pub fn protect_inline_tokens_with(
 /// `\inputpy[...]{file}` / `\inputpycon[...]{file}` /
 /// `\inputpylab[...]{file}` / `\inputpylabcon[...]{file}` /
 /// `\inputsympy[...]{file}` / `\inputsympycon[...]{file}` /
-/// `\sageinput{file}` so inner `.!?%` cannot
+/// `\sageinput{file}` / `\inputsc[...]{name}` so inner `.!?%` cannot
 /// split or comment. `\piton{...}` stays on the generic `\cmd{arg}`
 /// path (piton.sty brace syntax is not verbatim; GitHub #305).
 fn protect_latex_verbatim(
@@ -237,7 +237,7 @@ fn protect_latex_verbatim(
 /// `\lstinputlisting` / `\VerbatimInput` / `\BVerbatimInput` /
 /// `\LVerbatimInput` / `\listinginput` / `\inputpy` / `\inputpycon` /
 /// `\inputpylab` / `\inputpylabcon` / `\inputsympy` / `\inputsympycon` /
-/// `\sageinput` / extra-name span starting at `at`.
+/// `\sageinput` / `\inputsc` / extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
 /// character is the
@@ -270,6 +270,10 @@ fn protect_latex_verbatim(
 /// `\sageinput` (sagetex leftover; GitHub #428) takes a required
 /// `{filename}`; no brace is not a span. `\sage` / `\sageplot` /
 /// `\sagestr` are not this name. There is no `*` form.
+/// `\inputsc` (scontents leftover sequence replay; GitHub #437)
+/// takes optional `[...]` then a required `{name}`; no brace is not
+/// a span. There is no `*` form. `\input` / `\inputpy` are not this
+/// name.
 /// Extra names are tokenized like `\verb`. With
 /// no closer, the span runs to end of line so an inner `%` is not a
 /// comment.
@@ -316,6 +320,14 @@ pub(crate) fn latex_verb_span_end_with(
             return None;
         }
         (after_bs + "sageinput".len(), VerbKind::Tcbinputlisting)
+    } else if let Some(stripped) = tail.strip_prefix("inputsc") {
+        // scontents leftover sequence replay (GitHub #437). No `*`
+        // form; alphabetic tail rejects a longer name. `\input` /
+        // `\inputpy` do not match this name.
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic() || c == '*') {
+            return None;
+        }
+        (after_bs + "inputsc".len(), VerbKind::Lstinputlisting)
     } else if let Some(stripped) = tail.strip_prefix("lstinputlisting") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -545,8 +557,8 @@ enum VerbKind {
     Lstinline,
     /// `\lstinputlisting` / `\VerbatimInput` / `\BVerbatimInput` /
     /// `\LVerbatimInput` / `\inputpy` / `\inputpycon` / `\inputpylab` /
-    /// `\inputpylabcon` / `\inputsympy` / `\inputsympycon`: optional `[...]`
-    /// then required `{filename}`.
+    /// `\inputpylabcon` / `\inputsympy` / `\inputsympycon` / `\inputsc`:
+    /// optional `[...]` then required `{filename}` / `{name}`.
     Lstinputlisting,
     /// `\\verbatiminput`: required `{filename}` (verbatim.sty leftover).
     Verbatiminput,
@@ -631,6 +643,7 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "inputpylabcon"
             || name == "inputsympy"
             || name == "inputsympycon"
+            || name == "inputsc"
             || name == "verbatiminput"
             || name == "tcbinputlisting"
             || name == "listinginput"
@@ -2858,6 +2871,74 @@ mod tests {
             latex_verb_span_end_with(r"\inputpygments{python}{foo.py}", 0, &[]),
             None,
             "inputpylab must not steal inputpygments"
+        );
+    }
+
+    /// Ticket fixture (GitHub #437): scontents.sty `\inputsc{name}` is
+    /// one leftover sequence-replay command; following `After.` still
+    /// splits. Optional `[keys]` stay in the span. No `*` form.
+    /// inputpy / listinginput / sageinput unchanged. A configured extra
+    /// of the same name must not re-tokenize the no-brace form as Delim.
+    #[test]
+    fn latex_inputsc_stays_atomic() {
+        let cmd = r"\inputsc{foo}";
+        let text = r"See \inputsc{foo} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == cmd),
+            "inputsc span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(latex_verb_span_end_with(cmd, 0, &[]), Some(cmd.len()));
+        assert_eq!(
+            split(text),
+            vec![r"See \inputsc{foo} here.".to_string(), "After.".to_string()]
+        );
+        let opts = r"\inputsc[print-env=verbatim]{foo}";
+        assert_eq!(
+            latex_verb_span_end_with(opts, 0, &[]),
+            Some(opts.len()),
+            "inputsc optional keys must stay in the span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputsc foo", 0, &[]),
+            None,
+            "inputsc without a brace name is not a verb span"
+        );
+        let extras = ["inputsc".to_string()];
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputsc foo", 0, &extras),
+            None,
+            "configured extra inputsc must not re-tokenize the no-brace form as Delim"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(cmd, 0, &extras),
+            Some(cmd.len()),
+            "configured extra inputsc must keep the brace form as leftover"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputsc*{foo}", 0, &[]),
+            None,
+            "inputsc has no star form"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpy{foo.py}", 0, &[]),
+            Some(r"\inputpy{foo.py}".len()),
+            "inputpy must stay a span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\listinginput{1}{foo.py}", 0, &[]),
+            Some(r"\listinginput{1}{foo.py}".len()),
+            "listinginput must stay a span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\sageinput{foo.sage}", 0, &[]),
+            Some(r"\sageinput{foo.sage}".len()),
+            "sageinput must stay a span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\input{foo}", 0, &[]),
+            None,
+            "inputsc must not steal \\input"
         );
     }
 

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -82,6 +82,8 @@
 //! following flush prose does not join the command line.
 //! GitHub #428: sagetex.sty \\sageinput is one leftover command;
 //! following flush prose does not join the command line.
+//! GitHub #437: scontents.sty \\inputsc is one leftover command;
+//! following flush prose does not join the command line.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -4177,5 +4179,111 @@ fn sageinput_fixture_does_not_join_following_prose() {
     assert!(
         !piton_out.contains("\\PitonInputFile{foo.py} After."),
         "PitonInputFile must not join following prose, got:\n{piton_out}"
+    );
+}
+
+/// Ticket fixture (GitHub #437): scontents.sty `\inputsc{name}` stays
+/// one atomic command. Following flush `After.` does not join the
+/// command line. `After.` / `Next.` still split. scontents env /
+/// inputpy / sageinput / listinginput unchanged.
+#[test]
+fn inputsc_fixture_does_not_join_following_prose() {
+    let input = concat!("Before. Next.\n", "\\inputsc{foo}\n", "After. Next.\n",);
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\inputsc{foo}")
+        )),
+        "inputsc must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\inputsc{foo}")
+        )),
+        "inputsc must not leak into Prose, got: {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+        )),
+        "After. / Next. must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\inputsc{foo}\n"),
+        "inputsc must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\inputsc{foo} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before inputsc must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after inputsc must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let sc = concat!(
+        "\\begin{scontents}\n",
+        "First line. Second line.\n",
+        "\\end{scontents}\n",
+        "After the block. Next.\n",
+    );
+    let sc_out = format_text(sc, &latex_cfg()).unwrap();
+    assert!(
+        sc_out.contains("\\begin{scontents}\nFirst line. Second line.\n\\end{scontents}"),
+        "scontents env must stay a code env, got:\n{sc_out}"
+    );
+    assert!(
+        sc_out.contains("After the block.\nNext."),
+        "prose after scontents env must still split, got:\n{sc_out}"
+    );
+
+    let py = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+    let py_out = format_text(py, &latex_cfg()).unwrap();
+    assert!(
+        py_out.contains("\\inputpy{foo.py}\n"),
+        "inputpy must stay unchanged, got:\n{py_out}"
+    );
+    assert!(
+        !py_out.contains("\\inputpy{foo.py} After."),
+        "inputpy must not join following prose, got:\n{py_out}"
+    );
+
+    let sage = concat!(
+        "Before. Next.\n",
+        "\\sageinput{foo.sage}\n",
+        "After. Next.\n",
+    );
+    let sage_out = format_text(sage, &latex_cfg()).unwrap();
+    assert!(
+        sage_out.contains("\\sageinput{foo.sage}\n"),
+        "sageinput must stay unchanged, got:\n{sage_out}"
+    );
+    assert!(
+        !sage_out.contains("\\sageinput{foo.sage} After."),
+        "sageinput must not join following prose, got:\n{sage_out}"
+    );
+
+    let listing = concat!(
+        "Before. Next.\n",
+        "\\listinginput{1}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let listing_out = format_text(listing, &latex_cfg()).unwrap();
+    assert!(
+        listing_out.contains("\\listinginput{1}{foo.py}\n"),
+        "listinginput must stay unchanged, got:\n{listing_out}"
+    );
+    assert!(
+        !listing_out.contains("\\listinginput{1}{foo.py} After."),
+        "listinginput must not join following prose, got:\n{listing_out}"
     );
 }


### PR DESCRIPTION
discovered-from: scontents.sty `\inputsc`. GREEN snapper-j8cw (impl-A/B+rev-1/2, ljos consensus accept 1.000, unanimous-green-195 ok=true).

The command is one leftover token (optional `[...]`, required `{name}`). Following flush prose does not join.

fixture:
Before. Next.
\inputsc{foo}
After. Next.

verify (terra, format_text without_safety_backstops):
`\inputsc{foo}` stays one line. After. / Next. still split.
scontents env / inputpy / sageinput / listinginput unchanged.

Do not hand-edit CHANGELOG.md.

Closes #437.
