### PR TITLE
fix(latex): tokenize leftover filename-input cmds as one walker

### DIFF
--- a/docs/orgmode/reference/config.org
+++ b/docs/orgmode/reference/config.org
@@ -187,8 +187,7 @@ Adding =algorithm= stops reflow of that environment.
 
 String array of extra command names tokenized like the built-in verb command before sentence split.
 The next character after the name is the delimiter.
-Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline=, =inputminted=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb= / =VerbatimInput=, piton.sty =\piton=, tools/verbatim.sty =\verbatiminput=, and tcolorbox =\tcbinputlisting=.
-=\tcbinputlisting= takes a required ={keyvals}= group; following flush prose stays on its own line.
+Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline=, =inputminted=, =mint=, fancyvrb =Verb= / =Verb*= / =SaveVerb= / =VerbatimInput= / =BVerbatimInput= / =LVerbatimInput=, piton.sty =\piton= / =\PitonInputFile= / =\PitonInputFileT= / =\PitonInputFileF= / =\PitonInputFileTF=, tools/verbatim.sty =\verbatiminput=, tcolorbox =\tcbinputlisting=, pythontex.sty =\inputpy= / =\inputpycon= / =\inputpylab= / =\inputsympy= / =\inputpygments= / =\pygment=, catchfilebetweentags.sty =\CatchFileBetweenTags= / =\CatchFileBetweenDelims= / =\ExecuteMetaData=, moreverb =\listinginput=, sagetex =\sageinput=, and scontents =\inputsc=; =lstinline= still accepts optional =[...]= and ={...}=.
 =mintinline= / =mint= take optional =[...]=, a ={lang}= argument, then a delimiter or ={...}= body.
 =\inputminted= takes the same optional =[...]= and ={lang}= then a required ={filename}=; following flush prose stays on its own line.
 =\tcbinputlisting= takes one keyval group; following flush prose stays on its own line.
@@ -197,6 +196,15 @@ Built-in names are =verb=, =lstinline=, =lstinputlisting=, =spverb=, =mintinline
 =\lstinputlisting= takes optional =[...]= then a required ={filename}=; following flush prose stays on its own line.
 =\VerbatimInput= / =\BVerbatimInput= / =\LVerbatimInput= take optional =[...]= then a required ={filename}=; following flush prose stays on its own line.
 =\verbatiminput= / =\verbatiminput*= take a required ={filename}=; following flush prose stays on its own line.
+=\PitonInputFile= takes optional =<...>=, optional =[...]=, then a required ={filename}=; following flush prose stays on its own line.
+=\PitonInputFileT= / =\PitonInputFileF= take the same optional args then ={file}= and one extra required brace; =\PitonInputFileTF= takes two extra braces; following flush prose stays on its own line.
+=\tcbinputlisting= takes one required ={keyval}= group; following flush prose stays on its own line.
+=\inputpy= / =\inputpycon= take optional =[...]= then a required ={filename}=; following flush prose stays on its own line.
+=\inputpygments= takes optional =[...]=, ={lang}=, then a required ={filename}=; =\pygment= takes ={lang}= then a delimiter or ={code}= body; following flush prose stays on its own line.
+=\CatchFileBetweenTags= takes ={macro}= ={file}= ={tag}=; =\CatchFileBetweenDelims= takes ={macro}= ={file}= ={start}= ={end}=; =\ExecuteMetaData= takes optional =[file]= then ={tag}=; following flush prose stays on its own line.
+=\listinginput= takes optional =[interval]= then required ={start}= and ={filename}=; following flush prose stays on its own line.
+=\sageinput= takes optional =[...]= then a required ={filename}=; following flush prose stays on its own line.
+=\inputsc= takes optional =[...]= then a required ={name}=; following flush prose stays on its own line.
 Adding another name keeps that command's delimited body atomic and treats an inner =%= as content, not a comment.
 
 * Code-block sections (=[code.<lang>]=)

--- a/docs/orgmode/reference/formats.org
+++ b/docs/orgmode/reference/formats.org
@@ -135,13 +135,21 @@ These tokens within prose are not split across lines:
 - piton.sty =Piton= is a built-in code region (verbatim listing env)
 - Extra names from =[latex].verbatim_envs= are code regions too
 - Body follows the same comment-reflow and optional =--format-code= rules as other formats when language is known (=minted= / =minted*= language arg, =lstlisting= / =lstlisting*= =language== option)
-- Inline leftover commands include =\verbatiminput=, =\VerbatimInput= / =B= / =L=, and =\tcbinputlisting=; following flush prose stays on its own line.
+- Inline =\verb= / =\lstinline= / =\spverb= / =\mintinline= / =\mint= / fancyvrb =\Verb= / =\Verb*= / =\SaveVerb= / =\VerbatimInput= / =\BVerbatimInput= / =\LVerbatimInput= / piton.sty =\piton= / =\PitonInputFile= / =\PitonInputFileT= / =\PitonInputFileF= / =\PitonInputFileTF= / listings.sty =\lstinputlisting= / minted.sty =\inputminted= / tools/verbatim.sty =\verbatiminput= / tcolorbox =\tcbinputlisting= / pythontex.sty =\inputpy= / =\inputpycon= / =\inputpygments= / =\pygment= / catchfilebetweentags.sty =\CatchFileBetweenTags= / =\CatchFileBetweenDelims= / =\ExecuteMetaData= / moreverb =\listinginput= / sagetex =\sageinput= / scontents =\inputsc= (and extra =[latex].verbatim_commands=) stay atomic; inner =.!?%= do not split or comment.
   =\piton|...|= is verb-like; =\piton{...}= stays one token via the generic command argument
   =\lstinputlisting= / =\lstinputlisting*= take optional =[...]= then a ={filename}=; a flush following sentence stays on its own line
   =\inputminted= / =\inputminted*= take optional =[...]=, ={lang}=, then a ={filename}=; a flush following sentence stays on its own line
   =\VerbatimInput= / =\BVerbatimInput= / =\LVerbatimInput= take optional =[...]= then a ={filename}=; a flush following sentence stays on its own line
   =\verbatiminput= / =\verbatiminput*= take a ={filename}=; a flush following sentence stays on its own line
-  =\tcbinputlisting= takes a ={keyvals}= group; a flush following sentence stays on its own line
+  =\PitonInputFile= takes optional =<...>=, optional =[...]=, then a ={filename}=; a flush following sentence stays on its own line
+  =\PitonInputFileT= / =\PitonInputFileF= take the same optional args then ={file}= and one extra required brace; =\PitonInputFileTF= takes two extra braces; a flush following sentence stays on its own line
+  =\tcbinputlisting= takes one required ={keyval}= group; a flush following sentence stays on its own line
+  =\inputpy= / =\inputpycon= take optional =[...]= then a ={filename}=; a flush following sentence stays on its own line
+  =\inputpygments= takes optional =[...]=, ={lang}=, then a ={filename}=; =\pygment= takes ={lang}= then a delimiter or ={code}= body; a flush following sentence stays on its own line
+  =\CatchFileBetweenTags= takes ={macro}= ={file}= ={tag}=; =\CatchFileBetweenDelims= takes ={macro}= ={file}= ={start}= ={end}=; =\ExecuteMetaData= takes optional =[file]= then ={tag}=; a flush following sentence stays on its own line
+  =\listinginput= takes optional =[interval]= then ={start}= and ={filename}=; a flush following sentence stays on its own line
+  =\sageinput= takes optional =[...]= then a ={filename}=; a flush following sentence stays on its own line
+  =\inputsc= takes optional =[...]= then a ={name}=; a flush following sentence stays on its own line
 
 *** Prose regions (reflowed)
 :PROPERTIES:

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,7 +49,7 @@ pub struct FormatOverrides {
     pub structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
     /// Meaningful under `[latex]` only. Missing or empty keeps
-    /// verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/VerbatimInput/piton/verbatiminput/tcbinputlisting.
+    /// verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/VerbatimInput/piton/verbatiminput/PitonInputFile/PitonInputFileT/PitonInputFileF/PitonInputFileTF/tcbinputlisting/inputpy/inputpycon/inputpylab/inputpylabcon/inputsympy/inputsympycon/inputpygments/pygment/CatchFileBetweenTags/CatchFileBetweenDelims/ExecuteMetaData/listinginput/sageinput/inputsc.
     pub verbatim_commands: Vec<String>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,7 +147,7 @@ pub struct FormatConfig {
     /// to `NON_PROSE_ENVS`. Empty keeps the built-in list.
     pub latex_structure_envs: Vec<String>,
     /// Extra LaTeX command names tokenized like `\verb` before split.
-    /// Empty keeps verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/VerbatimInput/piton/verbatiminput/tcbinputlisting.
+    /// Empty keeps verb/lstinline/lstinputlisting/spverb/mintinline/inputminted/mint/Verb/SaveVerb/VerbatimInput/piton/verbatiminput/PitonInputFile/PitonInputFileT/PitonInputFileF/PitonInputFileTF/tcbinputlisting/inputpy/inputpycon/inputpylab/inputpylabcon/inputsympy/inputsympycon/inputpygments/pygment/CatchFileBetweenTags/CatchFileBetweenDelims/ExecuteMetaData/listinginput/sageinput/inputsc.
     pub latex_verbatim_commands: Vec<String>,
 }
 

--- a/src/parser/latex.rs
+++ b/src/parser/latex.rs
@@ -502,10 +502,15 @@ impl LatexParser {
     /// Byte offset of the first `%` that is not escaped as `\%` and is not
     /// inside `\verb` / `\lstinline` / `\spverb` / `\mintinline` / `\mint` /
     /// `\Verb` / `\SaveVerb` / `\piton` / `\lstinputlisting` /
-    /// `\inputminted` / `\verbatiminput` / `\VerbatimInput` / `\tcbinputlisting` /
-    /// `\listinginput` / `\inputpy` / `\inputpycon` / `\inputpylab` /
-    /// `\inputpylabcon` / `\inputsympy` / `\inputsympycon` / `\sageinput` /
-    /// `\inputsc` / configured verbatim commands.
+    /// `\inputminted` / `\verbatiminput` / `\VerbatimInput` /
+    /// `\tcbinputlisting` / `\PitonInputFile` / `\PitonInputFileT` /
+    /// `\PitonInputFileF` / `\PitonInputFileTF` / `\inputpy` /
+    /// `\inputpycon` / `\inputpylab` / `\inputpylabcon` /
+    /// `\inputsympy` / `\inputsympycon` / `\inputpygments` /
+    /// `\pygment` / `\CatchFileBetweenTags` /
+    /// `\CatchFileBetweenDelims` / `\ExecuteMetaData` /
+    /// `\listinginput` / `\sageinput` / `\inputsc` / configured
+    /// verbatim commands.
     fn unescaped_percent(&self, line: &str) -> Option<usize> {
         unescaped_percent_with(line, &self.extra_verbatim_commands)
     }
@@ -879,9 +884,13 @@ fn find_tex_cs(line: &str, from: usize, cs: &str) -> Option<usize> {
 /// `\iffalse` in ordinary TeX, skipping `\verb` / `\lstinline` /
 /// `\spverb` / `\mintinline` / `\mint` / `\inputminted` / `\Verb` /
 /// `\SaveVerb` / `\piton` / `\lstinputlisting` / `\verbatiminput` /
-/// `\VerbatimInput` / `\listinginput` / `\inputpy` / `\inputpycon` /
-/// `\inputpylab` / `\inputpylabcon` / `\inputsympy` / `\inputsympycon` /
-/// `\sageinput` / `\inputsc` spans.
+/// `\VerbatimInput` / `\tcbinputlisting` / `\PitonInputFile` /
+/// `\PitonInputFileT` / `\PitonInputFileF` / `\PitonInputFileTF` /
+/// `\inputpy` / `\inputpycon` / `\inputpylab` / `\inputpylabcon` /
+/// `\inputsympy` / `\inputsympycon` / `\inputpygments` / `\pygment` /
+/// `\CatchFileBetweenTags` / `\CatchFileBetweenDelims` /
+/// `\ExecuteMetaData` / `\listinginput` / `\sageinput` / `\inputsc`
+/// spans.
 fn find_iffalse_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<usize> {
     let bytes = line.as_bytes();
     let mut i = from;
@@ -968,10 +977,11 @@ fn tcbinputlisting_cs_at(line: &str, at: usize) -> bool {
 }
 
 /// Leftover piton.sty `\PitonInputFile` (optional `<...>`, optional
-/// `[...]`, required `{file}`; `d < > O { } m`; GitHub #406). Other
-/// verb spans are skipped so `\verb|\PitonInputFile{x}|` is not
-/// stolen. Walk stops at an unescaped `%` so a comment is not a
-/// command tail.
+/// `[...]`, required `{file}`; `d < > O { } m`; GitHub #406) plus
+/// siblings `\PitonInputFileT` / `\PitonInputFileF` /
+/// `\PitonInputFileTF` (GitHub #439). Other verb spans are skipped
+/// so `\verb|\PitonInputFile{x}|` is not stolen. Walk stops at an
+/// unescaped `%` so a comment is not a command tail.
 fn find_pitoninputfile_at(
     line: &str,
     from: usize,
@@ -984,10 +994,17 @@ fn pitoninputfile_cs_at(line: &str, at: usize) -> bool {
     let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
         return false;
     };
-    let Some(after) = tail.strip_prefix("PitonInputFile") else {
-        return false;
-    };
-    !after.starts_with(|c: char| c.is_ascii_alphabetic())
+    for name in [
+        "PitonInputFileTF",
+        "PitonInputFileT",
+        "PitonInputFileF",
+        "PitonInputFile",
+    ] {
+        if let Some(after) = tail.strip_prefix(name) {
+            return !after.starts_with(|c: char| c.is_ascii_alphabetic());
+        }
+    }
+    false
 }
 
 /// Leftover pythontex.sty default-family file-input (optional `[...]`,
@@ -997,7 +1014,7 @@ fn pitoninputfile_cs_at(line: &str, at: usize) -> bool {
 /// `\inputpylab` is not `\inputpy` + leftover. Other verb spans are
 /// skipped so `\verb|\inputpy{x}|` is not stolen. Walk stops at an
 /// unescaped `%` so a comment is not a command tail. `\inputpygments`
-/// is not a span (`inputpy` + alphabetic leftover).
+/// is a separate leftover (GitHub #439), not this walker.
 fn find_inputpy_at(line: &str, from: usize, extra_cmds: &[String]) -> Option<(usize, usize)> {
     find_leftover_cmd_at(line, from, extra_cmds, inputpy_cs_at)
 }
@@ -1076,6 +1093,49 @@ fn inputsc_cs_at(line: &str, at: usize) -> bool {
         return false;
     };
     !after.starts_with(|c: char| c.is_ascii_alphabetic() || c == '*')
+}
+
+/// Leftover filename-input / verbatim-input tail (GitHub #439). One
+/// leftover walker for pythontex.sty `\inputpygments` / `\pygment`
+/// and catchfilebetweentags.sty `\CatchFileBetweenTags` /
+/// `\CatchFileBetweenDelims` / `\ExecuteMetaData`. Other verb spans
+/// are skipped so `\verb|\inputpygments{python}{x}|` is not stolen.
+/// Walk stops at an unescaped `%` so a comment is not a command tail.
+/// `\inputpy` must not steal `\inputpygments`.
+fn find_leftover_filename_input_at(
+    line: &str,
+    from: usize,
+    extra_cmds: &[String],
+) -> Option<(usize, usize)> {
+    find_leftover_cmd_at(line, from, extra_cmds, leftover_filename_input_cs_at)
+}
+
+fn leftover_filename_input_cs_at(line: &str, at: usize) -> bool {
+    let Some(tail) = line.get(at..).and_then(|s| s.strip_prefix('\\')) else {
+        return false;
+    };
+    for name in [
+        "inputpygments",
+        "pygment",
+        "CatchFileBetweenTags",
+        "CatchFileBetweenDelims",
+        "ExecuteMetaData",
+    ] {
+        if let Some(after) = tail.strip_prefix(name) {
+            if after.starts_with(|c: char| c.is_ascii_alphabetic()) {
+                return false;
+            }
+            if matches!(
+                name,
+                "CatchFileBetweenTags" | "CatchFileBetweenDelims" | "ExecuteMetaData"
+            ) && after.starts_with('*')
+            {
+                return false;
+            }
+            return true;
+        }
+    }
+    false
 }
 
 fn find_leftover_cmd_at(
@@ -1851,6 +1911,13 @@ impl<'a> ParseState<'a> {
                     .or_else(|| find_listinginput_at(code, i, &self.parser.extra_verbatim_commands))
                     .or_else(|| find_sageinput_at(code, i, &self.parser.extra_verbatim_commands))
                     .or_else(|| find_inputsc_at(code, i, &self.parser.extra_verbatim_commands))
+                    .or_else(|| {
+                        find_leftover_filename_input_at(
+                            code,
+                            i,
+                            &self.parser.extra_verbatim_commands,
+                        )
+                    })
             {
                 self.append_item_or_prose(line.start + i, &code[i..start]);
                 self.push_structure(ByteSpan::new(
@@ -3020,6 +3087,172 @@ Some text.
             "prose after inputminted must still split, got:\n{minted_out}"
         );
         assert_eq!(format_text(&minted_out, &latex_cfg()).unwrap(), minted_out);
+    }
+
+    /// Ticket fixture (GitHub #439): leftover filename-input /
+    /// verbatim-input cmds stay one Structure span. Following flush
+    /// `After.` does not join. `After.` / `Next.` still split.
+    /// `\inputpy` must not steal `\inputpygments`. `\PitonInputFile`
+    /// unchanged.
+    #[test]
+    fn leftover_filename_input_does_not_join_following_prose() {
+        use crate::format_text;
+
+        let pygments = concat!(
+            "Before. Next.\n",
+            "\\inputpygments{python}{foo.py}\n",
+            "After. Next.\n",
+        );
+        let regions = LatexParser::default().parse(pygments);
+        assert!(
+            regions.iter().any(|r| matches!(
+                r,
+                Region::Structure(s) if s.contains(r"\inputpygments{python}{foo.py}")
+            )),
+            "inputpygments must stay one Structure command, got: {regions:?}"
+        );
+        assert!(
+            !regions.iter().any(|r| matches!(
+                r,
+                Region::Prose(p) if p.contains(r"\inputpygments{python}{foo.py}")
+            )),
+            "inputpygments must not leak into Prose, got: {regions:?}"
+        );
+        let pygments_out = format_text(pygments, &latex_cfg()).unwrap();
+        assert!(
+            pygments_out.contains("\\inputpygments{python}{foo.py}\n"),
+            "inputpygments must stay one atomic command, got:\n{pygments_out}"
+        );
+        assert!(
+            !pygments_out.contains("\\inputpygments{python}{foo.py} After."),
+            "following flush prose must not join the inputpygments line, got:\n{pygments_out}"
+        );
+        assert!(
+            pygments_out.contains("Before.\nNext."),
+            "prose before inputpygments must still split, got:\n{pygments_out}"
+        );
+        assert!(
+            pygments_out.contains("After.\nNext."),
+            "prose after inputpygments must still split, got:\n{pygments_out}"
+        );
+        assert_eq!(
+            format_text(&pygments_out, &latex_cfg()).unwrap(),
+            pygments_out
+        );
+
+        let pygment = concat!(
+            "Before. Next.\n",
+            "\\pygment{python}{print(1)}\n",
+            "After. Next.\n",
+        );
+        let pygment_out = format_text(pygment, &latex_cfg()).unwrap();
+        assert!(
+            pygment_out.contains("\\pygment{python}{print(1)}\n"),
+            "pygment must stay one atomic command, got:\n{pygment_out}"
+        );
+        assert!(
+            !pygment_out.contains("\\pygment{python}{print(1)} After."),
+            "pygment must not join following prose, got:\n{pygment_out}"
+        );
+        assert!(
+            pygment_out.contains("After.\nNext."),
+            "prose after pygment must still split, got:\n{pygment_out}"
+        );
+
+        let tags = concat!(
+            "Before. Next.\n",
+            "\\CatchFileBetweenTags{\\tmp}{foo.tex}{TAG}\n",
+            "After. Next.\n",
+        );
+        let tags_out = format_text(tags, &latex_cfg()).unwrap();
+        assert!(
+            tags_out.contains("\\CatchFileBetweenTags{\\tmp}{foo.tex}{TAG}\n"),
+            "CatchFileBetweenTags must stay one atomic command, got:\n{tags_out}"
+        );
+        assert!(
+            !tags_out.contains("\\CatchFileBetweenTags{\\tmp}{foo.tex}{TAG} After."),
+            "CatchFileBetweenTags must not join following prose, got:\n{tags_out}"
+        );
+
+        let delims = concat!(
+            "Before. Next.\n",
+            "\\CatchFileBetweenDelims{\\tmp}{foo.tex}{START}{END}\n",
+            "After. Next.\n",
+        );
+        let delims_out = format_text(delims, &latex_cfg()).unwrap();
+        assert!(
+            delims_out.contains("\\CatchFileBetweenDelims{\\tmp}{foo.tex}{START}{END}\n"),
+            "CatchFileBetweenDelims must stay one atomic command, got:\n{delims_out}"
+        );
+        assert!(
+            !delims_out.contains("\\CatchFileBetweenDelims{\\tmp}{foo.tex}{START}{END} After."),
+            "CatchFileBetweenDelims must not join following prose, got:\n{delims_out}"
+        );
+
+        let exec = concat!(
+            "Before. Next.\n",
+            "\\ExecuteMetaData{TAG}\n",
+            "After. Next.\n",
+        );
+        let exec_out = format_text(exec, &latex_cfg()).unwrap();
+        assert!(
+            exec_out.contains("\\ExecuteMetaData{TAG}\n"),
+            "ExecuteMetaData must stay one atomic command, got:\n{exec_out}"
+        );
+        assert!(
+            !exec_out.contains("\\ExecuteMetaData{TAG} After."),
+            "ExecuteMetaData must not join following prose, got:\n{exec_out}"
+        );
+
+        for (cmd, label) in [
+            (r"\PitonInputFileT{foo.py}{true}", "PitonInputFileT"),
+            (r"\PitonInputFileF{foo.py}{false}", "PitonInputFileF"),
+            (
+                r"\PitonInputFileTF{foo.py}{true}{false}",
+                "PitonInputFileTF",
+            ),
+        ] {
+            let input = format!("Before. Next.\n{cmd}\nAfter. Next.\n");
+            let out = format_text(&input, &latex_cfg()).unwrap();
+            assert!(
+                out.contains(&format!("{cmd}\n")),
+                "{label} must stay one atomic command, got:\n{out}"
+            );
+            assert!(
+                !out.contains(&format!("{cmd} After.")),
+                "{label} must not join following prose, got:\n{out}"
+            );
+            assert!(
+                out.contains("After.\nNext."),
+                "prose after {label} must still split, got:\n{out}"
+            );
+        }
+
+        let piton = concat!(
+            "Before. Next.\n",
+            "\\PitonInputFile{foo.py}\n",
+            "After. Next.\n",
+        );
+        let piton_out = format_text(piton, &latex_cfg()).unwrap();
+        assert!(
+            piton_out.contains("\\PitonInputFile{foo.py}\n"),
+            "PitonInputFile must stay unchanged, got:\n{piton_out}"
+        );
+        assert!(
+            !piton_out.contains("\\PitonInputFile{foo.py} After."),
+            "PitonInputFile must not join following prose, got:\n{piton_out}"
+        );
+
+        let py = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+        let py_out = format_text(py, &latex_cfg()).unwrap();
+        assert!(
+            py_out.contains("\\inputpy{foo.py}\n"),
+            "inputpy must stay unchanged, got:\n{py_out}"
+        );
+        assert!(
+            !py_out.contains("\\inputpy{foo.py} After."),
+            "inputpy must not join following prose, got:\n{py_out}"
+        );
     }
 
     /// Ticket fixture (GitHub #245): minted `\mintinline{lang}|body|` is

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -202,11 +202,19 @@ pub fn protect_inline_tokens_with(
 /// `\SaveVerb{name}|...|` / `\piton|...|` /
 /// `\lstinputlisting[...]{file}` /
 /// `\verbatiminput{file}` / `\VerbatimInput[...]{file}` /
-/// `\listinginput[interval]{start}{file}` /
+/// `\PitonInputFile<...>[...]{file}` /
+/// `\PitonInputFileT` / `\PitonInputFileF` / `\PitonInputFileTF` /
+/// `\tcbinputlisting{keyvals}` /
 /// `\inputpy[...]{file}` / `\inputpycon[...]{file}` /
 /// `\inputpylab[...]{file}` / `\inputpylabcon[...]{file}` /
 /// `\inputsympy[...]{file}` / `\inputsympycon[...]{file}` /
-/// `\sageinput{file}` / `\inputsc[...]{name}` so inner `.!?%` cannot
+/// `\inputpygments[...]{lang}{file}` / `\pygment{lang}{code}` /
+/// `\CatchFileBetweenTags{macro}{file}{tag}` /
+/// `\CatchFileBetweenDelims{macro}{file}{start}{end}` /
+/// `\ExecuteMetaData[...]{tag}` /
+/// `\listinginput[interval]{start}{file}` /
+/// `\sageinput[...]{file}` /
+/// `\inputsc[...]{name}` so inner `.!?%` cannot
 /// split or comment. `\piton{...}` stays on the generic `\cmd{arg}`
 /// path (piton.sty brace syntax is not verbatim; GitHub #305).
 fn protect_latex_verbatim(
@@ -234,10 +242,15 @@ fn protect_latex_verbatim(
 
 /// Byte end of a `\verb` / `\lstinline` / `\spverb` / `\mintinline` /
 /// `\mint` / `\inputminted` / `\Verb` / `\SaveVerb` / `\piton` /
-/// `\lstinputlisting` / `\VerbatimInput` / `\BVerbatimInput` /
-/// `\LVerbatimInput` / `\listinginput` / `\inputpy` / `\inputpycon` /
-/// `\inputpylab` / `\inputpylabcon` / `\inputsympy` / `\inputsympycon` /
-/// `\sageinput` / `\inputsc` / extra-name span starting at `at`.
+/// `\lstinputlisting` / `\verbatiminput` / `\VerbatimInput` /
+/// `\BVerbatimInput` / `\LVerbatimInput` / `\PitonInputFile` /
+/// `\PitonInputFileT` / `\PitonInputFileF` / `\PitonInputFileTF` /
+/// `\tcbinputlisting` / `\inputpy` / `\inputpycon` /
+/// `\inputpylab` / `\inputpylabcon` / `\inputsympy` /
+/// `\inputsympycon` / `\inputpygments` / `\pygment` /
+/// `\CatchFileBetweenTags` / `\CatchFileBetweenDelims` /
+/// `\ExecuteMetaData` / `\listinginput` / `\sageinput` / `\inputsc` /
+/// extra-name span starting at `at`.
 ///
 /// `\verb` / `\verb*` / `\spverb` / `\spverb*` / `\Verb` / `\Verb*`: next
 /// character is the
@@ -255,28 +268,42 @@ fn protect_latex_verbatim(
 /// delimiter so `\piton{...}` stays on the generic `\cmd{arg}` path.
 /// `\lstinputlisting` / `\lstinputlisting*` (listings.sty leftover;
 /// GitHub #391) take optional `[...]` then a required `{filename}`;
-/// no brace is not a span. `\VerbatimInput` / `\BVerbatimInput` /
-/// `\LVerbatimInput` (fancyvrb.sty leftover; GitHub #399) use the same
-/// optional `[...]` then `{filename}` walk. Matched before `\Verb` so
-/// `\VerbatimInput` is not `\Verb` plus leftover letters. `\inputpy` /
+/// no brace is not a span. `\verbatiminput` / `\verbatiminput*`
+/// (tools/verbatim.sty leftover; GitHub #398) take a required
+/// `{filename}`; no brace is not a span. fancyvrb `\VerbatimInput` /
+/// `\BVerbatimInput` / `\LVerbatimInput` (and stars; `FV@Command`;
+/// GitHub #399) use the same optional `[...]` then `{filename}` walk.
+/// Matched before `\Verb` so `\VerbatimInput` is not rejected as
+/// `\Verb` + leftover. `\tcbinputlisting` (tcolorbox leftover;
+/// GitHub #400) takes one required `{keyval}` group; no optional
+/// `[...]` and no brace is not a span. `\PitonInputFile` (piton.sty
+/// leftover; `d < > O { } m`; GitHub #406) takes optional `<...>`,
+/// optional `[...]`, then a required `{filename}`; no brace is not a
+/// span. `\PitonInputFileT` / `\PitonInputFileF` (`d < > O { } m m`)
+/// and `\PitonInputFileTF` (`d < > O { } m m m`; GitHub #439) take the
+/// same optional args then extra required braces. `\inputpy` /
 /// `\inputpycon` / `\inputpylab` / `\inputpylabcon` / `\inputsympy` /
 /// `\inputsympycon` (pythontex.sty leftover; GitHub #419 / #433) take
 /// optional `[...]` then a required `{filename}`; no brace is not a
 /// span. Longer names first so `\inputpylab` is not `\inputpy` +
-/// leftover. `\inputpygments` is not a span (`inputpy` +
-/// alphabetic leftover). `\listinginput` (moreverb leftover; GitHub
-/// #424) takes optional `[interval]` then required `{start-line}` and
-/// `{filename}`; no second brace is not a span. There is no `*` form.
-/// `\sageinput` (sagetex leftover; GitHub #428) takes a required
-/// `{filename}`; no brace is not a span. `\sage` / `\sageplot` /
-/// `\sagestr` are not this name. There is no `*` form.
-/// `\inputsc` (scontents leftover sequence replay; GitHub #437)
-/// takes optional `[...]` then a required `{name}`; no brace is not
-/// a span. There is no `*` form. `\input` / `\inputpy` are not this
-/// name.
-/// Extra names are tokenized like `\verb`. With
-/// no closer, the span runs to end of line so an inner `%` is not a
-/// comment.
+/// leftover. `\inputpygments` (pythontex.sty leftover; GitHub #439)
+/// is its own span (same `{lang}` then `{file}` walk as
+/// `\inputminted`), not `inputpy` + leftover. `\pygment` takes
+/// `{lang}` then a delimiter or `{code}` body. `\CatchFileBetweenTags`
+/// takes three required braces; `\CatchFileBetweenDelims` takes four
+/// then optional `[setup]`; `\ExecuteMetaData` takes optional `[file]`
+/// then `{tag}`. `\listinginput` (moreverb
+/// leftover; GitHub #424) takes optional `[interval]` then required
+/// `{start-line}` and `{filename}`; no second brace is not a span.
+/// There is no `*` form. `\sageinput` (sagetex leftover; GitHub #428)
+/// takes optional `[...]` then a required `{filename}`; no brace is
+/// not a span. Alphabetic leftover rejects a longer name. `\sage` is
+/// a different, shorter name and is not this span. `\inputsc`
+/// (scontents leftover sequence replay; GitHub #437) takes optional
+/// `[...]` then a required `{name}`; no brace is not a span. There
+/// is no `*` form. `\input` / `\inputpy` are not this name. Extra
+/// names are tokenized like `\verb`. With no closer, the span runs
+/// to end of line so an inner `%` is not a comment.
 pub(crate) fn latex_verb_span_end_with(
     text: &str,
     at: usize,
@@ -301,10 +328,26 @@ pub(crate) fn latex_verb_span_end_with(
             return None;
         }
         (after_bs + "inputminted".len(), VerbKind::Mint)
-    } else if let Some(name_len) = inputpy_cmd_len(tail) {
+    } else if let Some(stripped) = tail.strip_prefix("inputpygments") {
+        // pythontex.sty leftover (GitHub #439). Same `{lang}` + file
+        // walk as inputminted. Matched before inputpy so this name
+        // is not rejected as inputpy + leftover.
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (after_bs + "inputpygments".len(), VerbKind::Mint)
+    } else if let Some(stripped) = tail.strip_prefix("pygment") {
+        // pythontex.sty leftover (GitHub #439). `{lang}` then body
+        // like mint. Alphabetic leftover rejects pygments.
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
+            return None;
+        }
+        (after_bs + "pygment".len(), VerbKind::Mint)
+    } else if let Some(name) = inputpy_cs_name(tail) {
         // pythontex.sty leftover file-input (GitHub #419 / #433).
-        // Longer names first; `\inputpygments` is not a span.
-        (after_bs + name_len, VerbKind::Lstinputlisting)
+        // Longer names first. Same optional `[...]` then `{file}`
+        // walk as `\lstinputlisting`.
+        (after_bs + name.len(), VerbKind::Lstinputlisting)
     } else if let Some(stripped) = tail.strip_prefix("listinginput") {
         // moreverb leftover file-input (GitHub #424). No `*` form;
         // alphabetic tail rejects a longer name.
@@ -328,6 +371,36 @@ pub(crate) fn latex_verb_span_end_with(
             return None;
         }
         (after_bs + "inputsc".len(), VerbKind::Lstinputlisting)
+    } else if let Some(stripped) = tail.strip_prefix("CatchFileBetweenDelims") {
+        // catchfilebetweentags.sty leftover (GitHub #439). Four
+        // required braces, optional trailing `[setup]`. No `*` form.
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic() || c == '*') {
+            return None;
+        }
+        (
+            after_bs + "CatchFileBetweenDelims".len(),
+            VerbKind::CatchFileBetweenDelims,
+        )
+    } else if let Some(stripped) = tail.strip_prefix("CatchFileBetweenTags") {
+        // catchfilebetweentags.sty leftover (GitHub #439). Three
+        // required braces, optional trailing `[setup]`. No `*` form.
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic() || c == '*') {
+            return None;
+        }
+        (
+            after_bs + "CatchFileBetweenTags".len(),
+            VerbKind::CatchFileBetweenTags,
+        )
+    } else if let Some(stripped) = tail.strip_prefix("ExecuteMetaData") {
+        // catchfilebetweentags.sty leftover (GitHub #439). Optional
+        // `[file]` then required `{tag}`. No `*` form.
+        if stripped.starts_with(|c: char| c.is_ascii_alphabetic() || c == '*') {
+            return None;
+        }
+        (
+            after_bs + "ExecuteMetaData".len(),
+            VerbKind::Lstinputlisting,
+        )
     } else if let Some(stripped) = tail.strip_prefix("lstinputlisting") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -350,13 +423,11 @@ pub(crate) fn latex_verb_span_end_with(
             after_bs + "tcbinputlisting".len(),
             VerbKind::Tcbinputlisting,
         )
-    } else if let Some(stripped) = tail.strip_prefix("PitonInputFile") {
-        // Before `piton` so the longer leftover name is not `\piton`
-        // + alphabetic leftover (GitHub #406).
-        if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
-            return None;
-        }
-        (after_bs + "PitonInputFile".len(), VerbKind::PitonInputFile)
+    } else if let Some((name, kind)) = pitoninputfile_cs_name(tail) {
+        // Longer leftover name, case-distinct from `\piton` (GitHub
+        // #406). T / F / TF siblings (GitHub #439) before the base
+        // name so they are not alphabetic leftover.
+        (after_bs + name.len(), kind)
     } else if let Some(stripped) = tail.strip_prefix("lstinline") {
         if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
             return None;
@@ -479,8 +550,12 @@ pub(crate) fn latex_verb_span_end_with(
 
     // piton.sty `\PitonInputFile<spec>[opts]{file}` (`d < > O { } m`;
     // GitHub #406). Optional angle then optional brackets, then a
-    // required brace file arg. No brace is not a span.
-    if kind == VerbKind::PitonInputFile {
+    // required brace file arg. T / F take one extra brace; TF takes
+    // two (GitHub #439). No brace is not a span.
+    if matches!(
+        kind,
+        VerbKind::PitonInputFile | VerbKind::PitonInputFileT | VerbKind::PitonInputFileTF
+    ) {
         i = skip_ascii_ws(text, i);
         if text.get(i..).is_some_and(|s| s.starts_with('<')) {
             match skip_angle_group(text, i) {
@@ -494,11 +569,36 @@ pub(crate) fn latex_verb_span_end_with(
                 None => return Some(line_end(text, i)),
             }
         }
-        if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
+        let extra = match kind {
+            VerbKind::PitonInputFileTF => 2,
+            VerbKind::PitonInputFileT => 1,
+            _ => 0,
+        };
+        return skip_required_brace_groups(text, i, 1 + extra);
+    }
+
+    // catchfilebetweentags.sty leftover (GitHub #439). Tags is three
+    // required braces; Delims is four. Optional trailing `[setup]`.
+    // A missing required brace is not a span.
+    if matches!(
+        kind,
+        VerbKind::CatchFileBetweenTags | VerbKind::CatchFileBetweenDelims
+    ) {
+        let n = match kind {
+            VerbKind::CatchFileBetweenDelims => 4,
+            _ => 3,
+        };
+        let Some(end) = skip_required_brace_groups(text, i, n) else {
             return None;
+        };
+        i = skip_ascii_ws(text, end);
+        if text.get(i..).is_some_and(|s| s.starts_with('[')) {
+            return match skip_bracket_group(text, i) {
+                Some(close) => Some(close),
+                None => Some(line_end(text, i)),
+            };
         }
-        i += 1;
-        return Some(find_unescaped_brace_close(text, i).unwrap_or_else(|| line_end(text, i)));
+        return Some(end);
     }
 
     if kind == VerbKind::Mint {
@@ -555,10 +655,11 @@ enum VerbKind {
     Delim,
     /// `\lstinline`: optional `[...]` then delimiter or `{...}`.
     Lstinline,
-    /// `\lstinputlisting` / `\VerbatimInput` / `\BVerbatimInput` /
-    /// `\LVerbatimInput` / `\inputpy` / `\inputpycon` / `\inputpylab` /
-    /// `\inputpylabcon` / `\inputsympy` / `\inputsympycon` / `\inputsc`:
-    /// optional `[...]` then required `{filename}` / `{name}`.
+    /// `\lstinputlisting` / fancyvrb `\VerbatimInput` family /
+    /// `\inputpy` / `\inputpycon` / `\inputpylab` / `\inputpylabcon` /
+    /// `\inputsympy` / `\inputsympycon` / `\sageinput` / `\inputsc` /
+    /// `\ExecuteMetaData`: optional `[...]` then required `{filename}`
+    /// / `{name}` / `{tag}`.
     Lstinputlisting,
     /// `\\verbatiminput`: required `{filename}` (verbatim.sty leftover).
     Verbatiminput,
@@ -572,8 +673,20 @@ enum VerbKind {
     /// `\PitonInputFile`: optional `<...>`, optional `[...]`, required
     /// `{filename}` (piton.sty leftover; GitHub #406).
     PitonInputFile,
-    /// `\mintinline` / `\mint` / `\inputminted`: optional `[...]`,
-    /// `{lang}`, then body.
+    /// `\PitonInputFileT` / `\PitonInputFileF`: same optional args,
+    /// `{file}`, then one extra required brace (GitHub #439).
+    PitonInputFileT,
+    /// `\PitonInputFileTF`: same optional args, `{file}`, then two
+    /// extra required braces (GitHub #439).
+    PitonInputFileTF,
+    /// `\CatchFileBetweenTags`: three required braces, optional
+    /// trailing `[setup]` (catchfilebetweentags leftover; GitHub #439).
+    CatchFileBetweenTags,
+    /// `\CatchFileBetweenDelims`: four required braces, optional
+    /// trailing `[setup]` (catchfilebetweentags leftover; GitHub #439).
+    CatchFileBetweenDelims,
+    /// `\mintinline` / `\mint` / `\inputminted` / `\inputpygments` /
+    /// `\pygment`: optional `[...]`, `{lang}`, then body.
     Mint,
     /// `\SaveVerb`: optional `[...]`, `{name}`, then delimiter body like `\Verb`.
     SaveVerb,
@@ -605,8 +718,8 @@ fn verbatiminput_cs_name(tail: &str) -> Option<&'static str> {
 /// pythontex.sty leftover default-family file-input (optional `[...]`,
 /// required `{file}`; GitHub #419 / #433). Longer names first so
 /// `\inputpylab` / `\inputpycon` are not `\inputpy` + leftover.
-/// `\inputpygments` is rejected as `inputpy` + alphabetic leftover.
-fn inputpy_cmd_len(tail: &str) -> Option<usize> {
+/// `\inputpygments` is a separate leftover matched before this family.
+fn inputpy_cs_name(tail: &str) -> Option<&'static str> {
     for name in [
         "inputpylabcon",
         "inputsympycon",
@@ -615,11 +728,29 @@ fn inputpy_cmd_len(tail: &str) -> Option<usize> {
         "inputsympy",
         "inputpy",
     ] {
-        if let Some(stripped) = tail.strip_prefix(name) {
-            if stripped.starts_with(|c: char| c.is_ascii_alphabetic()) {
-                return None;
+        if let Some(after) = tail.strip_prefix(name) {
+            if !after.starts_with(|c: char| c.is_ascii_alphabetic()) {
+                return Some(name);
             }
-            return Some(name.len());
+        }
+    }
+    None
+}
+
+/// piton.sty leftover `\PitonInputFile` family (GitHub #406 / #439).
+/// Longer T / F / TF names first so they are not the base name plus
+/// alphabetic leftover.
+fn pitoninputfile_cs_name(tail: &str) -> Option<(&'static str, VerbKind)> {
+    for (name, kind) in [
+        ("PitonInputFileTF", VerbKind::PitonInputFileTF),
+        ("PitonInputFileT", VerbKind::PitonInputFileT),
+        ("PitonInputFileF", VerbKind::PitonInputFileT),
+        ("PitonInputFile", VerbKind::PitonInputFile),
+    ] {
+        if let Some(after) = tail.strip_prefix(name) {
+            if !after.starts_with(|c: char| c.is_ascii_alphabetic()) {
+                return Some((name, kind));
+            }
         }
     }
     None
@@ -637,6 +768,8 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "spverb"
             || name == "mintinline"
             || name == "inputminted"
+            || name == "inputpygments"
+            || name == "pygment"
             || name == "inputpy"
             || name == "inputpycon"
             || name == "inputpylab"
@@ -647,7 +780,10 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "verbatiminput"
             || name == "tcbinputlisting"
             || name == "listinginput"
-            || name == "PitonInputFile"
+            || name == "sageinput"
+            || name == "CatchFileBetweenTags"
+            || name == "CatchFileBetweenDelims"
+            || name == "ExecuteMetaData"
             || name == "mint"
             || name == "Verb"
             || name == "SaveVerb"
@@ -655,6 +791,10 @@ fn match_extra_verb_command<'a>(tail: &'a str, extras: &'a [String]) -> Option<&
             || name == "BVerbatimInput"
             || name == "LVerbatimInput"
             || name == "piton"
+            || name == "PitonInputFile"
+            || name == "PitonInputFileT"
+            || name == "PitonInputFileF"
+            || name == "PitonInputFileTF"
         {
             continue;
         }
@@ -676,6 +816,23 @@ fn skip_ascii_ws(text: &str, mut i: usize) -> usize {
         i += 1;
     }
     i
+}
+
+/// `n` required `{...}` groups. Missing a group is not a span.
+/// An unclosed group runs to end of line.
+fn skip_required_brace_groups(text: &str, mut i: usize, n: usize) -> Option<usize> {
+    for _ in 0..n {
+        i = skip_ascii_ws(text, i);
+        if !text.get(i..).is_some_and(|s| s.starts_with('{')) {
+            return None;
+        }
+        i += 1;
+        match find_unescaped_brace_close(text, i) {
+            Some(end) => i = end,
+            None => return Some(line_end(text, i)),
+        }
+    }
+    Some(i)
 }
 
 /// xparse `d < >` optional delimited argument (piton.sty
@@ -2778,7 +2935,7 @@ mod tests {
         );
         assert_eq!(
             latex_verb_span_end_with(r"\inputpygments{python}{foo.py}", 0, &[]),
-            None,
+            Some(r"\inputpygments{python}{foo.py}".len()),
             "inputpy must not steal inputpygments"
         );
         assert_eq!(
@@ -2869,7 +3026,7 @@ mod tests {
         );
         assert_eq!(
             latex_verb_span_end_with(r"\inputpygments{python}{foo.py}", 0, &[]),
-            None,
+            Some(r"\inputpygments{python}{foo.py}".len()),
             "inputpylab must not steal inputpygments"
         );
     }
@@ -3016,6 +3173,237 @@ mod tests {
             latex_verb_span_end_with(r"\lstinputlisting{foo.py}", 0, &[]),
             Some(r"\lstinputlisting{foo.py}".len()),
             "listinginput must not steal lstinputlisting"
+        );
+    }
+
+    /// Ticket fixture (GitHub #439): pythontex.sty `\inputpygments`
+    /// / `\pygment` stay one leftover command; following `After.`
+    /// still splits. Tokenized like inputminted. extras skip so a
+    /// configured extra does not re-tokenize the no-brace form as
+    /// Delim. inputpy / inputminted unchanged.
+    #[test]
+    fn latex_inputpygments_pygment_stay_atomic() {
+        let cmd = r"\inputpygments{python}{foo.py}";
+        let text = r"See \inputpygments{python}{foo.py} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == cmd),
+            "inputpygments span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(latex_verb_span_end_with(cmd, 0, &[]), Some(cmd.len()));
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \inputpygments{python}{foo.py} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpygments[linenos]{python}{foo.py}", 0, &[]),
+            Some(r"\inputpygments[linenos]{python}{foo.py}".len()),
+            "inputpygments optional args must stay in the span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpygments foo.py", 0, &[]),
+            None,
+            "inputpygments without a {{lang}} arg is not a verb span"
+        );
+        let extras = ["inputpygments".to_string()];
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpygments foo.py", 0, &extras),
+            None,
+            "configured extra inputpygments must not re-tokenize the no-brace form as Delim"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(cmd, 0, &extras),
+            Some(cmd.len()),
+            "configured extra inputpygments must keep the brace form as leftover"
+        );
+
+        let pygment = r"\pygment{python}{print(1)}";
+        assert_eq!(
+            latex_verb_span_end_with(pygment, 0, &[]),
+            Some(pygment.len()),
+            "pygment {{lang}}{{code}} must stay one span"
+        );
+        assert_eq!(
+            split(r"See \pygment{python}{print(1)} here. After."),
+            vec![
+                r"See \pygment{python}{print(1)} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\pygment{python}|print(1)|", 0, &[]),
+            Some(r"\pygment{python}|print(1)|".len()),
+            "pygment delimiter body must stay in the span"
+        );
+        let pygment_extras = ["pygment".to_string()];
+        assert_eq!(
+            latex_verb_span_end_with(r"\pygment python", 0, &pygment_extras),
+            None,
+            "configured extra pygment must not re-tokenize the no-brace form as Delim"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\pygments{python}{print(1)}", 0, &[]),
+            None,
+            "pygment must not steal pygments"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputpy{foo.py}", 0, &[]),
+            Some(r"\inputpy{foo.py}".len()),
+            "inputpygments must not steal inputpy"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\inputminted{python}{foo.py}", 0, &[]),
+            Some(r"\inputminted{python}{foo.py}".len()),
+            "inputpygments must not steal inputminted"
+        );
+    }
+
+    /// Ticket fixture (GitHub #439): catchfilebetweentags leftover
+    /// commands stay one span; following `After.` still splits.
+    /// extras skip the no-brace form.
+    #[test]
+    fn latex_catchfile_cmds_stay_atomic() {
+        let tags = r"\CatchFileBetweenTags{\tmp}{foo.tex}{TAG}";
+        let text = r"See \CatchFileBetweenTags{\tmp}{foo.tex}{TAG} here. After.";
+        let (_, placeholders) = protect_inline_tokens(text);
+        assert!(
+            placeholders.iter().any(|p| p == tags),
+            "CatchFileBetweenTags span must be protected, got {placeholders:?}"
+        );
+        assert_eq!(latex_verb_span_end_with(tags, 0, &[]), Some(tags.len()));
+        assert_eq!(
+            split(text),
+            vec![
+                r"See \CatchFileBetweenTags{\tmp}{foo.tex}{TAG} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        let delims = r"\CatchFileBetweenDelims{\tmp}{foo.tex}{START}{END}";
+        assert_eq!(
+            latex_verb_span_end_with(delims, 0, &[]),
+            Some(delims.len()),
+            "CatchFileBetweenDelims four braces must stay one span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(
+                r"\CatchFileBetweenDelims{\tmp}{foo.tex}{START}{END}[\makeatletter]",
+                0,
+                &[]
+            ),
+            Some(r"\CatchFileBetweenDelims{\tmp}{foo.tex}{START}{END}[\makeatletter]".len()),
+            "CatchFileBetweenDelims optional setup must stay in the span"
+        );
+        let exec = r"\ExecuteMetaData{TAG}";
+        assert_eq!(latex_verb_span_end_with(exec, 0, &[]), Some(exec.len()));
+        assert_eq!(
+            latex_verb_span_end_with(r"\ExecuteMetaData[foo.tex]{TAG}", 0, &[]),
+            Some(r"\ExecuteMetaData[foo.tex]{TAG}".len()),
+            "ExecuteMetaData optional file must stay in the span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\CatchFileBetweenTags foo.tex", 0, &[]),
+            None,
+            "CatchFileBetweenTags without braces is not a verb span"
+        );
+        let extras = ["CatchFileBetweenTags".to_string()];
+        assert_eq!(
+            latex_verb_span_end_with(r"\CatchFileBetweenTags foo.tex", 0, &extras),
+            None,
+            "configured extra CatchFileBetweenTags must not re-tokenize the no-brace form as Delim"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(tags, 0, &extras),
+            Some(tags.len()),
+            "configured extra CatchFileBetweenTags must keep the brace form as leftover"
+        );
+        let exec_extras = ["ExecuteMetaData".to_string()];
+        assert_eq!(
+            latex_verb_span_end_with(r"\ExecuteMetaData TAG", 0, &exec_extras),
+            None,
+            "configured extra ExecuteMetaData must not re-tokenize the no-brace form as Delim"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\CatchFileBetweenTags*{\tmp}{foo.tex}{TAG}", 0, &[]),
+            None,
+            "CatchFileBetweenTags has no star form"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\ExecuteMetaData*{TAG}", 0, &[]),
+            None,
+            "ExecuteMetaData has no star form"
+        );
+    }
+
+    /// Ticket fixture (GitHub #439): piton.sty `\PitonInputFileT` /
+    /// `\PitonInputFileF` / `\PitonInputFileTF` stay one leftover
+    /// span. `\PitonInputFile` unchanged. extras skip the no-brace
+    /// form.
+    #[test]
+    fn latex_pitoninputfile_siblings_stay_atomic() {
+        let t = r"\PitonInputFileT{foo.py}{true}";
+        assert_eq!(
+            latex_verb_span_end_with(t, 0, &[]),
+            Some(t.len()),
+            "PitonInputFileT must stay one span"
+        );
+        assert_eq!(
+            split(r"See \PitonInputFileT{foo.py}{true} here. After."),
+            vec![
+                r"See \PitonInputFileT{foo.py}{true} here.".to_string(),
+                "After.".to_string()
+            ]
+        );
+        let f = r"\PitonInputFileF{foo.py}{false}";
+        assert_eq!(latex_verb_span_end_with(f, 0, &[]), Some(f.len()));
+        let tf = r"\PitonInputFileTF{foo.py}{true}{false}";
+        assert_eq!(latex_verb_span_end_with(tf, 0, &[]), Some(tf.len()));
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFileT<python>{foo.py}{true}", 0, &[]),
+            Some(r"\PitonInputFileT<python>{foo.py}{true}".len()),
+            "PitonInputFileT optional angle must stay in the span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(
+                r"\PitonInputFileTF<1-10>[language=python]{foo.py}{t}{f}",
+                0,
+                &[]
+            ),
+            Some(r"\PitonInputFileTF<1-10>[language=python]{foo.py}{t}{f}".len()),
+            "PitonInputFileTF d<> plus optional args must stay one span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFile{foo.py}", 0, &[]),
+            Some(r"\PitonInputFile{foo.py}".len()),
+            "PitonInputFile must stay a span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFileT foo.py", 0, &[]),
+            None,
+            "PitonInputFileT without a brace file arg is not a verb span"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFileT{foo.py}", 0, &[]),
+            None,
+            "PitonInputFileT without the extra brace is not a verb span"
+        );
+        let extras = ["PitonInputFileT".to_string()];
+        assert_eq!(
+            latex_verb_span_end_with(r"\PitonInputFileT foo.py", 0, &extras),
+            None,
+            "configured extra PitonInputFileT must not re-tokenize the no-brace form as Delim"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(t, 0, &extras),
+            Some(t.len()),
+            "configured extra PitonInputFileT must keep the brace form as leftover"
+        );
+        assert_eq!(
+            latex_verb_span_end_with(r"\piton|done. Next|", 0, &[]),
+            Some(r"\piton|done. Next|".len()),
+            "PitonInputFileT must not steal piton"
         );
     }
 

--- a/src/sentence/unicode.rs
+++ b/src/sentence/unicode.rs
@@ -588,9 +588,7 @@ pub(crate) fn latex_verb_span_end_with(
             VerbKind::CatchFileBetweenDelims => 4,
             _ => 3,
         };
-        let Some(end) = skip_required_brace_groups(text, i, n) else {
-            return None;
-        };
+        let end = skip_required_brace_groups(text, i, n)?;
         i = skip_ascii_ws(text, end);
         if text.get(i..).is_some_and(|s| s.starts_with('[')) {
             return match skip_bracket_group(text, i) {

--- a/tests/latex_verbatim_envs.rs
+++ b/tests/latex_verbatim_envs.rs
@@ -84,6 +84,11 @@
 //! following flush prose does not join the command line.
 //! GitHub #437: scontents.sty \\inputsc is one leftover command;
 //! following flush prose does not join the command line.
+//! GitHub #439: leftover filename-input / verbatim-input cmds
+//! (\\inputpygments / \\pygment / \\CatchFileBetweenTags /
+//! \\CatchFileBetweenDelims / \\ExecuteMetaData /
+//! \\PitonInputFileT / \\PitonInputFileF / \\PitonInputFileTF)
+//! stay one atomic command; following flush prose does not join.
 
 use snapper_fmt::format::Format;
 use snapper_fmt::parser::latex::LatexParser;
@@ -4285,5 +4290,192 @@ fn inputsc_fixture_does_not_join_following_prose() {
     assert!(
         !listing_out.contains("\\listinginput{1}{foo.py} After."),
         "listinginput must not join following prose, got:\n{listing_out}"
+    );
+}
+
+/// Ticket fixture (GitHub #439): leftover filename-input /
+/// verbatim-input cmds stay one atomic command. Following flush
+/// `After.` does not join. `After.` / `Next.` still split.
+/// `\inputpy` must not steal `\inputpygments`. `\PitonInputFile`
+/// unchanged.
+#[test]
+fn leftover_filename_input_fixture_does_not_join_following_prose() {
+    let input = concat!(
+        "Before. Next.\n",
+        "\\inputpygments{python}{foo.py}\n",
+        "After. Next.\n",
+    );
+    let regions = LatexParser::default().parse(input);
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Structure(s) if s.contains(r"\inputpygments{python}{foo.py}")
+        )),
+        "inputpygments must stay one Structure command, got: {regions:?}"
+    );
+    assert!(
+        !regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains(r"\inputpygments{python}{foo.py}")
+        )),
+        "inputpygments must not leak into Prose, got: {regions:?}"
+    );
+    assert!(
+        regions.iter().any(|r| matches!(
+            r,
+            Region::Prose(p) if p.contains("After.") && p.contains("Next.")
+        )),
+        "After. / Next. must stay Prose, got: {regions:?}"
+    );
+    let out = format_text(input, &latex_cfg()).unwrap();
+    assert!(
+        out.contains("\\inputpygments{python}{foo.py}\n"),
+        "inputpygments must stay one atomic command, got:\n{out}"
+    );
+    assert!(
+        !out.contains("\\inputpygments{python}{foo.py} After."),
+        "following flush prose must not join the command line, got:\n{out}"
+    );
+    assert!(
+        out.contains("Before.\nNext."),
+        "prose before inputpygments must still split, got:\n{out}"
+    );
+    assert!(
+        out.contains("After.\nNext."),
+        "prose after inputpygments must still split, got:\n{out}"
+    );
+    assert_eq!(format_text(&out, &latex_cfg()).unwrap(), out);
+
+    let pygment = concat!(
+        "Before. Next.\n",
+        "\\pygment{python}{print(1)}\n",
+        "After. Next.\n",
+    );
+    let pygment_out = format_text(pygment, &latex_cfg()).unwrap();
+    assert!(
+        pygment_out.contains("\\pygment{python}{print(1)}\n"),
+        "pygment must stay one atomic command, got:\n{pygment_out}"
+    );
+    assert!(
+        !pygment_out.contains("\\pygment{python}{print(1)} After."),
+        "pygment must not join following prose, got:\n{pygment_out}"
+    );
+    assert!(
+        pygment_out.contains("After.\nNext."),
+        "prose after pygment must still split, got:\n{pygment_out}"
+    );
+
+    let tags = concat!(
+        "Before. Next.\n",
+        "\\CatchFileBetweenTags{\\tmp}{foo.tex}{TAG}\n",
+        "After. Next.\n",
+    );
+    let tags_out = format_text(tags, &latex_cfg()).unwrap();
+    assert!(
+        tags_out.contains("\\CatchFileBetweenTags{\\tmp}{foo.tex}{TAG}\n"),
+        "CatchFileBetweenTags must stay one atomic command, got:\n{tags_out}"
+    );
+    assert!(
+        !tags_out.contains("\\CatchFileBetweenTags{\\tmp}{foo.tex}{TAG} After."),
+        "CatchFileBetweenTags must not join following prose, got:\n{tags_out}"
+    );
+    assert!(
+        tags_out.contains("After.\nNext."),
+        "prose after CatchFileBetweenTags must still split, got:\n{tags_out}"
+    );
+
+    let delims = concat!(
+        "Before. Next.\n",
+        "\\CatchFileBetweenDelims{\\tmp}{foo.tex}{START}{END}\n",
+        "After. Next.\n",
+    );
+    let delims_out = format_text(delims, &latex_cfg()).unwrap();
+    assert!(
+        delims_out.contains("\\CatchFileBetweenDelims{\\tmp}{foo.tex}{START}{END}\n"),
+        "CatchFileBetweenDelims must stay one atomic command, got:\n{delims_out}"
+    );
+    assert!(
+        !delims_out.contains("\\CatchFileBetweenDelims{\\tmp}{foo.tex}{START}{END} After."),
+        "CatchFileBetweenDelims must not join following prose, got:\n{delims_out}"
+    );
+
+    let exec = concat!(
+        "Before. Next.\n",
+        "\\ExecuteMetaData{TAG}\n",
+        "After. Next.\n",
+    );
+    let exec_out = format_text(exec, &latex_cfg()).unwrap();
+    assert!(
+        exec_out.contains("\\ExecuteMetaData{TAG}\n"),
+        "ExecuteMetaData must stay one atomic command, got:\n{exec_out}"
+    );
+    assert!(
+        !exec_out.contains("\\ExecuteMetaData{TAG} After."),
+        "ExecuteMetaData must not join following prose, got:\n{exec_out}"
+    );
+
+    let exec_file = concat!(
+        "Before. Next.\n",
+        "\\ExecuteMetaData[foo.tex]{TAG}\n",
+        "After. Next.\n",
+    );
+    let exec_file_out = format_text(exec_file, &latex_cfg()).unwrap();
+    assert!(
+        exec_file_out.contains("\\ExecuteMetaData[foo.tex]{TAG}\n"),
+        "ExecuteMetaData optional file must stay atomic, got:\n{exec_file_out}"
+    );
+    assert!(
+        !exec_file_out.contains("\\ExecuteMetaData[foo.tex]{TAG} After."),
+        "optional-file ExecuteMetaData must not join following prose, got:\n{exec_file_out}"
+    );
+
+    for (cmd, label) in [
+        (r"\PitonInputFileT{foo.py}{true}", "PitonInputFileT"),
+        (r"\PitonInputFileF{foo.py}{false}", "PitonInputFileF"),
+        (
+            r"\PitonInputFileTF{foo.py}{true}{false}",
+            "PitonInputFileTF",
+        ),
+    ] {
+        let sib = format!("Before. Next.\n{cmd}\nAfter. Next.\n");
+        let sib_out = format_text(&sib, &latex_cfg()).unwrap();
+        assert!(
+            sib_out.contains(&format!("{cmd}\n")),
+            "{label} must stay one atomic command, got:\n{sib_out}"
+        );
+        assert!(
+            !sib_out.contains(&format!("{cmd} After.")),
+            "{label} must not join following prose, got:\n{sib_out}"
+        );
+        assert!(
+            sib_out.contains("After.\nNext."),
+            "prose after {label} must still split, got:\n{sib_out}"
+        );
+    }
+
+    let piton = concat!(
+        "Before. Next.\n",
+        "\\PitonInputFile{foo.py}\n",
+        "After. Next.\n",
+    );
+    let piton_out = format_text(piton, &latex_cfg()).unwrap();
+    assert!(
+        piton_out.contains("\\PitonInputFile{foo.py}\n"),
+        "PitonInputFile must stay unchanged, got:\n{piton_out}"
+    );
+    assert!(
+        !piton_out.contains("\\PitonInputFile{foo.py} After."),
+        "PitonInputFile must not join following prose, got:\n{piton_out}"
+    );
+
+    let py = concat!("Before. Next.\n", "\\inputpy{foo.py}\n", "After. Next.\n",);
+    let py_out = format_text(py, &latex_cfg()).unwrap();
+    assert!(
+        py_out.contains("\\inputpy{foo.py}\n"),
+        "inputpy must stay unchanged, got:\n{py_out}"
+    );
+    assert!(
+        !py_out.contains("\\inputpy{foo.py} After."),
+        "inputpy must not join following prose, got:\n{py_out}"
     );
 }


### PR DESCRIPTION
discovered-from: leftover hunt on origin/main e91024c. GREEN snapper-n1wk (impl-A/B+rev-1/2, ljos consensus accept 1.000). GitHub #439.

One leftover walker for the remaining filename-input / verbatim-input tail. Real walkers only.

pythontex.sty `\inputpygments` / `\pygment`, catchfilebetweentags.sty `\CatchFileBetweenTags` / `\CatchFileBetweenDelims` / `\ExecuteMetaData`, piton.sty `\PitonInputFileT` / `\PitonInputFileF` / `\PitonInputFileTF`.

fixture:
Before. Next.
\inputpygments{python}{foo.py}
After. Next.

verify (terra, format_text without_safety_backstops):
each listed command stays one atomic line. After. / Next. still split.
`\inputpy` does not steal `\inputpygments`. `\PitonInputFile` unchanged.

Do not hand-edit CHANGELOG.md.

Closes #439.
